### PR TITLE
docs: fix stale cd compiler path, exempt good-first-issue from ask-first

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ Closes #
 
 ## Checklist
 
-- [ ] `cargo test` passes locally (`cd compiler && cargo test`)
+- [ ] `cargo test` passes locally (`cd crates/compiler && cargo test`)
 - [ ] Docs updated in this same PR if behavior changed
       (`docs/LANGUAGE.md`/`docs/GRAMMAR.md`/`docs/ROADMAP.md`/`docs/PUBLIC_ROADMAP.md`, as
       applicable) — this project treats docs as load-bearing, not

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,14 +28,16 @@ triage, or design feedback — helps.
 1. Check existing issues and the [Public Roadmap](./docs/PUBLIC_ROADMAP.md)
    so you're not duplicating work already scoped or underway.
 2. For anything non-trivial, open an issue first so we can agree on
-   direction before you sink time into an implementation.
+   direction before you sink time into an implementation. **Exception:**
+   an issue already labeled `good first issue` is pre-scoped — just send
+   the PR, no need to ask.
 3. Keep changes minimal and focused — a bug fix doesn't need drive-by
    refactoring bundled in.
 
 ## Development setup
 
 ```sh
-cd compiler
+cd crates/compiler
 cargo build          # fast dev build
 cargo test           # full suite (unit + crates/compiler/tests/*.rs)
 ```
@@ -67,7 +69,7 @@ the right design doc for whatever you're changing.
 ## Pull request process
 
 1. Fork and branch.
-2. Run the full test suite: `cargo test` in `compiler/`.
+2. Run the full test suite: `cargo test` in `crates/compiler/`.
 3. Update relevant docs (`docs/LANGUAGE.md`, `docs/GRAMMAR.md`, `docs/ROADMAP.md`,
    `docs/PUBLIC_ROADMAP.md`) in the *same* PR, not a follow-up — this
    project treats docs as load-bearing, not aspirational.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ triage, or design feedback — helps.
 
 ## Development setup
 
-**No local toolchain?** [Open in GitHub Codespaces](https://codespaces.new/arunsoman/nirdosha?quickstart=1) —
+**No local toolchain?** [Open in GitHub Codespaces](https://codespaces.new/kannamma-labs/nirdosha?quickstart=1) —
 `.devcontainer/devcontainer.json` installs `clang`/`libz3-dev` and runs
 the first build for you, so you land in a ready-to-go shell.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,10 @@ triage, or design feedback — helps.
 
 ## Development setup
 
+**No local toolchain?** [Open in GitHub Codespaces](https://codespaces.new/arunsoman/nirdosha?quickstart=1) —
+`.devcontainer/devcontainer.json` installs `clang`/`libz3-dev` and runs
+the first build for you, so you land in a ready-to-go shell.
+
 ```sh
 cd crates/compiler
 cargo build          # fast dev build


### PR DESCRIPTION
## What
- `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` both said `cd compiler`, left over from before the `crates/` reorg. Anyone following the doc as written hits `No such file or directory` on their very first command.
- Adds an explicit exception to "open an issue before anything non-trivial": an issue already labeled `good first issue` is pre-scoped, so contributors can just send the PR.

## Why
Found while diagnosing why traffic (896 views / 216 uniques from Reddit+Medium in the last 2 weeks) isn't converting to stars/forks/PRs (currently 19/0/0). A broken first command in the onboarding doc is a concrete, fixable piece of that gap — didn't touch `docs/PHASE0.md`'s copy of the same command, since that file is an intentionally-preserved historical snapshot (says so in its own header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)