### PR TITLE
Governance: GOVERNANCE.md, MAINTAINERS.md, AREAS.md, RFCs, ADRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,26 @@
+# Mechanical mirror of ../AREAS.md — GitHub review-routing only.
+# Update both files in the same PR when an area's owner changes.
+# `require_code_owner_reviews` is currently OFF in branch protection
+# (see ../GOVERNANCE.md#branch-protection): with a bus factor this low,
+# a hard CODEOWNERS-only gate would block merges nobody but the Owner
+# could clear. This file still drives GitHub's automatic
+# reviewer-suggestion UI even with the hard requirement off.
+
+*                                       @arunsoman
+
+/crates/compiler/src/plugin.rs         @arunsoman
+/crates/plugin-example-rot13/          @arunsoman
+/crates/grammar_check/                 @arunsoman
+/crates/grammar_export/                @arunsoman
+/crates/bench/                         @arunsoman
+/crates/presence-gateway/              @arunsoman
+
+/deploy/                               @arunsoman @lekshmideepu @maheshmindlabs
+/Dockerfile                            @arunsoman
+/.github/workflows/                    @arunsoman
+
+/GOVERNANCE.md                         @arunsoman
+/MAINTAINERS.md                        @arunsoman
+/AREAS.md                              @arunsoman
+/rfcs/                                 @arunsoman
+/docs/adr/                             @arunsoman

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,28 +1,30 @@
-# Documented label set for this repo. Not yet applied to GitHub — this
-# is the source of truth to create them from (manually, via `gh label
-# create`, or a labeler GitHub Action) once the maintainer is ready.
+# Documented label set for this repo — kept in sync with the live
+# GitHub labels (`gh label list --repo arunsoman/nirdosha`), last
+# reconciled 2026-09-04. This file is the source of truth for *intent*;
+# if it and the live repo ever drift, fix the repo to match this file
+# (`gh label create`/`gh label edit`), not the other way around.
 #
 #   gh label create "good first issue" --color 7057ff --description "..."
 #   (repeat per row, or script it from this file)
 
 - name: "good first issue"
   color: "7057ff"
-  description: "Small, well-scoped, good for a first contribution"
+  description: "Good for newcomers"
 - name: "help wanted"
   color: "008672"
-  description: "Open for anyone to pick up"
+  description: "Extra attention is needed"
 - name: bug
   color: "d73a4a"
-  description: "Something isn't working as documented"
+  description: "Something isn't working"
 - name: enhancement
   color: "a2eeef"
-  description: "New feature or capability request"
-- name: docs
+  description: "New feature or request"
+- name: documentation
   color: "0075ca"
-  description: "Documentation only"
+  description: "Improvements or additions to documentation"
 - name: compiler
-  color: "5319e7"
-  description: "Parser, typeck, ownership, codegen, interpreter"
+  color: "1d76db"
+  description: "Parser, typeck, codegen, interpreter"
 - name: grammar
   color: "5319e7"
   description: "Grammar/GBNF/LL(1) surface, not codegen internals"
@@ -32,9 +34,27 @@
 - name: examples
   color: "c5def5"
   description: "A `.nir` example — new, broken, or needs updating"
+- name: llm
+  color: "5319e7"
+  description: "LLM/agent-facing: prompts, grammar, eval harness"
+- name: infra
+  color: "c2e0c6"
+  description: "CI, packaging, install, cross-platform"
 - name: question
   color: "d876e3"
   description: "Further information is requested"
 - name: blocked
   color: "b60205"
   description: "Can't proceed until a named dependency lands"
+- name: accessibility
+  color: "f143ab"
+  description: "Barrier affecting people with disabilities"
+- name: duplicate
+  color: "cfd3d7"
+  description: "This issue or pull request already exists"
+- name: invalid
+  color: "e4e669"
+  description: "This doesn't seem right"
+- name: wontfix
+  color: "ffffff"
+  description: "This will not be worked on"

--- a/AREAS.md
+++ b/AREAS.md
@@ -1,0 +1,32 @@
+# Areas
+
+Repo-level mirror of [`crates/compiler/src/INDEX.md`](./crates/compiler/src/INDEX.md)'s
+approach: a durable name for each subsystem and who owns it, not a
+claim about exact file boundaries (those drift; consult the actual
+`crates/*/Cargo.toml` layout or `INDEX.md` for that). Consumed by
+[`.github/CODEOWNERS`](./.github/CODEOWNERS) for automatic review
+routing, and by [`MAINTAINERS.md`](./MAINTAINERS.md) for the "which
+area" column.
+
+**Owner column is honest, not aspirational** — see
+[`MAINTAINERS.md`](./MAINTAINERS.md)'s note on activation. `arunsoman`
+is listed as owner of everything below because that's who has actually
+touched it; "help wanted" areas are open for a maintainer candidate to
+claim per `MAINTAINERS.md`'s "Becoming a maintainer" steps, not areas
+nobody may touch.
+
+| Area | Path(s) | Owner | Notes |
+|---|---|---|---|
+| Compiler core (parser, typeck, ownership, SMT/refine) | `crates/compiler/src/{parser,typeck,ast,ownership,smt,refine}.rs` | `arunsoman` | Static-checking pipeline. See `crates/compiler/src/INDEX.md` for the per-function map. |
+| Interpreter | `crates/compiler/src/interpreter.rs` | `arunsoman` | The reference execution semantics — anything the native backend doesn't yet cover falls back here. |
+| Native codegen (LLVM) | `crates/compiler/src/codegen.rs`, `runtime_kernels.rs` | `arunsoman` | Narrower than the interpreter by design (`check_supported`'s explicit reject list); help wanted closing Track B gaps, `docs/ROADMAP.md`. |
+| UI/screen DSL | `crates/compiler/src/{ui_gen,serve}.rs` | `arunsoman` | Manifest derivation + the server that enforces its gates; see `docs/LANGUAGE.md` §11–13. |
+| Plugin/extension system | `crates/compiler/src/plugin.rs`, `crates/plugin-example-rot13/` | `arunsoman` | New, Track G1 Kind A (native builtin extension via Cargo) — actively in progress; see `rfcs/0001-package-manifest-format.md`. |
+| Grammar / GBNF / constrained decoding | `crates/grammar_check/`, `crates/grammar_export/`, `crates/compiler/nirdosha.gbnf` | `arunsoman` | LALR(1) cross-check against the hand-written LL(1) parser; corpus entries are a **help wanted** / good-first-issue source (see open issue #3). |
+| LLM eval harness | `crates/bench/` | `arunsoman` | Real pass@1/self-repair scaffold, mock models only today — **help wanted** wiring a real provider (open issue #2, `docs/ECOSYSTEM.md` §G3). |
+| Presence gateway | `crates/presence-gateway/` | `arunsoman` | `docs/ROADMAP.md` Track A5. |
+| Deployment (Docker, Helm, Kustomize) | `Dockerfile`, `deploy/`, `.github/workflows/docker.yml` | `arunsoman` (Helm chart maintainers: `arunsoman`, `lekshmideepu`, `maheshmindlabs` per `deploy/helm/nirdosha/Chart.yaml`) | Chart-level maintainer listing predates GitHub write access; both are now real for `lekshmideepu`/`maheshmindlabs` (see `MAINTAINERS.md`). |
+| Release/CI | `.github/workflows/{build,release,docker}.yml` | `arunsoman` | See `GOVERNANCE.md`#releases for the signing/OIDC policy. |
+| Docs (design specs, language reference) | `docs/*.md` | `arunsoman` | Treated as load-bearing — `CONTRIBUTING.md`'s PR process requires doc updates in the same PR as the code change they describe. |
+| Examples | `examples/*.nir` | `arunsoman` | **help wanted / good first issue** source — missing coverage tracked as individual issues (e.g. #7, #8). |
+| Governance / process | `GOVERNANCE.md`, `MAINTAINERS.md`, `AREAS.md`, `rfcs/`, `docs/adr/`, `.github/labels.yml` | `arunsoman` | This document tree. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,16 +75,35 @@ the right design doc for whatever you're changing.
 
 ## Response time
 
-This is presently a solo-maintained research project. Expect a response
-within about a week; feel free to ping the thread if you haven't heard
-back.
+**Triage SLA: 48 hours** to a first response (a label, a question, or
+just "seen, will look") on a new issue or PR. That's not the same as a
+full resolution — this is still a mostly-solo-maintained project (see
+[`MAINTAINERS.md`](./MAINTAINERS.md) for who actually has write access
+today and how active each is), so expect a real answer or merge within
+about a week; feel free to ping the thread if you haven't heard back
+past that.
+
+## Breaking changes
+
+A change to the language surface, grammar, or a public interface (CLI
+flags, the manifest format, the plugin ABI) goes through the
+[RFC process](./rfcs/README.md) before it lands — a written proposal
+and a review window, not a change that just appears in one commit. See
+[`GOVERNANCE.md`](./GOVERNANCE.md) for the full policy and
+[`docs/adr/0002-ban-str-in-fn-signatures.md`](./docs/adr/0002-ban-str-in-fn-signatures.md)
+for the real precedent (a breaking change shipped in one session, no
+proposal, no window) that made this a written rule instead of an
+assumption.
 
 ## Community
 
 - **GitHub Discussions** for long-form questions and design conversations.
-- All substantive design decisions happen in public GitHub issues —
-  nothing gets decided in private that affects the language or its
-  roadmap.
+- All substantive design decisions happen in public GitHub issues,
+  [RFCs](./rfcs/README.md), or Discussions — nothing gets decided in
+  private that affects the language or its roadmap.
+- See [`GOVERNANCE.md`](./GOVERNANCE.md) for roles (owner/maintainer/
+  triager), [`MAINTAINERS.md`](./MAINTAINERS.md) for who holds them
+  today, and [`AREAS.md`](./AREAS.md) for who owns which subsystem.
 
 ## Code of Conduct
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,118 @@
+# Governance
+
+How decisions get made in Nirdosha, and who can make them. Written
+2026-09-04 as the project moved from purely solo-maintained to having
+real (if not yet active) maintainer access — see
+[`docs/ECOSYSTEM.md` §G5](./docs/ECOSYSTEM.md) for the gap analysis
+this closes, and [`MAINTAINERS.md`](./MAINTAINERS.md) for who currently
+holds which role.
+
+## Roles
+
+| Role | Grants | Who |
+|---|---|---|
+| **Owner** | Repo admin: branch protection, releases, secrets, adding/removing maintainers. Final say when consensus doesn't form. | [`MAINTAINERS.md`](./MAINTAINERS.md) |
+| **Maintainer** | Push access, reviews and merges PRs (branch protection requires 1 approval — a maintainer can approve someone else's PR, not their own), triages issues, can shepherd an RFC. Scoped in practice to the area(s) listed for them in [`AREAS.md`](./AREAS.md), though nothing in GitHub enforces that boundary technically. | [`MAINTAINERS.md`](./MAINTAINERS.md) |
+| **Triager** | Labels, closes duplicates/invalid issues, requests changes on PRs, cannot merge. A step for someone building toward Maintainer, not a separate track. | none appointed yet — see [Contributor funnel](#contributor-funnel) |
+
+Granting or revoking any of these is an Owner action, done by adding/
+removing the person from [`MAINTAINERS.md`](./MAINTAINERS.md) (or the
+triager list) and the corresponding GitHub permission, in the same PR.
+
+## How day-to-day decisions get made
+
+- **A bug fix, doc fix, or small feature inside one area:** the
+  maintainer for that area (or the Owner, if unassigned) reviews and
+  merges. No separate process.
+- **Anything cross-cutting, breaking, or that changes the language
+  surface, grammar, or a public interface (CLI flags, the manifest
+  format, the plugin ABI):** goes through the [RFC process](./rfcs/README.md)
+  first. This is the direct fix for the gap `docs/ECOSYSTEM.md` §G5
+  named: the `str`-in-signatures ban shipped in one session with no
+  proposal or review window — a real breaking-change precedent this
+  process exists to not repeat. See
+  [`docs/adr/0002-ban-str-in-fn-signatures.md`](./docs/adr/0002-ban-str-in-fn-signatures.md)
+  for that decision recorded after the fact.
+- **A decision made outside the RFC process anyway** (a judgment call
+  during implementation, not a designed-up-front change) gets recorded
+  as an [ADR](./docs/adr/README.md) so the reasoning survives — see
+  `docs/adr/` for the pattern, mirrored from
+  [`crates/compiler/src/INDEX.md`](./crates/compiler/src/INDEX.md)'s
+  own "durable name, not durable line number" approach to documenting
+  decisions that would otherwise only live in a commit message.
+- **Disagreement that doesn't resolve in review:** the Owner decides.
+  This is a small project — there is no vote, no quorum, just an
+  escalation path so a stuck PR doesn't stay stuck.
+
+## Branch protection
+
+`main` is protected (configured 2026-09-04): merging requires a green
+`build` + `build-windows` CI run and at least one approving review;
+force-pushes and branch deletion are blocked; conversation threads
+must be resolved before merge. The repo Owner can bypass in a genuine
+emergency (`enforce_admins` is off) — this is a deliberate, disclosed
+exception for a project with real bus-factor risk, not an oversight;
+using it outside an actual emergency defeats the point of having the
+rule and should get called out in the next PR, not left silent.
+
+## Releases
+
+- Tags matching `v*` trigger [`release.yml`](./.github/workflows/release.yml)
+  (prebuilt binaries → GitHub Release) and
+  [`docker.yml`](./.github/workflows/docker.yml) (container images,
+  cosign-signed and SBOM'd, all via GitHub OIDC — no long-lived
+  registry credentials are stored as repo secrets today; verified
+  2026-09-04 via `gh secret list`, which returned none, and both
+  workflows authenticate with the ephemeral `GITHUB_TOKEN`/OIDC, not a
+  personal access token. If a future workflow needs a third-party
+  registry or crates.io, it should use that same OIDC/trusted-publishing
+  pattern — a GitHub Environment with an OIDC trust relationship, not a
+  PAT pasted into repo secrets — so a release doesn't depend on any one
+  person's account.
+- **Signed tags — policy, not yet enforced.** A release tag should be
+  a GPG- or SSH-signed `git tag -s`, not a plain tag, so a release's
+  provenance doesn't rest solely on whoever had push access at the
+  time. This isn't yet enforced by a GitHub tag-protection rule because
+  that requires each maintainer's signing key to be registered with
+  GitHub first — a per-person setup step, not something to switch on
+  as a side effect of writing this document. Tracked as a follow-up;
+  whoever cuts the next release should sign the tag by hand in the
+  meantime.
+- Only the Owner cuts releases today (single point of failure,
+  disclosed — see [`MAINTAINERS.md`](./MAINTAINERS.md)). Delegating
+  this needs at minimum GitHub Environments with required reviewers,
+  not a shared credential; not yet set up.
+
+## Contributor funnel
+
+- Issues are triaged weekly and labeled from the set in
+  [`.github/labels.yml`](./.github/labels.yml) (the file is the
+  documented source of truth; `gh label list` on the live repo should
+  match it — reconcile the file, not the repo, if they drift).
+  `good first issue`/`help wanted` are kept current on real open
+  issues, not aspirational.
+- **Triage SLA: 48 hours** to a first response (label, question, or
+  "seen, will look") on a new issue or PR — not to a full resolution.
+  See [`CONTRIBUTING.md`](./CONTRIBUTING.md#response-time) for how this
+  relates to the "about a week" full-response expectation.
+- [GitHub Discussions](https://github.com/arunsoman/nirdosha/discussions)
+  is enabled for design chatter that isn't yet a formal RFC.
+- The [Public Roadmap](./docs/PUBLIC_ROADMAP.md) is linked from the
+  README so a prospective contributor can see what's open without
+  reading the full internal roadmap.
+
+## Documents this governance model depends on
+
+- [`MAINTAINERS.md`](./MAINTAINERS.md) — who holds which role, today.
+- [`AREAS.md`](./AREAS.md) — which subsystem each maintainer is
+  responsible for.
+- [`.github/CODEOWNERS`](./.github/CODEOWNERS) — GitHub's own
+  mechanical mirror of `AREAS.md`, so review requests route
+  automatically.
+- [`rfcs/`](./rfcs/README.md) — the RFC process and its current
+  proposals.
+- [`docs/adr/`](./docs/adr/README.md) — decisions made outside the RFC
+  process, recorded after the fact.
+- [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md) / [`SECURITY.md`](./SECURITY.md) —
+  unchanged by this document, still the standing policies for conduct
+  and vulnerability reports.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,56 @@
+# Maintainers
+
+Roles are defined in [`GOVERNANCE.md`](./GOVERNANCE.md); area
+assignments are in [`AREAS.md`](./AREAS.md). This file is the source of
+truth for both GitHub access and the table below — a permission change
+on GitHub without a matching edit here is a bug in the process, not
+just a stale doc.
+
+## Owner
+
+| GitHub | Name | Since |
+|---|---|---|
+| [@arunsoman](https://github.com/arunsoman) | Arun Soman | project start |
+
+Repo admin. 107 of the repository's commits are the Owner's as of
+2026-09-04 (`git log --format=%an \| sort \| uniq -c`) — the project is
+still, in practice, primarily one person's active work, even though
+write access below is broader than that.
+
+## Maintainers
+
+| GitHub | Areas ([`AREAS.md`](./AREAS.md)) | Write access granted | Status |
+|---|---|---|---|
+| [@lekshmideepu](https://github.com/lekshmideepu) | *unassigned* | yes | not yet active — no commits/reviews on record yet |
+| [@maheshmindlabs](https://github.com/maheshmindlabs) | *unassigned* | yes | active on Helm chart maintainership ([`deploy/helm/nirdosha/Chart.yaml`](./deploy/helm/nirdosha/Chart.yaml)); 1 commit on record |
+| [@arulrajan123](https://github.com/arulrajan123) | *unassigned* | yes | not yet active — no commits/reviews on record yet |
+| [@Baskarrajcodeflow](https://github.com/Baskarrajcodeflow) | *unassigned* | yes | not yet active — no commits/reviews on record yet |
+
+**Read this table honestly, not optimistically.** GitHub write access
+exists for all four names above (confirmed via
+`gh api repos/arunsoman/nirdosha/collaborators/<user>/permission`,
+2026-09-04) — that part of `docs/ECOSYSTEM.md` §G5's ask is already
+done. What's still open is *activation*: none of the four has an
+assigned area, and three have no commits or reviews on this repo yet.
+Access without an assigned area and a first review doesn't move the
+bus factor — the fix is each of them picking up (or being assigned) a
+row in `AREAS.md`, not another access grant. Until that happens, branch
+protection's "1 approving review" requirement is real but its pool of
+practical reviewers is closer to 1–2 people than 4.
+
+## Triagers
+
+None appointed yet. See [`GOVERNANCE.md`#contributor-funnel](./GOVERNANCE.md#contributor-funnel) —
+a maintainer candidate not yet ready for write access is exactly who
+this role is for.
+
+## Becoming a maintainer
+
+1. Land a few substantive, reviewed PRs in one area from
+   [`AREAS.md`](./AREAS.md) — this is what "active" in the table above
+   means in practice.
+2. Ask in a PR or GitHub Discussion, or get nominated by an existing
+   maintainer.
+3. The Owner grants GitHub write access and adds a row here and in
+   `AREAS.md` in the same PR — access and documentation land together,
+   never one without the other.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Wiki](https://img.shields.io/badge/docs-wiki-blue)](https://github.com/arunsoman/nirdosha/wiki)
 [![Contributing](https://img.shields.io/badge/CONTRIBUTING-read-blue)](./CONTRIBUTING.md)
+[![Governance](https://img.shields.io/badge/GOVERNANCE-read-blue)](./GOVERNANCE.md)
 [![Roadmap](https://img.shields.io/badge/ROADMAP-view-purple)](./docs/PUBLIC_ROADMAP.md)
-[![Maintainers](https://img.shields.io/badge/maintainers-3-green)](./deploy/helm/nirdosha/Chart.yaml)
+[![Maintainers](https://img.shields.io/badge/maintainers-5-green)](./MAINTAINERS.md)
 [![Sponsor](https://img.shields.io/badge/%E2%9D%A4-Sponsor-ea4aaa)](https://github.com/sponsors/arunsoman)
 
 > **A systems language designed for LLMs to write, with a grammar so
@@ -85,8 +86,12 @@ matter more than volume. Right now:
 
 Full list with status tags: [`docs/PUBLIC_ROADMAP.md`](./docs/PUBLIC_ROADMAP.md).
 Issues are labeled `good first issue` / `help wanted` / `compiler` /
-`llm` / `infra` / `docs`. Pick one, comment before starting on anything
-non-trivial — see [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+`llm` / `infra` / `documentation` (full set: [`.github/labels.yml`](./.github/labels.yml)).
+Pick one, comment before starting on anything non-trivial — see
+[`CONTRIBUTING.md`](./CONTRIBUTING.md). [`AREAS.md`](./AREAS.md) lists
+who owns which subsystem; a cross-cutting or breaking change goes
+through the [RFC process](./rfcs/README.md) first — see
+[`GOVERNANCE.md`](./GOVERNANCE.md).
 
 | If you care about | Try | 
 |---|---|

--- a/docs/ECOSYSTEM.md
+++ b/docs/ECOSYSTEM.md
@@ -277,33 +277,51 @@ not this doc.
 
 ---
 
-## G5 — Community/governance depth
+## G5 — Community/governance depth — `[DONE]` 2026-09-04
 
-**Problem:** solo-maintained. GitHub's own contributor graph shows
-`arunsoman` only, 94 contributions — no RFC process for breaking
-changes, no bus-factor resilience if that one person is unavailable.
+**Problem, as of this doc's original writing:** solo-maintained.
+GitHub's own contributor graph showed `arunsoman` only, 94
+contributions — no RFC process for breaking changes, no bus-factor
+resilience if that one person was unavailable.
 
-**This is a people/process gap, not a design gap** — the fix isn't a
-spec doc, it's action:
+**Closed 2026-09-04.** Everything this section flagged now has a real
+document or a real GitHub setting behind it, not just this design doc:
 
-- **An RFC-lite process for breaking changes**, living in
-  `CONTRIBUTING.md` — this is the same root cause as G4's Track A4
-  (compatibility/versioning policy): a documented policy that a
-  breaking change (like the str-ban shipped in one session, per
-  Track A4's own note) goes through a written proposal + review window
-  before landing, not silently in one commit.
-- **Real maintainer access, not just a metadata field.**
-  `deploy/helm/nirdosha/Chart.yaml`'s `maintainers:` list now names
-  `lekshmideepu` and `maheshmindlabs` (added this session) — that's a
-  Helm chart field, not GitHub repo access. Turning that into real
-  governance means actually inviting them as GitHub collaborators/
-  maintainers with real review rights, and enabling branch protection
-  (required review before merge to `main`) so a second set of eyes is
-  structurally required, not optional. **This doc flags it; it isn't
-  done by this doc** — granting real repository access is a
-  maintainer-only action for the repo owner to take directly on
-  GitHub, not something to do silently as a side effect of writing a
-  design doc.
+- **RFC process** — [`rfcs/README.md`](../rfcs/README.md), seeded with
+  two real drafts: [`rfcs/0001-package-manifest-format.md`](../rfcs/0001-package-manifest-format.md)
+  (this section's own G1) and
+  [`rfcs/0002-editor-tooling-lsp-tree-sitter.md`](../rfcs/0002-editor-tooling-lsp-tree-sitter.md)
+  (G2). The breaking-change policy referenced below lives in
+  [`GOVERNANCE.md`](../GOVERNANCE.md) and
+  [`CONTRIBUTING.md`](../CONTRIBUTING.md#breaking-changes), and the
+  str-ban precedent that motivated it is recorded (after the fact) as
+  [`docs/adr/0002-ban-str-in-fn-signatures.md`](./adr/0002-ban-str-in-fn-signatures.md).
+- **Real maintainer access.** Confirmed via GitHub's API (not just the
+  Helm chart field this section originally flagged as insufficient):
+  `lekshmideepu`, `maheshmindlabs`, plus `arulrajan123` and
+  `Baskarrajcodeflow`, all hold real repo write access today. See
+  [`MAINTAINERS.md`](../MAINTAINERS.md) for the honest read on this —
+  access exists, but three of the four have no commits/reviews on
+  record yet, so the practical bus factor is still closer to 1–2 than
+  5 until they're activated into an assigned area.
+- **Branch protection** — enabled on `main` 2026-09-04: 1 required
+  approving review, green `build`/`build-windows` CI, no force-push/
+  delete, admin bypass kept for genuine emergencies. Details:
+  [`GOVERNANCE.md`#branch-protection](../GOVERNANCE.md#branch-protection).
+- **ADRs** for decisions made outside the RFC process:
+  [`docs/adr/`](./adr/README.md).
+- **Areas/ownership** — [`AREAS.md`](../AREAS.md), consumed by
+  [`.github/CODEOWNERS`](../.github/CODEOWNERS).
+- **Contributor funnel** — 48h triage SLA
+  (`CONTRIBUTING.md`#response-time), GitHub Discussions (already
+  enabled), and the full label set live on GitHub, reconciled with
+  [`.github/labels.yml`](../.github/labels.yml).
+- **Release credentials** — audited, not changed: `release.yml`/
+  `docker.yml` already authenticate via the ephemeral `GITHUB_TOKEN`/
+  OIDC, not a personal token (`gh secret list` returns none). Signed
+  release tags are documented as policy in `GOVERNANCE.md` but not yet
+  enforced — needs each maintainer's signing key registered first, a
+  real follow-up, not done here.
 
 ---
 
@@ -314,9 +332,10 @@ the two highest-leverage, lowest-risk starting points — both are
 additive (nothing existing has to change), both have a concrete first
 artifact (one reference plugin; one grammar file checked against
 `crates/grammar_check/`), and both are the kind of thing a new
-contributor could plausibly pick up — which itself starts chipping
-away at G5. G3 (wire a real model into the existing bench harness) is
-similarly small and fast, and closes a gap the project's own docs
-already admit to. G4 stays inside Track A. G5's process piece
-(RFC-lite in `CONTRIBUTING.md`) is cheap to write; the access-granting
-half needs the repo owner, not more design.
+contributor could plausibly pick up — which itself now has somewhere
+real to land, per G5's `rfcs/`. G3 (wire a real model into the
+existing bench harness) is similarly small and fast, and closes a gap
+the project's own docs already admit to. G4 stays inside Track A. G5
+itself is `[DONE]` (see above) — what's left there is activation
+(named maintainers actually using their access), not more design or
+process.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2815,16 +2815,23 @@ sequencing in `docs/ECOSYSTEM.md`; this entry only tracks status.*
   A1–A4 above, which already track real status for each. See
   `docs/ECOSYSTEM.md` §G4 for the explicit mapping — deliberately not
   duplicated as new tracked items here.
-- `[OPEN]` **G5. Community/governance depth.** Solo-maintained today
+- `[DONE]` **G5. Community/governance depth.** Was solo-maintained
   (GitHub contributor graph: `arunsoman` only, 94 contributions) — no
-  RFC process, no bus-factor resilience. `docs/ECOSYSTEM.md` §G5: an
-  RFC-lite process for breaking changes in `CONTRIBUTING.md` (same
-  root cause as A4's versioning-policy gap), plus turning
-  `deploy/helm/nirdosha/Chart.yaml`'s `maintainers:` entries
-  (`lekshmideepu`, `maheshmindlabs`, added 2026-09-04) into real GitHub
-  collaborator access and branch protection — flagged here, not done
-  here; granting real repo access is a maintainer-only action for the
-  repo owner, not a side effect of a design doc.
+  RFC process, no bus-factor resilience. Closed 2026-09-04:
+  `GOVERNANCE.md` (roles + decision process), `MAINTAINERS.md` (honest
+  activation status, not just access), `AREAS.md` +
+  `.github/CODEOWNERS`, an RFC process (`rfcs/`, seeded with G1's
+  package-manifest-format and G2's editor-tooling drafts), ADRs
+  (`docs/adr/`, backfilled for the Z3-vendoring and str-ban decisions),
+  branch protection on `main` (1 review + green CI required), and a
+  48h triage SLA in `CONTRIBUTING.md`. Real GitHub write access for
+  `lekshmideepu`/`maheshmindlabs`/`arulrajan123`/`Baskarrajcodeflow`
+  was confirmed already granted (not just the Helm chart field this
+  row used to flag as insufficient) — `MAINTAINERS.md` discloses that
+  three of the four aren't yet *active* (no commits/reviews on
+  record), so real bus-factor improvement still needs those seats
+  used, not just held. See `docs/ECOSYSTEM.md` §G5 for the full
+  before/after.
 
 ---
 

--- a/docs/adr/0001-vendor-z3-except-macos.md
+++ b/docs/adr/0001-vendor-z3-except-macos.md
@@ -1,0 +1,52 @@
+# 0001: Vendor Z3 for release builds, except macOS (system Z3 there)
+
+Date: 2026-08-25
+Status: accepted
+
+## Context
+
+`crates/compiler` links Z3 at compile time (`smt.rs`'s Tier-2 bounds
+proving). A prebuilt `nirdosha` release binary that requires the end
+user to have `libz3` installed separately is a real distribution
+tax — most of the "download and run" install story
+([`scripts/install.sh`](../../scripts/install.sh)) would otherwise
+silently need "...and also `apt install libz3-dev`" first. The `z3`
+crate's `z3-src` feature (`dist` feature,
+[`crates/compiler/Cargo.toml`](../../crates/compiler/Cargo.toml))
+vendors and statically builds Z3 as part of `cargo build`, removing
+that runtime dependency — for Linux and Windows.
+
+macOS is the disclosed exception: `z3-src` 416.0.2 (the version the
+`z3` 0.20.2 crate pulls) fails to compile against the AppleClang
+shipped on GitHub's `macos-13`/`macos-14` runners — a real upstream
+`obj_hashtable.h` constructor-strictness incompatibility, confirmed
+2026-08-25 on [`release.yml`](../../.github/workflows/release.yml)'s
+first real CI run for that leg, not a local config mistake.
+
+## Decision
+
+- Linux and Windows release binaries vendor Z3 (`--features dist`) —
+  zero extra system dependency for the end user, `clang` only needed
+  at runtime for `nirdosha build`/`emit-llvm` (native codegen), not for
+  interpreting/`emit-ast`/`emit-ui`/`serve`.
+- macOS release binaries instead link the **system** Z3 (`brew install
+  z3` on the CI runner, and required on the end user's machine too) —
+  the same dependency building from source would already require.
+  This is a real, disclosed asymmetry between platforms, not a silent
+  gap: `release.yml`'s own header comment states it, and this ADR
+  restates it here so the reasoning doesn't live only in a workflow
+  comment.
+
+## Consequences
+
+- Linux/Windows users get the frictionless "download and run" install
+  story this ADR exists to protect.
+- macOS users carry one extra install step (`brew install z3`) that
+  Linux/Windows users don't — a real, if narrow, platform-support gap,
+  tracked as [issue #5](https://github.com/arunsoman/nirdosha/issues/5)
+  ("macOS: z3-src 416.0.2 fails against current AppleClang — vendor Z3
+  or document workaround").
+- This decision reverses automatically, with no code change needed
+  here, once a `z3`/`z3-src` release upstream fixes the AppleClang
+  incompatibility — at that point `release.yml`'s macOS legs should
+  switch to `--features dist` like the other two, and issue #5 closes.

--- a/docs/adr/0002-ban-str-in-fn-signatures.md
+++ b/docs/adr/0002-ban-str-in-fn-signatures.md
@@ -1,0 +1,68 @@
+# 0002: Ban `str` as a function argument/return type
+
+Date: 2026-08-23
+Status: accepted
+
+## Context
+
+Nirdosha's core value proposition is that an LLM-written program is
+provably free of a set of whole bug classes — memory safety, data
+races, deadlocks, integer/buffer overflow (README). Stringly-typed
+control flow (`if status == "PENDING"`, `match currency { "USD" =>
+..., "EUR" => ... }`) sits outside every one of those proofs: a typo'd
+literal, an unhandled case, or a silently-accepted new value are all
+compile-clean and only fail at runtime, or never fail loudly at all —
+exactly the class of defect the rest of the type system exists to rule
+out statically. Real `enum`s already get exhaustive `match` checking
+and already render as searchable dropdowns in `emit-ui`
+(`docs/LANGUAGE.md` §11) for free; nothing was pushing authors (human
+or LLM) toward using them at a function boundary instead of a bare
+`str`.
+
+This decision shipped in a single implementation session (2026-08-23),
+with no RFC, no discussion window, and no advance notice — a real
+breaking change to what typechecks, made unilaterally. `docs/ECOSYSTEM.md`
+§G5 names this specific event as the concrete precedent motivating
+[`GOVERNANCE.md`](../../GOVERNANCE.md)'s RFC requirement for future
+breaking changes; this ADR is that decision recorded after the fact,
+not before.
+
+## Decision
+
+A user-defined `fn`'s parameter or return type may not be, or contain
+(recursively, through `Result`/`Option`/generics/`box`/`&`/`thread`/
+`chan`/`Vector`/`Matrix`/`fn(...) -> ...`), a bare `str`
+(`TypeErrorKind::StrInFnSignature`, `typeck.rs::check_fn`). Two
+conventions replace what a bare `str` parameter/return used to carry:
+
+- A closed, categorical vocabulary becomes a small zero-payload `enum`.
+- Genuine free text gets wrapped in a one-field carrier struct,
+  conventionally named `Text { value: str }`.
+
+Three things are exempt **by construction**, not by special-casing,
+because none of them is a `fn_decl`: builtins (the language's real
+external-I/O boundary — an HTTP body, SQL text, a JWT — is
+irreducibly `str`), struct/enum constructors (a struct can freely keep
+a `str` field), and `transact`'s synthesized `txn_id` parameter (must
+stay a plain scalar for WAL durability). An enum variant's own payload
+(`External(str)`) is likewise unaffected — the check inspects a
+signature's declared type expression, not a named type's internal
+declaration. Full detail: `docs/LANGUAGE.md` §6b.
+
+## Consequences
+
+- Every existing `.nir` program with a `str`-typed `fn` parameter or
+  return became a compile error in this one session — a real breaking
+  change to the language surface, not additive.
+- The `==`/`!=` interpreter gap this migration surfaced and fixed in
+  the same pass (`Value::Struct`/`Value::Enum` had no binary-operator
+  arm, despite typechecking cleanly) is documented in `docs/LANGUAGE.md`
+  §6b rather than repeated here — a reminder that "push people toward
+  enums" is only a real improvement if comparing the resulting enums
+  then actually works at runtime, which it didn't until this same pass
+  fixed it.
+- Established the precedent this repo's process gap is now fixed
+  against: see [`GOVERNANCE.md`](../../GOVERNANCE.md#how-day-to-day-decisions-get-made)
+  and [`rfcs/README.md`](../../rfcs/README.md) — a change of this shape
+  going forward gets an RFC and a review window before it ships, not
+  after.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,43 @@
+# Architecture Decision Records
+
+A decision made **outside** the [RFC process](../../rfcs/README.md) —
+a judgment call made while implementing something, not a design
+proposed and discussed up front — gets recorded here so the reasoning
+survives past the commit that made it. See
+[`GOVERNANCE.md`](../../GOVERNANCE.md#how-day-to-day-decisions-get-made)
+for when something needs an RFC instead of an ADR.
+
+Same pattern as [`crates/compiler/src/INDEX.md`](../../crates/compiler/src/INDEX.md):
+a durable name (`NNNN-title.md`), not a durable line number or a
+promise the decision is still current — an ADR records that a
+decision *was made* and why, not that it's still the right call
+forever. A later ADR can supersede an earlier one; it doesn't edit or
+delete it.
+
+## Format
+
+`docs/adr/NNNN-title.md`, `NNNN` = next unused 4-digit number:
+
+```markdown
+# NNNN: Title
+
+Date: YYYY-MM-DD
+Status: accepted | superseded by NNNN
+
+## Context
+What situation forced a decision.
+
+## Decision
+What was actually decided.
+
+## Consequences
+What this makes easier, harder, or newly possible — including the
+honest downside, not just the win.
+```
+
+## Index
+
+| # | Title | Status |
+|---|---|---|
+| [0001](./0001-vendor-z3-except-macos.md) | Vendor Z3 for release builds, except macOS (system Z3 there) | accepted |
+| [0002](./0002-ban-str-in-fn-signatures.md) | Ban `str` as a function argument/return type | accepted |

--- a/rfcs/0000-template.md
+++ b/rfcs/0000-template.md
@@ -1,0 +1,44 @@
+---
+state: draft
+shepherd: (unassigned)
+---
+
+# RFC NNNN: Title
+
+## Motivation
+
+What problem is this solving, for whom, and why now. Link the issue(s)
+or discussion that prompted it if any exist.
+
+## Design
+
+The actual proposal. Concrete enough that someone could start
+implementing it from this section alone — grammar changes, new
+`TypeErrorKind`/`ErrorKind` variants, CLI surface, file formats, all
+belong here, not hand-waved.
+
+## Effect on the permission model
+
+Does this change what `requires(role/claim: ...)`, `acquire`, a
+`screen`'s view/edit gates, or `serve.rs`'s server-side enforcement can
+express or must check? If genuinely none, say so explicitly — don't
+omit the section.
+
+## Compatibility
+
+Does an existing `.nir` program's behavior change? A grammar addition
+that only introduces new syntax at a spot nothing valid could occupy
+before is backward-compatible by construction — say why, the same way
+`docs/LANGUAGE.md` §17 does for real-namespace `module`. A breaking
+change needs a migration note, not just a warning that it's breaking.
+
+## Rejected alternatives
+
+What else was considered and why it lost — this is what lets a
+`rejected`/`postponed` RFC actually prevent the same idea from being
+re-proposed from zero later.
+
+## Open questions
+
+Anything left genuinely undecided at merge time. Not a place to hide
+scope that should actually block acceptance.

--- a/rfcs/0001-package-manifest-format.md
+++ b/rfcs/0001-package-manifest-format.md
@@ -1,0 +1,119 @@
+---
+state: draft
+shepherd: (unassigned)
+---
+
+# RFC 0001: Package manifest format (Cargo-based package manager)
+
+## Motivation
+
+`docs/ECOSYSTEM.md` §G1 works through the proposal "use Cargo itself
+as Nirdosha's package manager" and splits it into two kinds of
+package that need different treatment:
+
+- **Kind A — native/builtin extension crates.** Real Rust code adding
+  new builtins (crypto, PDF rendering, barcode reading), linked
+  statically into the `nirdosha` binary.
+- **Kind B — pure-`.nir` library packages.** No Rust code — shared
+  `.nir` function/screen/workflow definitions, distributed via
+  crates.io's registry protocol even though nothing in them compiles.
+
+**Kind A's runtime mechanism already exists and is real**, not
+proposed by this RFC: [`crates/compiler/src/plugin.rs`](../crates/compiler/src/plugin.rs)
+defines `NirdoshaPlugin`/`PluginBuiltin`, `run_with_plugins` wires a
+plugin's builtins into both `typeck.rs` and the interpreter, and
+[`crates/plugin-example-rot13/`](../crates/plugin-example-rot13/) is a
+working reference plugin — including the
+`[package.metadata.nirdosha]` block this RFC is about to formalize,
+already present in that crate's `Cargo.toml`. What's missing is
+everything *around* that mechanism: a build step that assembles a
+project-specific binary from a project's own declared plugin
+dependencies, without a human hand-writing a `main.rs` that calls
+`run_with_plugins` with a literal list. That gap is this RFC's actual
+scope.
+
+## Design
+
+### The project manifest
+
+A Nirdosha *project* (not a plugin crate) gains a
+`[package.metadata.nirdosha]` block in its own `Cargo.toml` — reusing
+the exact key namespace `plugin-example-rot13` already established for
+a plugin crate describing itself, now used the other direction, for a
+project declaring what it depends on:
+
+```toml
+[package.metadata.nirdosha]
+plugins = ["nirdosha-plugin-rot13"]
+```
+
+`nirdosha build --with-plugins` (name open — see Open Questions) reads
+this block, resolves the listed crate names against the project's
+ordinary `[dependencies]` (so version/lockfile resolution is 100%
+Cargo's, nothing new invented), and generates the small `main.rs`-
+equivalent glue that calls `run_with_plugins` with each dependency's
+`builtins()`. The merged builtin signature table is then also emitted
+so `typeck.rs` can statically check calls into the plugin the same as
+any other builtin — this last part is the one piece `plugin.rs` doesn't
+yet do automatically (today `run_with_plugins`'s caller has to already
+know the signatures to typecheck against).
+
+### Kind B: not in this RFC's first-landed scope
+
+`docs/ECOSYSTEM.md` §G1 recommends Kind A ship first and Kind B only
+after F2 (real namespacing/`use`, `docs/LANGUAGE.md` §17) has more
+mileage. This RFC's Design section above covers Kind A only, on
+purpose. A Kind B design — `kind = "nir-lib"` in the same metadata
+block, and teaching F2's `use` resolver to shell out to `cargo
+metadata`/`cargo fetch` for a target it can't find locally — is
+sketched in `docs/ECOSYSTEM.md` §G1 but deliberately left for a
+follow-up RFC once Stage 1 lands, not decided here.
+
+## Effect on the permission model
+
+None for Kind A as designed: a linked-in plugin's builtin is subject
+to exactly the same `requires(...)`/effect-annotation rules as any
+other builtin — `plugin.rs`'s own doc comment already establishes a
+plugin builtin isn't a new capability class. Worth restating in the
+follow-up Kind B RFC once that's designed, since a fetched `.nir`
+source file executing with the *importing* project's privileges (not
+its own) is a real question that doesn't arise for Kind A.
+
+## Compatibility
+
+Fully additive — a project with no `[package.metadata.nirdosha]`
+block builds exactly as it does today. No change to the grammar or to
+any existing `.nir` program's behavior.
+
+## Rejected alternatives
+
+- **A bespoke `nirpkg` registry/CLI.** Rejected in `docs/ECOSYSTEM.md`
+  §G1 already — the expensive option (hosting, uptime, abuse
+  moderation) for a solo/small-team-maintained project, when
+  crates.io already solves resolution, semver, lockfiles, and yanking.
+- **Dynamic loading (`dlopen`) instead of static linking.** Rejected
+  in `plugin.rs`'s own module doc: no stable Rust ABI to rely on.
+  Static linking via ordinary Cargo dependency resolution is the same
+  story every other native Rust dependency already has.
+
+## Open questions
+
+- **Security.** A Kind A plugin is arbitrary native code with no
+  sandbox — this cuts against the language's own memory/overflow-
+  safety proof story unless plugins are vetted or compiled to WASM
+  instead of linked natively. `docs/ECOSYSTEM.md` §G1 flags this as
+  needing its own design pass before Stage 1 ships *publicly* (the
+  mechanism existing in-repo as a reference implementation is not the
+  same as recommending untrusted third-party plugins to users yet).
+- **`nirdosha build --with-plugins` vs. always-on.** Should a project
+  with a `[package.metadata.nirdosha]` block just always link its
+  declared plugins on a plain `nirdosha build`, or does that need an
+  explicit opt-in flag the way this draft assumes? Affects whether
+  `main.rs`/`INDEX.md`'s "`fn main`... dispatches on the first
+  remaining arg to a subcommand" table needs a new flag documented.
+  Actual CLI flag name (`--with-plugins`, `--plugins`, or reading the
+  manifest unconditionally) is also undecided.
+- **Two version resolvers**, once Kind B exists: F2's own module
+  resolution and Cargo's semver would both have an opinion about
+  "which version of X." Needs a stated precedence rule before Kind B's
+  RFC, not silent overlap.

--- a/rfcs/0002-editor-tooling-lsp-tree-sitter.md
+++ b/rfcs/0002-editor-tooling-lsp-tree-sitter.md
@@ -1,0 +1,95 @@
+---
+state: draft
+shepherd: (unassigned)
+---
+
+# RFC 0002: Editor/tooling ecosystem — tree-sitter grammar + minimal LSP
+
+## Motivation
+
+No LSP, no tree-sitter grammar, no formatter, no debugger exist today.
+`docs/ECOSYSTEM.md` §G2 records that `cie` (a related repo) already
+frames this from the outside: Nirdosha is "a language with no LSP and
+no tree-sitter grammar," worked around via raw AST dump
+(`nirdosha emit-ast`). This is a real adoption barrier distinct from
+the compiler's own correctness work — a contributor evaluating the
+language today gets no inline diagnostics, no go-to-definition, no
+syntax highlighting beyond whatever generic heuristic their editor
+already applies to an unrecognized extension.
+
+## Design
+
+Build order, cheapest/highest-leverage first (`docs/ECOSYSTEM.md` §G2's
+own sequencing, restated here as the thing this RFC is asking to
+formally accept):
+
+1. **Tree-sitter grammar (`grammar.js`).** [`crates/grammar_check/`](../crates/grammar_check/)
+   already cross-checks the hand-written LL(1) parser
+   (`crates/compiler/src/parser.rs`) against an independently-generated
+   LALR(1) grammar — that pairing is the authoritative grammar source,
+   per `docs/GRAMMAR.md`. `grammar.js` must be *derived from and
+   checked against* that pair, not hand-authored a third time
+   independently, or it drifts the same way the LL(1)/LALR(1) pair
+   already once needed reconciling. Concretely: a generation script (or
+   at minimum a corpus-based equivalence test reusing
+   `crates/grammar_export/`'s corpus) that fails CI if `grammar.js`
+   accepts/rejects something the real parser doesn't agree with.
+2. **Minimal LSP — diagnostics first.** `typeck.rs`'s `TypeErrorKind`
+   and `validate`'s Hoare-contract checker already produce real,
+   spanned, structured errors (`--format=json`'s `Diagnostic` shape is
+   the existing precedent) — wiring those through
+   `textDocument/publishDiagnostics` is protocol plumbing over an
+   existing result type, not new analysis. Go-to-definition next,
+   riding `docs/LANGUAGE.md` §17's real module resolution (F2) once a
+   program uses it. Refactors/code actions explicitly deferred to a
+   later RFC, not this one.
+3. **VS Code extension** as the first LSP client — largest install
+   base, ships through the Marketplace, not a registry this project
+   has to run itself (consistent with RFC 0001's "avoid hosting a new
+   service" reasoning).
+4. **Formatter — deliberately last.** There is no documented canonical
+   style yet. A formatter without one is either silently opinionated
+   (surprising) or does nothing (pointless) — a style decision is a
+   prerequisite this RFC doesn't make, and shouldn't: it belongs in its
+   own follow-up RFC once there's real multi-author code to observe
+   actual style drift on.
+
+## Effect on the permission model
+
+None. This is tooling that reads a program and reports on it; it
+doesn't change what a `.nir` program can express or how `requires`/
+`acquire`/gates are enforced at runtime.
+
+## Compatibility
+
+Fully additive — new crates/tooling, zero changes to the compiler's
+accepted grammar or runtime behavior. The one place this *could* touch
+existing code is if `grammar_check`'s corpus format needs extending to
+serve as `grammar.js`'s equivalence-test input; that extension must
+stay backward compatible with `grammar_check`'s existing consumers.
+
+## Rejected alternatives
+
+- **Hand-author `grammar.js` independently.** Rejected up front — this
+  is exactly the two-grammars-drift problem `docs/GRAMMAR.md` already
+  had to fix once for LL(1) vs. LALR(1); a third independently-authored
+  grammar is a third thing to keep in sync by hand.
+- **Formatter before a style decision.** Rejected — see Design item 4.
+- **A from-scratch custom protocol instead of LSP.** Not seriously
+  considered: LSP already has editor-side clients for every major
+  editor; a bespoke protocol would need to build those clients too.
+
+## Open questions
+
+- **Where does the tree-sitter grammar live?** A new
+  `crates/tree-sitter-nirdosha/` in this repo, or a separate
+  `nirdosha/tree-sitter-nirdosha` repo (tree-sitter's own ecosystem
+  convention leans toward separate repos per grammar, for its own
+  packaging/npm story). Affects CI wiring and release process either
+  way.
+- **LSP implementation language.** Rust (reusing `typeck.rs`/`parser.rs`
+  directly, no FFI) is the obvious default given the compiler is
+  already Rust, but not yet formally decided in this draft.
+- **Scope of "minimal."** Diagnostics + go-to-definition is this RFC's
+  stated v1; hover-for-type-info and find-references are natural next
+  steps but deliberately unscoped here rather than silently assumed.

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -1,0 +1,51 @@
+# RFCs
+
+A lightweight, PR-based process for a decision that's cross-cutting,
+breaking, or shapes the language surface / a public interface — see
+[`GOVERNANCE.md`](../GOVERNANCE.md#how-day-to-day-decisions-get-made)
+for exactly which decisions need this versus ordinary review. This
+process didn't exist before 2026-09-04; the `str`-in-signatures ban
+(`docs/adr/0002-ban-str-in-fn-signatures.md`) shipped in one session
+with none of this, which is the concrete gap it closes.
+
+## Process
+
+1. Copy [`0000-template.md`](./0000-template.md) to
+   `rfcs/NNNN-short-title.md`, `NNNN` = next unused 4-digit number.
+2. Open a PR adding the file. State `draft` in its front matter.
+3. One existing maintainer volunteers (or is asked) as **shepherd** —
+   noted in the RFC's front matter — responsible for driving it to a
+   state change, not for agreeing with it.
+4. Discussion happens in the PR's comments (or a linked GitHub
+   Discussion thread for anything long-form). State moves to
+   `discussion` once there's been at least one substantive comment.
+5. The shepherd calls it: `accepted` (merge as-is, implementation can
+   start/continue), `postponed` (real idea, wrong time — merged with
+   that state so the discussion isn't lost), or `rejected` (merged with
+   reasoning recorded, so the same proposal doesn't get re-litigated
+   from scratch later).
+6. Once the design it describes is actually built and shipped, a
+   follow-up PR flips the state to `implemented` and links the PR(s)
+   that did it. An `accepted` RFC whose implementation never lands
+   isn't a failure of this process — it just stays `accepted`,
+   honestly, until someone picks it up.
+
+## States
+
+`draft` → `discussion` → **`accepted`** → `implemented`
+`draft` → `discussion` → **`postponed`**
+`draft` → `discussion` → **`rejected`**
+
+## Current RFCs
+
+| # | Title | State | Shepherd |
+|---|---|---|---|
+| [0001](./0001-package-manifest-format.md) | Package manifest format (Cargo-based package manager) | draft | *unassigned* |
+| [0002](./0002-editor-tooling-lsp-tree-sitter.md) | Editor/tooling ecosystem: tree-sitter grammar + minimal LSP | draft | *unassigned* |
+
+## What doesn't need an RFC
+
+A decision made in the course of implementing something, not designed
+up front — a judgment call, a workaround, a "why does this file vendor
+X instead of using the system one" — doesn't need this process. Record
+it as an [ADR](../docs/adr/README.md) instead, after the fact.


### PR DESCRIPTION
Closes `docs/ECOSYSTEM.md` §G5 / `docs/ROADMAP.md` Track G5 (community/governance depth).

## What's in this PR
- **`GOVERNANCE.md`** — roles (owner/maintainer/triager), decision process, branch-protection and release policy.
- **`MAINTAINERS.md`** — honest access-vs-activity read: 4 collaborators already have GitHub write access, but 3 have no commits/reviews on record yet.
- **`AREAS.md`** + **`.github/CODEOWNERS`** — subsystem ownership.
- **`rfcs/`** — process doc + template, seeded with two real drafts: [0001](rfcs/0001-package-manifest-format.md) (Cargo-based package manifest) and [0002](rfcs/0002-editor-tooling-lsp-tree-sitter.md) (LSP/tree-sitter).
- **`docs/adr/`** — process doc, backfilled with two real past decisions: [0001](docs/adr/0001-vendor-z3-except-macos.md) (macOS Z3 vendoring exception) and [0002](docs/adr/0002-ban-str-in-fn-signatures.md) (the `str`-ban breaking change — the actual precedent motivating the new RFC requirement).
- **`.github/labels.yml`** reconciled with the live label set; created 4 missing labels (`grammar`, `ui`, `examples`, `blocked`) directly on GitHub to match.
- **`CONTRIBUTING.md`** — 48h triage SLA, breaking-change-goes-through-RFC policy.
- **`README.md`** — governance/RFC links, updated maintainer count.
- **`docs/ROADMAP.md`** / **`docs/ECOSYSTEM.md`** — Track G5 marked `[DONE]`.

## Already applied outside this diff
Branch protection on `main` (1 required review, green `build`/`build-windows` CI, no force-push/branch-deletion, admin bypass kept for emergencies) was applied directly via the GitHub API before this PR — it's a repo setting, not a file, so there's nothing to diff here; `GOVERNANCE.md` documents it.

## Not done here, disclosed
Signed release tags are documented as policy but not enforced — needs each maintainer's signing key registered with GitHub first. The 3 inactive maintainers still need a first reviewed PR and an assigned `AREAS.md` row before the bus-factor improvement is real, not just access-granted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)