### PR TITLE
fix: stop compiling out on macOS CI over a gitignored test fixture

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,19 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install system Z3 (see workflow header)
         run: brew install z3
+      - name: Install and start Redis (mq_connect/mq_publish/mq_consume tests)
+        # tests/mq.rs's own header comment: needs a real Redis at
+        # 127.0.0.1:6379, no auth. Unlike Postgres's own integration
+        # tests (#[ignore]d, opt-in via NIRDOSHA_TEST_POSTGRES_URL),
+        # mq.rs's tests run unconditionally -- this job is the first CI
+        # job that ever runs the full `cargo test --release` (see this
+        # workflow's own build-macos header comment), which is what
+        # surfaced the gap: without this step, every mq.rs test fails
+        # with "Connection refused" instead of exercising real behavior.
+        run: |
+          brew install redis
+          brew services start redis
+          for i in $(seq 1 10); do redis-cli ping && break; sleep 1; done
       - name: Cache cargo registry and build artifacts
         uses: actions/cache@v4
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,25 @@ members = [
     "crates/presence-gateway",
     "crates/plugin-example-rot13",
 ]
+
+# Rust's own integer-overflow panic is `nirdosha`'s only runtime guard for
+# i64 arithmetic (there's no dynamic `OutOfRange` check for it, see
+# `scalar_binop`/`eval_binary` in crates/compiler/src/interpreter.rs) --
+# `spawn`/`join` catches that panic via `catch_unwind` and reports
+# `ThreadPanicked`. Cargo's default release profile disables overflow
+# checks, which would silently make every distributed `nirdosha` binary
+# wrap i64 overflow instead of erroring -- directly contradicting the
+# project's overflow-safety guarantees. Keep this on in release builds.
+#
+# Must live HERE, at the workspace root -- Cargo only honors `[profile.*]`
+# from the root manifest, silently ignoring the same section in a member
+# crate's own Cargo.toml (with a build-time warning, easy to miss). This
+# setting used to live in crates/compiler/Cargo.toml, back when that file
+# was itself the workspace root; the `crates/`/`docs/` reorg moved it under
+# a real workspace without moving this section along with it, silently
+# turning overflow-checks off in every `--release` build since -- caught by
+# `tests/concurrency.rs::a_panic_inside_a_spawned_function_surfaces_as_
+# thread_panicked` failing in `--release` (it passed in plain `cargo test`,
+# which defaults to debug-mode overflow panics regardless of this setting).
+[profile.release]
+overflow-checks = true

--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -41,13 +41,10 @@ signal-hook = { version = "0.4", default-features = false }
 [features]
 dist = ["z3/vendored"]
 
-# Rust's own integer-overflow panic is `nirdosha`'s only runtime guard
-# for i64 arithmetic (there's no dynamic `OutOfRange` check for it, see
-# `scalar_binop`/`eval_binary` in src/interpreter.rs) -- `spawn`/`join`
-# catches that panic via `catch_unwind` and reports `ThreadPanicked`.
-# Cargo's default release profile disables overflow checks, which would
-# silently make every distributed `nirdosha` binary wrap i64 overflow
-# instead of erroring -- directly contradicting the project's overflow-
-# safety guarantees. Keep this on in release builds.
-[profile.release]
-overflow-checks = true
+# `overflow-checks = true` for release builds used to live here, back
+# when this file was itself the workspace root. It's now at the real
+# workspace root (../../Cargo.toml) -- Cargo only honors `[profile.*]`
+# from there, silently ignoring it in a member crate's own manifest (see
+# that file's comment for the full story, including the regression this
+# caused after the crates/-reorg moved this file without moving that
+# section along with it).

--- a/crates/compiler/tests/codegen.rs
+++ b/crates/compiler/tests/codegen.rs
@@ -2195,8 +2195,8 @@ fn free_port() -> u16 {
 #[test]
 fn compiled_connect_send_recv_stop_round_trips_real_bytes() {
     use std::io::{Read, Write};
-    let port = free_port();
-    let listener = std::net::TcpListener::bind(("127.0.0.1", port)).unwrap();
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
     let server = std::thread::spawn(move || {
         let (mut stream, _) = listener.accept().unwrap();
         let mut buf = [0u8; 1024];
@@ -2225,8 +2225,8 @@ fn compiled_connect_send_recv_stop_round_trips_real_bytes() {
 #[test]
 fn compiled_recv_payload_matches_interpreter_byte_for_byte() {
     use std::io::{Read, Write};
-    let port = free_port();
-    let listener = std::net::TcpListener::bind(("127.0.0.1", port)).unwrap();
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
     let server = std::thread::spawn(move || {
         let (mut stream, _) = listener.accept().unwrap();
         let mut buf = [0u8; 1024];

--- a/crates/compiler/tests/extracted_typed_v1_verification.rs
+++ b/crates/compiler/tests/extracted_typed_v1_verification.rs
@@ -1,6 +1,10 @@
 //! End-to-end demonstration of the two new verbatim-verification
-//! constructs against the real, checked-in extraction file
-//! `scratch/extracted_typed_v1.json` — not a synthetic fixture.
+//! constructs against a local extraction file, `scratch/
+//! extracted_typed_v1.json` — not a synthetic fixture, but also **not
+//! checked into git** (`scratch/` is in `.gitignore`; this file's
+//! original "the real, checked-in extraction file" claim was wrong —
+//! `scratch/extracted_typed_v1.json` has never once been committed).
+//! It's the output of a one-off LLM extraction pass.
 //!
 //! - `workflow_conformance::check_workflow_conformance` — structural,
 //!   exact (no solver): does a real `workflow { ... }` declare exactly
@@ -18,6 +22,14 @@
 //! than `include_str!`-ing the real, much larger, DB-backed
 //! `trade_finance.nir`: a small, self-contained snippet a unit test can
 //! actually typecheck/own-check/run on its own.
+//!
+//! Every `#[test]` below is `#[ignore]`d (same convention `postgres.rs`'s
+//! `NIRDOSHA_TEST_POSTGRES_URL`-gated tests use for "needs a local
+//! resource the test suite can't assume exists"): a plain `cargo test`
+//! never touches this file, so the fixture's absence can't break a clean
+//! checkout or CI. Anyone who still has it locally can run it directly:
+//! `cargo test --release --test extracted_typed_v1_verification --
+//! --ignored`.
 
 use std::collections::HashMap;
 
@@ -29,10 +41,21 @@ use nirdosha::token::Lexer;
 use nirdosha::typeck::typecheck_optional_main;
 use nirdosha::workflow_conformance::check_workflow_conformance;
 
-const EXTRACTED_JSON: &str = include_str!("../../../scratch/extracted_typed_v1.json");
-
+/// Read at test-run time, not compiled in via `include_str!` — the
+/// fixture is gitignored and won't exist on a clean checkout/CI runner,
+/// and `include_str!` would fail the whole *build* (every test in this
+/// binary, including ones that don't need this file) rather than just
+/// this one, ignored test.
 fn load_extraction() -> ExtractionFile {
-    serde_json::from_str(EXTRACTED_JSON).expect("scratch/extracted_typed_v1.json should match extraction_schema::ExtractionFile")
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../scratch/extracted_typed_v1.json");
+    let json = std::fs::read_to_string(path).unwrap_or_else(|e| {
+        panic!(
+            "couldn't read {path}: {e} -- this is a local-only fixture (scratch/ is gitignored, \
+             not shipped with the repo); only run this test with it present, via \
+             `cargo test --release --test extracted_typed_v1_verification -- --ignored`"
+        )
+    });
+    serde_json::from_str(&json).expect("scratch/extracted_typed_v1.json should match extraction_schema::ExtractionFile")
 }
 
 fn build_program(src: &str) -> nirdosha::ast::Program {
@@ -201,6 +224,7 @@ fn extracted_workflow<'a>(file: &'a ExtractionFile, id: &str) -> &'a nirdosha::e
     file.workflows.iter().find(|w| w.id == id).unwrap_or_else(|| panic!("no workflow with id {id} in the extraction file"))
 }
 
+#[ignore = "needs local scratch/extracted_typed_v1.json, not checked into git"]
 #[test]
 fn wf_trdpay_001_matches_the_real_workflow_verbatim() {
     let file = load_extraction();
@@ -209,6 +233,7 @@ fn wf_trdpay_001_matches_the_real_workflow_verbatim() {
     assert!(report.is_exact_match(), "conformance mismatches: {:#?}", report.mismatches);
 }
 
+#[ignore = "needs local scratch/extracted_typed_v1.json, not checked into git"]
 #[test]
 fn wf_trdpay_002_escrow_tranche_release_matches_verbatim() {
     let file = load_extraction();
@@ -217,6 +242,7 @@ fn wf_trdpay_002_escrow_tranche_release_matches_verbatim() {
     assert!(report.is_exact_match(), "conformance mismatches: {:#?}", report.mismatches);
 }
 
+#[ignore = "needs local scratch/extracted_typed_v1.json, not checked into git"]
 #[test]
 fn wf_comm_001_wallet_settlement_matches_verbatim() {
     let file = load_extraction();
@@ -228,6 +254,7 @@ fn wf_comm_001_wallet_settlement_matches_verbatim() {
 /// Proves the checker actually catches a real drift, rather than
 /// trivially reporting a match — drop one transition from the real
 /// workflow and confirm it's reported by name, not silently ignored.
+#[ignore = "needs local scratch/extracted_typed_v1.json, not checked into git"]
 #[test]
 fn conformance_check_actually_detects_a_missing_transition() {
     let file = load_extraction();
@@ -251,6 +278,7 @@ fn conformance_check_actually_detects_a_missing_transition() {
 /// `WorkflowStateHasNoTransitions` only requires a *non*-terminal state
 /// to have a way out; a terminal state with existing transitions still
 /// compiles fine, exactly the shape needed to isolate this one flag.
+#[ignore = "needs local scratch/extracted_typed_v1.json, not checked into git"]
 #[test]
 fn conformance_check_actually_detects_a_terminal_flag_mismatch() {
     let file = load_extraction();
@@ -280,6 +308,7 @@ fn wf_trdpay_001_routing_fn(file: &ExtractionFile) -> &nirdosha::extraction_sche
 /// concretely is today (the code's own hardcoded 5,000,000 cents,
 /// `docs/ROADMAP.md` A9). This is real: Z3 is asked to find a violation and
 /// fails, over the whole `i64` domain.
+#[ignore = "needs local scratch/extracted_typed_v1.json, not checked into git"]
 #[test]
 fn required_eyes_for_amount_satisfies_extracted_post_logic_when_threshold_is_bound() {
     let file = load_extraction();
@@ -296,6 +325,7 @@ fn required_eyes_for_amount_satisfies_extracted_post_logic_when_threshold_is_bou
 /// amount`'s own parameters — the real code hardcodes the number
 /// instead. Without a supplied binding, this is correctly reported as
 /// unresolvable, not silently treated as "any value" or skipped.
+#[ignore = "needs local scratch/extracted_typed_v1.json, not checked into git"]
 #[test]
 fn required_eyes_for_amount_post_logic_is_unbound_without_a_threshold_binding() {
     let file = load_extraction();
@@ -309,6 +339,7 @@ fn required_eyes_for_amount_post_logic_is_unbound_without_a_threshold_binding() 
 /// is supplied (one that doesn't match what the code actually
 /// hardcodes), the checker must find a real counterexample, not report
 /// `Proved` anyway.
+#[ignore = "needs local scratch/extracted_typed_v1.json, not checked into git"]
 #[test]
 fn required_eyes_for_amount_post_logic_fails_against_a_mismatched_threshold() {
     let file = load_extraction();

--- a/crates/compiler/tests/extracted_typed_v2_verification.rs
+++ b/crates/compiler/tests/extracted_typed_v2_verification.rs
@@ -6,6 +6,17 @@
 //! workflows and both of its `routing_fn`s are checked for real here,
 //! not just read — this is the actual answer to "does this extraction
 //! meet expectations," not a visual skim.
+//!
+//! `scratch/extracted_typed_v2.json` is a local fixture, **not** checked
+//! into git (`scratch/` is in `.gitignore`) — it's the output of a
+//! one-off LLM extraction pass, not something this repo's own tooling
+//! regenerates. Every `#[test]` below is `#[ignore]`d for that reason
+//! (same convention `postgres.rs`'s `NIRDOSHA_TEST_POSTGRES_URL`-gated
+//! tests use for "needs a local resource the test suite can't assume
+//! exists"): a plain `cargo test` never touches this file, so its
+//! absence can't break a clean checkout or CI. Anyone who still has the
+//! fixture locally can run it directly: `cargo test --release --test
+//! extracted_typed_v2_verification -- --ignored`.
 
 use std::collections::HashMap;
 
@@ -17,10 +28,21 @@ use nirdosha::token::Lexer;
 use nirdosha::typeck::typecheck_optional_main;
 use nirdosha::workflow_conformance::check_workflow_conformance;
 
-const EXTRACTED_JSON: &str = include_str!("../../../scratch/extracted_typed_v2.json");
-
+/// Read at test-run time, not compiled in via `include_str!` — the
+/// fixture is gitignored and won't exist on a clean checkout/CI runner,
+/// and `include_str!` would fail the whole *build* (every test in this
+/// binary, including ones that don't need this file) rather than just
+/// this one, ignored test.
 fn load_extraction() -> ExtractionFile {
-    serde_json::from_str(EXTRACTED_JSON).expect("scratch/extracted_typed_v2.json should match extraction_schema::ExtractionFile")
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../scratch/extracted_typed_v2.json");
+    let json = std::fs::read_to_string(path).unwrap_or_else(|e| {
+        panic!(
+            "couldn't read {path}: {e} -- this is a local-only fixture (scratch/ is gitignored, \
+             not shipped with the repo); only run this test with it present, via \
+             `cargo test --release --test extracted_typed_v2_verification -- --ignored`"
+        )
+    });
+    serde_json::from_str(&json).expect("scratch/extracted_typed_v2.json should match extraction_schema::ExtractionFile")
 }
 
 fn build_program(src: &str) -> nirdosha::ast::Program {
@@ -203,6 +225,7 @@ fn assert_conforms(nir: &str, file: &ExtractionFile, id: &str) {
     assert!(report.is_exact_match(), "{id}: conformance mismatches: {:#?}", report.mismatches);
 }
 
+#[ignore = "needs local scratch/extracted_typed_v2.json, not checked into git"]
 #[test]
 fn all_six_v2_workflows_match_their_real_nir_verbatim() {
     let file = load_extraction();
@@ -214,6 +237,7 @@ fn all_six_v2_workflows_match_their_real_nir_verbatim() {
     assert_conforms(WALLET_SETTLEMENT_NIR, &file, "WF-COMM-001");
 }
 
+#[ignore = "needs local scratch/extracted_typed_v2.json, not checked into git"]
 #[test]
 fn trade_payment_approval_routing_fn_is_proved_against_v2() {
     let file = load_extraction();
@@ -231,6 +255,7 @@ fn trade_payment_approval_routing_fn_is_proved_against_v2() {
 /// type in Nirdosha). Confirms `contract_check.rs` handles a multi-
 /// parameter arithmetic contract, not just the single-param case
 /// `extracted_typed_v1_verification.rs` already covered.
+#[ignore = "needs local scratch/extracted_typed_v2.json, not checked into git"]
 #[test]
 fn batch_payment_approval_routing_fn_is_proved_against_v2() {
     let file = load_extraction();
@@ -244,6 +269,7 @@ fn batch_payment_approval_routing_fn_is_proved_against_v2() {
 /// Same threshold-unbound case as v1, re-confirmed against the fresh
 /// extraction — `high_value_threshold` still isn't one of
 /// `required_eyes_for_amount`'s real parameters.
+#[ignore = "needs local scratch/extracted_typed_v2.json, not checked into git"]
 #[test]
 fn trade_payment_approval_routing_fn_is_unbound_without_a_threshold_binding() {
     let file = load_extraction();
@@ -257,6 +283,7 @@ fn trade_payment_approval_routing_fn_is_unbound_without_a_threshold_binding() {
 /// demonstrate: `required_role` (a literal token, not
 /// `required_permission`'s prose), `implements` (bound to a real
 /// function), and `input_fields` (typed, form-renderable).
+#[ignore = "needs local scratch/extracted_typed_v2.json, not checked into git"]
 #[test]
 fn user_story_ui_fields_are_populated_and_well_formed() {
     let file = load_extraction();
@@ -290,6 +317,7 @@ fn user_story_ui_fields_are_populated_and_well_formed() {
 /// State-ownership fields: `owner_role`/`required_decisions` should
 /// correctly distinguish Maker-Checker (1 other decider) from six-eyes
 /// (2 distinct ones) from a no-owner automatic state.
+#[ignore = "needs local scratch/extracted_typed_v2.json, not checked into git"]
 #[test]
 fn state_ownership_fields_distinguish_maker_checker_from_six_eyes() {
     let file = load_extraction();

--- a/crates/compiler/tests/http.rs
+++ b/crates/compiler/tests/http.rs
@@ -50,8 +50,8 @@ fn serve_one(listener: TcpListener, raw_response: &'static [u8]) -> std::thread:
 
 #[test]
 fn http_get_returns_the_status_and_body() {
-    let port = free_port();
-    let listener = TcpListener::bind(("127.0.0.1", port)).unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
     let server = serve_one(listener, b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nhello from server");
 
     let src = format!(
@@ -82,8 +82,8 @@ fn http_get_returns_the_status_and_body() {
 
 #[test]
 fn http_get_reports_a_non_200_status_code() {
-    let port = free_port();
-    let listener = TcpListener::bind(("127.0.0.1", port)).unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
     let server = serve_one(listener, b"HTTP/1.1 404 Not Found\r\n\r\nnope");
 
     let src = format!(
@@ -105,8 +105,8 @@ fn http_get_reports_a_non_200_status_code() {
 
 #[test]
 fn http_post_sends_the_body_with_a_matching_content_length() {
-    let port = free_port();
-    let listener = TcpListener::bind(("127.0.0.1", port)).unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
     let server = serve_one(listener, b"HTTP/1.1 201 Created\r\n\r\nok");
 
     let src = format!(
@@ -131,8 +131,8 @@ fn http_post_sends_the_body_with_a_matching_content_length() {
 
 #[test]
 fn a_response_body_composes_directly_with_json_get_str() {
-    let port = free_port();
-    let listener = TcpListener::bind(("127.0.0.1", port)).unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
     let server = serve_one(
         listener,
         b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{\"message\": \"pong\"}",
@@ -190,8 +190,8 @@ fn connecting_to_a_closed_port_is_a_recoverable_err_not_a_trap() {
 
 #[test]
 fn a_response_with_no_header_body_separator_is_a_recoverable_err() {
-    let port = free_port();
-    let listener = TcpListener::bind(("127.0.0.1", port)).unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
     let server = serve_one(listener, b"not a real HTTP response at all");
 
     let src = format!(
@@ -280,8 +280,8 @@ fn http_is_interpreter_only_rejected_by_codegen() {
 
 #[test]
 fn example_http_runs_to_completion() {
-    let port = free_port();
-    let listener = TcpListener::bind(("127.0.0.1", port)).unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
     let server = serve_one(
         listener,
         b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{\"message\": \"pong\"}",

--- a/crates/compiler/tests/https.rs
+++ b/crates/compiler/tests/https.rs
@@ -123,8 +123,8 @@ fn https_get_rejects_an_untrusted_self_signed_certificate() {
     };
     let identity = native_tls::Identity::from_pkcs12(&pkcs12, "testpass").expect("test cert should load");
 
-    let port = free_port();
-    let listener = TcpListener::bind(("127.0.0.1", port)).unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
     let server = serve_one_tls(listener, identity);
 
     let src = format!(
@@ -150,8 +150,8 @@ fn https_get_rejects_an_untrusted_self_signed_certificate() {
 fn https_against_a_plain_tcp_peer_is_a_recoverable_err() {
     // A listener that accepts and immediately closes -- speaks no TLS at
     // all. The handshake must fail cleanly, not hang or panic.
-    let port = free_port();
-    let listener = TcpListener::bind(("127.0.0.1", port)).unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
     let server = std::thread::spawn(move || {
         let _ = listener.accept();
     });

--- a/crates/compiler/tests/tcp.rs
+++ b/crates/compiler/tests/tcp.rs
@@ -41,8 +41,8 @@ fn free_port() -> u16 {
 
 #[test]
 fn a_connected_client_can_send_and_receive_real_bytes() {
-    let port = free_port();
-    let listener = TcpListener::bind(("127.0.0.1", port)).unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
     let server = std::thread::spawn(move || {
         let (mut stream, _) = listener.accept().unwrap();
         let mut buf = [0u8; 1024];

--- a/crates/compiler/tests/transact_durability.rs
+++ b/crates/compiler/tests/transact_durability.rs
@@ -881,8 +881,8 @@ fn replay_leaves_a_still_failing_network_at_pending_for_the_next_attempt() {
 /// end to end rather than just asserted.
 #[test]
 fn network_slot_talks_to_a_real_separate_process_over_tcp() {
-    let port = free_port();
-    let listener = TcpListener::bind(("127.0.0.1", port)).unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
     let received_txn_ids = Arc::new(std::sync::Mutex::new(Vec::new()));
     let received_clone = Arc::clone(&received_txn_ids);
     let server = std::thread::spawn(move || {


### PR DESCRIPTION
## What

`crates/compiler/tests/extracted_typed_v{1,2}_verification.rs` both pulled in `scratch/extracted_typed_v{1,2}.json` via `include_str!()` — a **compile-time** include. `scratch/` is gitignored and neither JSON file was ever committed, so a clean checkout fails to *compile* the test binary outright:

```
error: couldn't read `crates/compiler/tests/../../../scratch/extracted_typed_v2.json`: No such file or directory (os error 2)
```

The ubuntu `build` CI job never ran `cargo test`, so this went unnoticed until PR #14 added the first CI job that does (`build-macos`) — that's the red ✗ on the `main` merge commit for #14. Chasing `build-macos` to green surfaced three more real, pre-existing bugs along the way (each one only ever exercised by this newly-added job), fixed in the same PR rather than opening four separate ones for one CI job's worth of investigation.

## Fix 1 — the fixture `include_str!`

- Read the fixture at **test-run time** (`std::fs::read_to_string`) instead of compile time, with a clear panic message if it's missing.
- Marked every `#[test]` in both files `#[ignore]` — same convention `postgres.rs`'s `NIRDOSHA_TEST_POSTGRES_URL`-gated tests already use for "needs a local resource CI can't assume exists." A plain `cargo test` now never touches either file; anyone with the fixture locally can still run them directly via `--ignored`.
- Corrected a stale doc comment in the v1 file that claimed the fixture was "checked-in" — it never has been.

## Fix 2 — `overflow-checks = true` was silently a no-op since the repo reorg

`crates/compiler/Cargo.toml` had `[profile.release] overflow-checks = true`, but Cargo only honors `[profile.*]` from the **workspace root** manifest — a member crate's own profile section is silently ignored (`cargo build` even warns about it: "profiles for the non root package will be ignored, specify profiles at the workspace root"). This setting predates the `crates/`/`docs/` reorg, back when `crates/compiler/Cargo.toml` was itself the workspace root; the reorg introduced a real root `Cargo.toml` without moving this section along, silently disabling overflow checks in every `--release` build since — the interpreter's only runtime guard for i64 overflow, and the mechanism `spawn`/`join`'s `ThreadPanicked` conversion depends on. Moved it to the workspace root, where Cargo actually applies it.

## Fix 3 — no Redis on the macOS runner

`tests/mq.rs`'s `mq_connect`/`mq_publish`/`mq_consume` tests need a real Redis at `127.0.0.1:6379` and run unconditionally (not `#[ignore]`d like the Postgres integration tests). Added `brew install redis` + `brew services start redis` (with a short `redis-cli ping` retry loop) as a `build-macos` step.

## Fix 4 — a real TOCTOU port race

`free_port()` binds `"127.0.0.1:0"`, reads the OS-assigned port, **drops the listener**, then the caller rebinds that exact port a moment later — a window where a concurrently-running test can grab the same port first. Failed `build-macos` with a real `AddrInUse`. Fixed everywhere it's fully eliminable (12 sites across `codegen.rs`, `tcp.rs`, `http.rs`, `https.rs`, `transact_durability.rs`, where the same test binds its own listener right after `free_port()`): merged into one atomic `bind` + `local_addr()` read, no drop, no rebind, no race.

Left alone, disclosed rather than silently gapped: ~8 other files hand a reserved port to `nirdosha::serve::run(...)` running in a separate thread/process, where the same fix would need `serve::run`'s own signature changed to accept a pre-bound `TcpListener` — a larger change to production code, out of scope here. Also left alone on purpose: the "connect to a guaranteed-closed port" tests, which need the port free, not held — `free_port()`'s drop-then-use is the correct idiom there.

## Verification

- Both fixture-test binaries compile clean and report `ignored` rather than failing the build.
- `cargo build --release` from the workspace root no longer emits the "profiles ignored" warning.
- Full `codegen.rs` (142 tests), `tcp.rs`, `http.rs`, `https.rs`, `transact_durability.rs`, and `concurrency.rs` suites all green under `--release`.
