### PR TITLE
feat: crates.io packaging metadata + zero-setup Codespaces devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+  // Zero-setup "try it" path for GitHub Codespaces / VS Code Dev Containers.
+  // Uses system libz3-dev (linked via pkg-config), not the vendored
+  // `dist` feature -- matches CONTRIBUTING.md's own local-dev instructions
+  // ("apt install clang libz3-dev"), and is much faster to spin up than
+  // compiling Z3 from source (see Dockerfile's build stage, which uses
+  // the `dist` feature only for release/CI binaries).
+  "name": "Nirdosha",
+  "image": "mcr.microsoft.com/devcontainers/rust:1-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {}
+  },
+  "postCreateCommand": "sudo apt-get update && sudo apt-get install -y --no-install-recommends clang libz3-dev && cd crates/compiler && cargo build",
+  "postAttachCommand": "printf 'Built. Try:\\n  cd crates/compiler && cargo run -- ../../examples/hello.nir\\n  cd crates/compiler && cargo run -- serve ../../examples/store.nir --port 8080   # then use the Ports tab to open 8080\\n'",
+  "customizations": {
+    "vscode": {
+      "extensions": ["rust-lang.rust-analyzer"]
+    }
+  },
+  "forwardPorts": [8080],
+  "portsAttributes": {
+    "8080": { "label": "nirdosha serve", "onAutoForward": "notify" }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Roadmap](https://img.shields.io/badge/ROADMAP-view-purple)](./docs/PUBLIC_ROADMAP.md)
 [![Maintainers](https://img.shields.io/badge/maintainers-5-green)](./MAINTAINERS.md)
 [![Sponsor](https://img.shields.io/badge/%E2%9D%A4-Sponsor-ea4aaa)](https://github.com/sponsors/arunsoman)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/arunsoman/nirdosha?quickstart=1)
 
 > **A systems language designed for LLMs to write, with a grammar so
 > constrained the model can't emit invalid syntax.** No garbage collector,
@@ -178,6 +179,18 @@ Full comparison, plus the honest "why not just use Rust" answer, in the
 [wiki](https://github.com/kannamma-labs/nirdosha/wiki/Nirdosha-vs-Alternatives).
 
 ## Try it in under a minute
+
+**No local toolchain at all?** Click
+[**Open in GitHub Codespaces**](https://codespaces.new/arunsoman/nirdosha?quickstart=1)
+— it builds the compiler for you (system Z3, ~1 min) and drops you into a
+VS Code shell in the browser with everything already checked out. From
+there:
+
+```sh
+cd crates/compiler
+cargo run -- ../../examples/hello.nir
+cargo run -- serve ../../examples/store.nir --port 8080   # open via the Ports tab
+```
 
 **Don't want to learn the syntax first?** Paste
 [`agent-skills/nirdosha/paste-anywhere-prompt.md`](./agent-skills/nirdosha/paste-anywhere-prompt.md)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Roadmap](https://img.shields.io/badge/ROADMAP-view-purple)](./docs/PUBLIC_ROADMAP.md)
 [![Maintainers](https://img.shields.io/badge/maintainers-5-green)](./MAINTAINERS.md)
 [![Sponsor](https://img.shields.io/badge/%E2%9D%A4-Sponsor-ea4aaa)](https://github.com/sponsors/arunsoman)
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/arunsoman/nirdosha?quickstart=1)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/kannamma-labs/nirdosha?quickstart=1)
 
 > **A systems language designed for LLMs to write, with a grammar so
 > constrained the model can't emit invalid syntax.** No garbage collector,
@@ -181,15 +181,15 @@ Full comparison, plus the honest "why not just use Rust" answer, in the
 ## Try it in under a minute
 
 **No local toolchain at all?** Click
-[**Open in GitHub Codespaces**](https://codespaces.new/arunsoman/nirdosha?quickstart=1)
+[**Open in GitHub Codespaces**](https://codespaces.new/kannamma-labs/nirdosha?quickstart=1)
 — it builds the compiler for you (system Z3, ~1 min) and drops you into a
 VS Code shell in the browser with everything already checked out. From
 there:
 
 ```sh
 cd crates/compiler
-cargo run -- ../../examples/hello.nir
-cargo run -- serve ../../examples/store.nir --port 8080   # open via the Ports tab
+cargo run -- ../../examples/syntax/hello_nir.nir
+cargo run -- serve ../../examples/syntax/06_identity_and_declarative_ui.nir --port 8080   # open via the Ports tab
 ```
 
 **Don't want to learn the syntax first?** Paste

--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -2,6 +2,12 @@
 name = "nirdosha"
 version = "0.1.0"
 edition = "2024"
+description = "A systems language designed for LLMs to write: an LL(1) grammar constrained-decodable to GBNF, no GC/data races/deadlocks/overflow, OS-process sandboxing as a language primitive."
+license = "MIT"
+repository = "https://github.com/arunsoman/nirdosha"
+homepage = "https://github.com/arunsoman/nirdosha"
+keywords = ["compiler", "llm", "ai-agents", "language", "sandboxing"]
+categories = ["compilers", "command-line-utilities"]
 
 [dependencies]
 z3 = "0.20.2"

--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2024"
 description = "A systems language designed for LLMs to write: an LL(1) grammar constrained-decodable to GBNF, no GC/data races/deadlocks/overflow, OS-process sandboxing as a language primitive."
 license = "MIT"
-repository = "https://github.com/arunsoman/nirdosha"
-homepage = "https://github.com/arunsoman/nirdosha"
+repository = "https://github.com/kannamma-labs/nirdosha"
+homepage = "https://github.com/kannamma-labs/nirdosha"
 keywords = ["compiler", "llm", "ai-agents", "language", "sandboxing"]
 categories = ["compilers", "command-line-utilities"]
 


### PR DESCRIPTION
## What
1. **crates.io packaging metadata** (`crates/compiler/Cargo.toml`): `description`, `license`, `repository`, `homepage`, `keywords`, `categories` — good hygiene regardless, and required if/when this does get published.
2. **`.devcontainer/devcontainer.json`**: one-click "Open in GitHub Codespaces" path. Installs `clang`/`libz3-dev` and runs the first `cargo build` automatically. README/CONTRIBUTING link it as the fastest "try it" path. Verified for real: built the compiler locally and confirmed both quickstart commands work — `cargo run -- examples/syntax/hello_nir.nir` prints output, and `cargo run -- serve examples/syntax/06_identity_and_declarative_ui.nir --port 8080` actually serves (`/healthz` returns 200).

## ⚠️ Update: crates.io publish is currently NOT possible (found after rebasing onto main)
This PR originally verified `cargo publish --dry-run` succeeded. Since then, an unrelated concurrent change landed on `main` that moved `runtime-kernels` out of `crates/compiler/` into its own sibling Cargo project (`build.rs` now shells out `cargo rustc ../runtime-kernels`). Re-running the dry run against current `main`:

```
error: failed to run custom build command for `nirdosha v0.1.0`
  cargo rustc failed to build ../runtime-kernels into a staticlib:
  error: manifest path `.../target/package/nirdosha-0.1.0/../runtime-kernels/Cargo.toml` does not exist
```

`cargo publish` only packages files inside `crates/compiler/`, so a sibling directory outside the crate root can never be part of the tarball — this isn't a metadata problem, it's a real architectural blocker. Fixing it for real means one of:
- vendor `runtime-kernels`'s source back inside `crates/compiler/` (undoes the sibling-workspace split from the concurrent change), or
- publish `runtime-kernels` to crates.io as its own crate and depend on it by version instead of by relative path, or
- accept that `nirdosha` (the compiler crate) isn't crates.io-publishable in its current shape and skip that distribution channel.

The metadata in this PR is still correct to merge (any of the above still needs it), but treat the "ready to `cargo publish`" claim as retracted until one of those is done — that's a separate, real piece of work, not a "run this command" follow-up.

## Also fixed in this PR
Repo was transferred from `arunsoman` to `kannamma-labs` mid-session — updated the Codespaces badge/link and `Cargo.toml`'s `repository`/`homepage` to match (full repo-wide sweep is in #19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)