### PR TITLE
chore: update all repo references after arunsoman → kannamma-labs transfer

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,5 +1,5 @@
 # Documented label set for this repo — kept in sync with the live
-# GitHub labels (`gh label list --repo arunsoman/nirdosha`), last
+# GitHub labels (`gh label list --repo kannamma-labs/nirdosha`), last
 # reconciled 2026-09-04. This file is the source of truth for *intent*;
 # if it and the live repo ever drift, fix the repo to match this file
 # (`gh label create`/`gh label edit`), not the other way around.

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -39,7 +39,7 @@ jobs:
             Thanks for opening your first issue here — glad you tried Nirdosha.
 
             A couple of pointers while you wait:
-            - The ["Before you contribute"](https://github.com/arunsoman/nirdosha/blob/main/CONTRIBUTING.md#before-you-contribute) section of `CONTRIBUTING.md` covers checking the [Public Roadmap](https://github.com/arunsoman/nirdosha/blob/main/docs/PUBLIC_ROADMAP.md) for related work already scoped.
+            - The ["Before you contribute"](https://github.com/kannamma-labs/nirdosha/blob/main/CONTRIBUTING.md#before-you-contribute) section of `CONTRIBUTING.md` covers checking the [Public Roadmap](https://github.com/kannamma-labs/nirdosha/blob/main/docs/PUBLIC_ROADMAP.md) for related work already scoped.
             - This is a small team, but there's a **48-hour triage SLA** on every new issue (see `CONTRIBUTING.md`'s "Response time" section) — a real person will respond, even if it's just "seen, will look."
 
             You've been tagged `first-time contributor` so it's easy to spot. Thanks again.
@@ -47,8 +47,8 @@ jobs:
             Thanks for the PR — your first one here, welcome.
 
             A couple of pointers while it's in the queue:
-            - The ["Before you contribute"](https://github.com/arunsoman/nirdosha/blob/main/CONTRIBUTING.md#before-you-contribute) section of `CONTRIBUTING.md` covers what we look for before review (an issue discussed first for anything non-trivial, minimal/focused diffs, docs updated in the same PR).
-            - [`AREAS.md`](https://github.com/arunsoman/nirdosha/blob/main/AREAS.md) lists who owns the subsystem you touched, so you know who's likely to review.
+            - The ["Before you contribute"](https://github.com/kannamma-labs/nirdosha/blob/main/CONTRIBUTING.md#before-you-contribute) section of `CONTRIBUTING.md` covers what we look for before review (an issue discussed first for anything non-trivial, minimal/focused diffs, docs updated in the same PR).
+            - [`AREAS.md`](https://github.com/kannamma-labs/nirdosha/blob/main/AREAS.md) lists who owns the subsystem you touched, so you know who's likely to review.
             - **48-hour triage SLA** applies here too (`CONTRIBUTING.md`'s "Response time" section) — expect a first response, not necessarily a merge, within that window.
 
             You've been tagged `first-time contributor` so it's easy to spot. Thanks again.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ triage, or design feedback — helps.
 ## Quick ways to help
 
 - **Try it and report what breaks.** Build from source (below) or grab
-  a [prebuilt binary](https://github.com/arunsoman/nirdosha/releases/latest),
+  a [prebuilt binary](https://github.com/kannamma-labs/nirdosha/releases/latest),
   run a few `examples/*.nir`
   files, open an issue for anything confusing or wrong.
 - **Improve docs.** Typos, unclear explanations, and missing examples

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN cargo build --release --features dist
 # against a first version of this image that mismatched the two.
 FROM python:3.12-slim-trixie AS runtime
 
-LABEL org.opencontainers.image.source="https://github.com/arunsoman/nirdosha" \
+LABEL org.opencontainers.image.source="https://github.com/kannamma-labs/nirdosha" \
       org.opencontainers.image.description="nirdosha: one process serves both the API and the UI generated from a single .nir program" \
       org.opencontainers.image.licenses="Apache-2.0"
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -95,7 +95,7 @@ rule and should get called out in the next PR, not left silent.
   "seen, will look") on a new issue or PR — not to a full resolution.
   See [`CONTRIBUTING.md`](./CONTRIBUTING.md#response-time) for how this
   relates to the "about a week" full-response expectation.
-- [GitHub Discussions](https://github.com/arunsoman/nirdosha/discussions)
+- [GitHub Discussions](https://github.com/kannamma-labs/nirdosha/discussions)
   is enabled for design chatter that isn't yet a formal RFC.
 - The [Public Roadmap](./docs/PUBLIC_ROADMAP.md) is linked from the
   README so a prospective contributor can see what's open without

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -28,7 +28,7 @@ write access below is broader than that.
 
 **Read this table honestly, not optimistically.** GitHub write access
 exists for all four names above (confirmed via
-`gh api repos/arunsoman/nirdosha/collaborators/<user>/permission`,
+`gh api repos/kannamma-labs/nirdosha/collaborators/<user>/permission`,
 2026-09-04) — that part of `docs/ECOSYSTEM.md` §G5's ask is already
 done. What's still open is *activation*: none of the four has an
 assigned area, and three have no commits or reviews on this repo yet.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Nirdosha — निर्दोष ("without fault")
 
-[![build](https://github.com/arunsoman/nirdosha/actions/workflows/build.yml/badge.svg)](https://github.com/arunsoman/nirdosha/actions/workflows/build.yml)
+[![build](https://github.com/kannamma-labs/nirdosha/actions/workflows/build.yml/badge.svg)](https://github.com/kannamma-labs/nirdosha/actions/workflows/build.yml)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
-[![Wiki](https://img.shields.io/badge/docs-wiki-blue)](https://github.com/arunsoman/nirdosha/wiki)
+[![Wiki](https://img.shields.io/badge/docs-wiki-blue)](https://github.com/kannamma-labs/nirdosha/wiki)
 [![Contributing](https://img.shields.io/badge/CONTRIBUTING-read-blue)](./CONTRIBUTING.md)
 [![Governance](https://img.shields.io/badge/GOVERNANCE-read-blue)](./GOVERNANCE.md)
 [![Roadmap](https://img.shields.io/badge/ROADMAP-view-purple)](./docs/PUBLIC_ROADMAP.md)
@@ -17,7 +17,7 @@
 
 Status: a real, runnable Rust compiler (`crates/compiler/`) under
 active development — many safety properties are *proven* today, and
-where one is still *aspirational* the [wiki](https://github.com/arunsoman/nirdosha/wiki/Honest-Scope-and-Roadmap)
+where one is still *aspirational* the [wiki](https://github.com/kannamma-labs/nirdosha/wiki/Honest-Scope-and-Roadmap)
 says so plainly. Source files use the `.nir` extension.
 
 ```nirdosha
@@ -61,8 +61,8 @@ exact same screen drops the `risk_score` field and column entirely and
 disables `Approve` — both enforced by `serve.rs` on every call, not
 hidden by client JS. Signed in as `admin`, that same `Approve` action
 really flips a row from `requested` to `approved` in SQLite. Nothing here
-is simulated — see the [UI Engine](https://github.com/arunsoman/nirdosha/wiki/UI-Engine)
-and [Honest Scope](https://github.com/arunsoman/nirdosha/wiki/Honest-Scope-and-Roadmap)
+is simulated — see the [UI Engine](https://github.com/kannamma-labs/nirdosha/wiki/UI-Engine)
+and [Honest Scope](https://github.com/kannamma-labs/nirdosha/wiki/Honest-Scope-and-Roadmap)
 wiki pages.
 
 ---
@@ -93,7 +93,7 @@ active each is. Right now:
 - **macOS verification** — release binaries link system Z3 because
   `z3-src` doesn't build against current AppleClang ([ADR
   0001](./docs/adr/0001-vendor-z3-except-macos.md), tracked as
-  [issue #5](https://github.com/arunsoman/nirdosha/issues/5)) — that part
+  [issue #5](https://github.com/kannamma-labs/nirdosha/issues/5)) — that part
   is still open. What's now closed: macOS gets CI verification on every
   push/PR, not just at release time. `build-macos` in
   [`.github/workflows/build.yml`](./.github/workflows/build.yml) mirrors
@@ -137,7 +137,7 @@ obligation instead of a paragraph to guess at; `sandbox` is a real OS
 process and a language primitive, not a bolted-on Docker wrapper; there is
 no mutex in the language, so an agent literally cannot generate a
 lock-ordering deadlock. It isn't trying to be a better Rust — see the
-[wiki](https://github.com/arunsoman/nirdosha/wiki) for the full case,
+[wiki](https://github.com/kannamma-labs/nirdosha/wiki) for the full case,
 including where the design is still evolving, not a finished product.
 
 ## Who this is for — and who it isn't
@@ -163,7 +163,7 @@ including where the design is still evolving, not a finished product.
 - You need something production-ready this quarter — nothing here
   claims that.
 
-Full picture: [Who It's For](https://github.com/arunsoman/nirdosha/wiki/Who-Its-For) in the wiki.
+Full picture: [Who It's For](https://github.com/kannamma-labs/nirdosha/wiki/Who-Its-For) in the wiki.
 
 ## Nirdosha vs. Rust, Go, Mojo — the one-line version
 
@@ -175,7 +175,7 @@ Full picture: [Who It's For](https://github.com/arunsoman/nirdosha/wiki/Who-Its-
 | LLM writability | LL(1) grammar exported to GBNF for constrained decoding | LLMs default to Python 90–97% of the time | No constrained decoding built in | No published GBNF integration |
 
 Full comparison, plus the honest "why not just use Rust" answer, in the
-[wiki](https://github.com/arunsoman/nirdosha/wiki/Nirdosha-vs-Alternatives).
+[wiki](https://github.com/kannamma-labs/nirdosha/wiki/Nirdosha-vs-Alternatives).
 
 ## Try it in under a minute
 
@@ -186,17 +186,17 @@ the `.nir` code for you. This prompt has already been used, unmodified, to
 generate a working e-commerce store, a food-delivery platform, a telecom
 revenue-assurance system, and an online trading platform, each hundreds of
 lines, each by an LLM with no prior Nirdosha exposure. See
-[LLM Integration](https://github.com/arunsoman/nirdosha/wiki/LLM-Integration)
+[LLM Integration](https://github.com/kannamma-labs/nirdosha/wiki/LLM-Integration)
 for the full mechanism and evidence.
 
 **Install and run it yourself — no compiler needed, prebuilt binaries are
-published on every [release](https://github.com/arunsoman/nirdosha/releases):**
+published on every [release](https://github.com/kannamma-labs/nirdosha/releases):**
 
 ```sh
-git clone https://github.com/arunsoman/nirdosha.git && cd nirdosha
+git clone https://github.com/kannamma-labs/nirdosha.git && cd nirdosha
 
 # macOS / Linux — installer script, auto-detects your platform
-curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/arunsoman/nirdosha/main/scripts/install.sh | sh
+curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/kannamma-labs/nirdosha/main/scripts/install.sh | sh
 
 nirdosha examples/hello.nir
 nirdosha serve examples/store.nir --port 8080   # CRUD API from a struct
@@ -209,22 +209,22 @@ number to update. Run this from inside the `nirdosha` clone from above:
 
 ```sh
 # Linux x86_64
-curl -fsSL https://github.com/arunsoman/nirdosha/releases/latest/download/nirdosha-x86_64-unknown-linux-gnu.tar.gz | tar xz
+curl -fsSL https://github.com/kannamma-labs/nirdosha/releases/latest/download/nirdosha-x86_64-unknown-linux-gnu.tar.gz | tar xz
 
 # macOS, Apple Silicon
-curl -fsSL https://github.com/arunsoman/nirdosha/releases/latest/download/nirdosha-aarch64-apple-darwin.tar.gz | tar xz
+curl -fsSL https://github.com/kannamma-labs/nirdosha/releases/latest/download/nirdosha-aarch64-apple-darwin.tar.gz | tar xz
 
 ./nirdosha examples/hello.nir
 ```
 
 These two targets are what's currently published; Windows and Intel
 Mac binaries aren't up yet (build from source below in the meantime) —
-the [releases page](https://github.com/arunsoman/nirdosha/releases/latest)
+the [releases page](https://github.com/kannamma-labs/nirdosha/releases/latest)
 has the current full asset list.
 
 Full install (Windows, building from source, toolchain requirements),
 scaffolding a new project, and generating a UI: see
-[Getting Started](https://github.com/arunsoman/nirdosha/wiki/Getting-Started)
+[Getting Started](https://github.com/kannamma-labs/nirdosha/wiki/Getting-Started)
 in the wiki.
 
 ### Before you write your own program
@@ -255,37 +255,37 @@ This README is the pitch and the five-minute quick start. Everything
 else — the full design philosophy, the compiler architecture, the
 complete feature and grammar reference, benchmarks with methodology, and
 the LLM-integration mechanism with evidence — lives in the
-**[Nirdosha Wiki](https://github.com/arunsoman/nirdosha/wiki)**:
+**[Nirdosha Wiki](https://github.com/kannamma-labs/nirdosha/wiki)**:
 
-- [Design Philosophy](https://github.com/arunsoman/nirdosha/wiki/Design-Philosophy) — the twelve requirements, and the Rice's-theorem constraint that shapes everything
-- [Who It's For](https://github.com/arunsoman/nirdosha/wiki/Who-Its-For) — the honest fit
-- [Nirdosha vs. Rust, Go, Mojo](https://github.com/arunsoman/nirdosha/wiki/Nirdosha-vs-Alternatives)
-- [Architecture](https://github.com/arunsoman/nirdosha/wiki/Architecture) — the real compiler pipeline, the LL(1) grammar, independent cross-checks
-- [Language Features](https://github.com/arunsoman/nirdosha/wiki/Language-Features) — the full feature set
-- [The UI Engine](https://github.com/arunsoman/nirdosha/wiki/UI-Engine) — zero-syntax CRUD/dashboard generation
-- [Benchmarks](https://github.com/arunsoman/nirdosha/wiki/Benchmarks) — compiled-vs-compiled numbers, methodology and caveats included
-- [**LLM Integration**](https://github.com/arunsoman/nirdosha/wiki/LLM-Integration) — the flagship page: what each mechanism solves for an agent, and the evidence it's real
-- [Getting Started](https://github.com/arunsoman/nirdosha/wiki/Getting-Started) — full install/build/run/scaffold
-- [Honest Scope & Roadmap](https://github.com/arunsoman/nirdosha/wiki/Honest-Scope-and-Roadmap) — shipped vs. interpreter-only vs. aspirational
-- [FAQ](https://github.com/arunsoman/nirdosha/wiki/FAQ)
+- [Design Philosophy](https://github.com/kannamma-labs/nirdosha/wiki/Design-Philosophy) — the twelve requirements, and the Rice's-theorem constraint that shapes everything
+- [Who It's For](https://github.com/kannamma-labs/nirdosha/wiki/Who-Its-For) — the honest fit
+- [Nirdosha vs. Rust, Go, Mojo](https://github.com/kannamma-labs/nirdosha/wiki/Nirdosha-vs-Alternatives)
+- [Architecture](https://github.com/kannamma-labs/nirdosha/wiki/Architecture) — the real compiler pipeline, the LL(1) grammar, independent cross-checks
+- [Language Features](https://github.com/kannamma-labs/nirdosha/wiki/Language-Features) — the full feature set
+- [The UI Engine](https://github.com/kannamma-labs/nirdosha/wiki/UI-Engine) — zero-syntax CRUD/dashboard generation
+- [Benchmarks](https://github.com/kannamma-labs/nirdosha/wiki/Benchmarks) — compiled-vs-compiled numbers, methodology and caveats included
+- [**LLM Integration**](https://github.com/kannamma-labs/nirdosha/wiki/LLM-Integration) — the flagship page: what each mechanism solves for an agent, and the evidence it's real
+- [Getting Started](https://github.com/kannamma-labs/nirdosha/wiki/Getting-Started) — full install/build/run/scaffold
+- [Honest Scope & Roadmap](https://github.com/kannamma-labs/nirdosha/wiki/Honest-Scope-and-Roadmap) — shipped vs. interpreter-only vs. aspirational
+- [FAQ](https://github.com/kannamma-labs/nirdosha/wiki/FAQ)
 
 ## FAQ (short version)
 
 **Is it production-ready?** Not yet — it's under active development,
 with real guarantees proven today and the rest tracked openly, not
-hand-waved. See [Honest Scope & Roadmap](https://github.com/arunsoman/nirdosha/wiki/Honest-Scope-and-Roadmap).
+hand-waved. See [Honest Scope & Roadmap](https://github.com/kannamma-labs/nirdosha/wiki/Honest-Scope-and-Roadmap).
 
 **Why not just use Rust?** Rust already solves memory safety for teams
 that can invest in its learning curve. Nirdosha targets a narrower
 problem — AI agents writing backend code unsupervised. See the
-[full answer](https://github.com/arunsoman/nirdosha/wiki/Nirdosha-vs-Alternatives).
+[full answer](https://github.com/kannamma-labs/nirdosha/wiki/Nirdosha-vs-Alternatives).
 
 **Found a bug?** Run `nirdosha <file.nir> --format=json` and paste the
 `Diagnostic` JSON into a GitHub issue. Security issue? See
 [SECURITY.md](./SECURITY.md) instead.
 
 **Want to contribute?** See [CONTRIBUTING.md](./CONTRIBUTING.md). More in
-the [full FAQ](https://github.com/arunsoman/nirdosha/wiki/FAQ).
+the [full FAQ](https://github.com/kannamma-labs/nirdosha/wiki/FAQ).
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Reporting a vulnerability
 
 Please report security issues privately, not as a public GitHub issue —
-use [GitHub's private vulnerability reporting](https://github.com/arunsoman/nirdosha/security/advisories/new)
+use [GitHub's private vulnerability reporting](https://github.com/kannamma-labs/nirdosha/security/advisories/new)
 for this repository (the "Security" tab → "Report a vulnerability").
 This opens a private advisory only the maintainer can see until it's
 resolved.
@@ -26,7 +26,7 @@ response time is best-effort, not SLA-backed.
 Nirdosha is under active development. Some safety properties are proven
 today (ownership/affine types, SMT-discharged overflow bounds, the
 concurrency model); others are explicitly aspirational and documented
-as such — see [Honest Scope & Roadmap](https://github.com/arunsoman/nirdosha/wiki/Honest-Scope-and-Roadmap).
+as such — see [Honest Scope & Roadmap](https://github.com/kannamma-labs/nirdosha/wiki/Honest-Scope-and-Roadmap).
 A report that a *documented, disclosed* limitation is exploitable is
 still useful — please file it — but it's triaged differently from a
 violation of a claim the project actually makes.

--- a/agent-skills/nirdosha/AGENTS.md
+++ b/agent-skills/nirdosha/AGENTS.md
@@ -624,7 +624,7 @@ delete two lines." Save only what's between the fences as the `.nir`
 file's actual content.
 
 If you have shell access to a machine with `nirdosha` installed
-(`curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/arunsoman/nirdosha/main/scripts/install.sh | sh`),
+(`curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/kannamma-labs/nirdosha/main/scripts/install.sh | sh`),
 verify before presenting code as final:
 
 ```sh
@@ -652,7 +652,7 @@ run through the real compiler.
 Full type/builtin reference: `docs/LANGUAGE.md`. Full EBNF grammar:
 `docs/GRAMMAR.md`. `workflow`/state-ownership construct: `docs/WORKFLOW.md`.
 Worked examples: `examples/*.nir` in the main repo
-(https://github.com/arunsoman/nirdosha).
+(https://github.com/kannamma-labs/nirdosha).
 
 ## Verification is not optional
 

--- a/agent-skills/nirdosha/README.md
+++ b/agent-skills/nirdosha/README.md
@@ -21,15 +21,15 @@ for whichever tool you use.
 ```sh
 # from the root of a project that uses Nirdosha
 curl -o .claude/skills/nirdosha/SKILL.md --create-dirs \
-  https://raw.githubusercontent.com/arunsoman/nirdosha/main/agent-skills/nirdosha/claude-code/SKILL.md
+  https://raw.githubusercontent.com/kannamma-labs/nirdosha/main/agent-skills/nirdosha/claude-code/SKILL.md
 
 # or, for an AGENTS.md-reading tool:
 curl -o AGENTS.md \
-  https://raw.githubusercontent.com/arunsoman/nirdosha/main/agent-skills/nirdosha/AGENTS.md
+  https://raw.githubusercontent.com/kannamma-labs/nirdosha/main/agent-skills/nirdosha/AGENTS.md
 
 # or Cursor:
 curl -o .cursor/rules/nirdosha.mdc --create-dirs \
-  https://raw.githubusercontent.com/arunsoman/nirdosha/main/agent-skills/nirdosha/cursor/nirdosha.mdc
+  https://raw.githubusercontent.com/kannamma-labs/nirdosha/main/agent-skills/nirdosha/cursor/nirdosha.mdc
 ```
 
 Swap the URL/destination for the other tools using the table above.

--- a/agent-skills/nirdosha/claude-code/SKILL.md
+++ b/agent-skills/nirdosha/claude-code/SKILL.md
@@ -622,7 +622,7 @@ delete two lines." Save only what's between the fences as the `.nir`
 file's actual content.
 
 If you have shell access to a machine with `nirdosha` installed
-(`curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/arunsoman/nirdosha/main/scripts/install.sh | sh`),
+(`curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/kannamma-labs/nirdosha/main/scripts/install.sh | sh`),
 verify before presenting code as final:
 
 ```sh
@@ -650,7 +650,7 @@ run through the real compiler.
 Full type/builtin reference: `docs/LANGUAGE.md`. Full EBNF grammar:
 `docs/GRAMMAR.md`. `workflow`/state-ownership construct: `docs/WORKFLOW.md`.
 Worked examples: `examples/*.nir` in the main repo
-(https://github.com/arunsoman/nirdosha).
+(https://github.com/kannamma-labs/nirdosha).
 
 ## After writing or editing a `.nir` file
 
@@ -661,5 +661,5 @@ for that (see above — it doesn't typecheck). If `nirdosha` isn't
 installed yet, install it first:
 
 ```sh
-curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/arunsoman/nirdosha/main/scripts/install.sh | sh
+curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/kannamma-labs/nirdosha/main/scripts/install.sh | sh
 ```

--- a/agent-skills/nirdosha/clinerules
+++ b/agent-skills/nirdosha/clinerules
@@ -619,7 +619,7 @@ delete two lines." Save only what's between the fences as the `.nir`
 file's actual content.
 
 If you have shell access to a machine with `nirdosha` installed
-(`curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/arunsoman/nirdosha/main/scripts/install.sh | sh`),
+(`curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/kannamma-labs/nirdosha/main/scripts/install.sh | sh`),
 verify before presenting code as final:
 
 ```sh
@@ -647,4 +647,4 @@ run through the real compiler.
 Full type/builtin reference: `docs/LANGUAGE.md`. Full EBNF grammar:
 `docs/GRAMMAR.md`. `workflow`/state-ownership construct: `docs/WORKFLOW.md`.
 Worked examples: `examples/*.nir` in the main repo
-(https://github.com/arunsoman/nirdosha).
+(https://github.com/kannamma-labs/nirdosha).

--- a/agent-skills/nirdosha/core.md
+++ b/agent-skills/nirdosha/core.md
@@ -6,7 +6,7 @@ those platforms don't support file includes, so the body below is
 duplicated into each with platform-specific wrapping — if you're fixing
 a factual error, fix it here first, then propagate to the others.
 Source of truth for everything below: docs/LANGUAGE.md and docs/GRAMMAR.md in the
-main Nirdosha repo (https://github.com/arunsoman/nirdosha). If those
+main Nirdosha repo (https://github.com/kannamma-labs/nirdosha). If those
 docs and this file ever disagree, docs/LANGUAGE.md/docs/GRAMMAR.md win.
 -->
 
@@ -627,7 +627,7 @@ delete two lines." Save only what's between the fences as the `.nir`
 file's actual content.
 
 If you have shell access to a machine with `nirdosha` installed
-(`curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/arunsoman/nirdosha/main/scripts/install.sh | sh`),
+(`curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/kannamma-labs/nirdosha/main/scripts/install.sh | sh`),
 verify before presenting code as final:
 
 ```sh
@@ -655,4 +655,4 @@ run through the real compiler.
 Full type/builtin reference: `docs/LANGUAGE.md`. Full EBNF grammar:
 `docs/GRAMMAR.md`. `workflow`/state-ownership construct: `docs/WORKFLOW.md`.
 Worked examples: `examples/*.nir` in the main repo
-(https://github.com/arunsoman/nirdosha).
+(https://github.com/kannamma-labs/nirdosha).

--- a/agent-skills/nirdosha/cursor/nirdosha.mdc
+++ b/agent-skills/nirdosha/cursor/nirdosha.mdc
@@ -623,7 +623,7 @@ delete two lines." Save only what's between the fences as the `.nir`
 file's actual content.
 
 If you have shell access to a machine with `nirdosha` installed
-(`curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/arunsoman/nirdosha/main/scripts/install.sh | sh`),
+(`curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/kannamma-labs/nirdosha/main/scripts/install.sh | sh`),
 verify before presenting code as final:
 
 ```sh
@@ -651,4 +651,4 @@ run through the real compiler.
 Full type/builtin reference: `docs/LANGUAGE.md`. Full EBNF grammar:
 `docs/GRAMMAR.md`. `workflow`/state-ownership construct: `docs/WORKFLOW.md`.
 Worked examples: `examples/*.nir` in the main repo
-(https://github.com/arunsoman/nirdosha).
+(https://github.com/kannamma-labs/nirdosha).

--- a/agent-skills/nirdosha/github/copilot-instructions.md
+++ b/agent-skills/nirdosha/github/copilot-instructions.md
@@ -619,7 +619,7 @@ delete two lines." Save only what's between the fences as the `.nir`
 file's actual content.
 
 If you have shell access to a machine with `nirdosha` installed
-(`curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/arunsoman/nirdosha/main/scripts/install.sh | sh`),
+(`curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/kannamma-labs/nirdosha/main/scripts/install.sh | sh`),
 verify before presenting code as final:
 
 ```sh
@@ -647,4 +647,4 @@ run through the real compiler.
 Full type/builtin reference: `docs/LANGUAGE.md`. Full EBNF grammar:
 `docs/GRAMMAR.md`. `workflow`/state-ownership construct: `docs/WORKFLOW.md`.
 Worked examples: `examples/*.nir` in the main repo
-(https://github.com/arunsoman/nirdosha).
+(https://github.com/kannamma-labs/nirdosha).

--- a/agent-skills/nirdosha/paste-anywhere-prompt.md
+++ b/agent-skills/nirdosha/paste-anywhere-prompt.md
@@ -802,7 +802,7 @@ delete two lines." Save only what's between the fences as the `.nir`
 file's actual content.
 
 If you have shell access to a machine with `nirdosha` installed
-(`curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/arunsoman/nirdosha/main/scripts/install.sh | sh`),
+(`curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/kannamma-labs/nirdosha/main/scripts/install.sh | sh`),
 verify before presenting code as final:
 
 ```sh
@@ -837,7 +837,7 @@ been run through the real compiler.
 Full type/builtin reference: `docs/LANGUAGE.md`. Full EBNF grammar:
 `docs/GRAMMAR.md`. `workflow`/state-ownership construct: `docs/WORKFLOW.md`.
 Worked examples: `examples/*.nir` in the main repo
-(https://github.com/arunsoman/nirdosha).
+(https://github.com/kannamma-labs/nirdosha).
 
 ## Your task
 

--- a/agent-skills/nirdosha/windsurfrules
+++ b/agent-skills/nirdosha/windsurfrules
@@ -619,7 +619,7 @@ delete two lines." Save only what's between the fences as the `.nir`
 file's actual content.
 
 If you have shell access to a machine with `nirdosha` installed
-(`curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/arunsoman/nirdosha/main/scripts/install.sh | sh`),
+(`curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/kannamma-labs/nirdosha/main/scripts/install.sh | sh`),
 verify before presenting code as final:
 
 ```sh
@@ -647,4 +647,4 @@ run through the real compiler.
 Full type/builtin reference: `docs/LANGUAGE.md`. Full EBNF grammar:
 `docs/GRAMMAR.md`. `workflow`/state-ownership construct: `docs/WORKFLOW.md`.
 Worked examples: `examples/*.nir` in the main repo
-(https://github.com/arunsoman/nirdosha).
+(https://github.com/kannamma-labs/nirdosha).

--- a/assets/macos/nirdosha-launcher.c
+++ b/assets/macos/nirdosha-launcher.c
@@ -18,6 +18,6 @@ int main(void) {
         ".nir file icon with macOS. Use the `nirdosha` CLI instead:\n"
         "  nirdosha serve <file.nir>\n"
         "  nirdosha emit-ui <file.nir>\n"
-        "See https://github.com/arunsoman/nirdosha\n");
+        "See https://github.com/kannamma-labs/nirdosha\n");
     return 0;
 }

--- a/crates/presence-gateway/Dockerfile
+++ b/crates/presence-gateway/Dockerfile
@@ -32,7 +32,7 @@ RUN cargo build --release
 # ---- runtime stage -------------------------------------------------------
 FROM debian:bookworm-slim AS runtime
 
-LABEL org.opencontainers.image.source="https://github.com/arunsoman/nirdosha" \
+LABEL org.opencontainers.image.source="https://github.com/kannamma-labs/nirdosha" \
       org.opencontainers.image.description="nirdosha-presence-gateway: terminates real browser WebSocket connections for workflow's notify() live-push path" \
       org.opencontainers.image.licenses="Apache-2.0"
 

--- a/deploy/helm/nirdosha/Chart.yaml
+++ b/deploy/helm/nirdosha/Chart.yaml
@@ -10,9 +10,9 @@ description: |
 type: application
 version: 0.2.0
 appVersion: "0.1.0"
-home: https://github.com/arunsoman/nirdosha
+home: https://github.com/kannamma-labs/nirdosha
 sources:
-  - https://github.com/arunsoman/nirdosha
+  - https://github.com/kannamma-labs/nirdosha
 keywords:
   - nirdosha
   - low-code

--- a/docs/adr/0001-vendor-z3-except-macos.md
+++ b/docs/adr/0001-vendor-z3-except-macos.md
@@ -43,7 +43,7 @@ first real CI run for that leg, not a local config mistake.
   story this ADR exists to protect.
 - macOS users carry one extra install step (`brew install z3`) that
   Linux/Windows users don't — a real, if narrow, platform-support gap,
-  tracked as [issue #5](https://github.com/arunsoman/nirdosha/issues/5)
+  tracked as [issue #5](https://github.com/kannamma-labs/nirdosha/issues/5)
   ("macOS: z3-src 416.0.2 fails against current AppleClang — vendor Z3
   or document workaround").
 - This decision reverses automatically, with no code change needed

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,6 +1,6 @@
 # One-line installer for the nirdosha CLI (Windows).
 #
-#   irm https://raw.githubusercontent.com/arunsoman/nirdosha/main/scripts/install.ps1 | iex
+#   irm https://raw.githubusercontent.com/kannamma-labs/nirdosha/main/scripts/install.ps1 | iex
 #
 # Downloads the prebuilt x86_64 binary from GitHub Releases, verifies its
 # sha256 checksum, and installs it to $env:NIRDOSHA_INSTALL_DIR (default
@@ -12,7 +12,7 @@
 
 $ErrorActionPreference = "Stop"
 
-$repo = "arunsoman/nirdosha"
+$repo = "kannamma-labs/nirdosha"
 $installDir = if ($env:NIRDOSHA_INSTALL_DIR) { $env:NIRDOSHA_INSTALL_DIR } else { "$env:LOCALAPPDATA\nirdosha\bin" }
 $version = if ($env:NIRDOSHA_VERSION) { $env:NIRDOSHA_VERSION } else { "latest" }
 $asset = "nirdosha-x86_64-pc-windows-msvc.zip"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # One-line installer for the nirdosha CLI (macOS / Linux).
 #
-#   curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/arunsoman/nirdosha/main/scripts/install.sh | sh
+#   curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/kannamma-labs/nirdosha/main/scripts/install.sh | sh
 #
 # Downloads the right prebuilt binary from GitHub Releases, verifies its
 # sha256 checksum, and installs it to $NIRDOSHA_INSTALL_DIR (default
@@ -14,7 +14,7 @@
 # Windows: use scripts/install.ps1 instead.
 set -eu
 
-repo="arunsoman/nirdosha"
+repo="kannamma-labs/nirdosha"
 install_dir="${NIRDOSHA_INSTALL_DIR:-$HOME/.local/bin}"
 
 os="$(uname -s)"


### PR DESCRIPTION
## What
Repo was just transferred from `arunsoman/nirdosha` to `kannamma-labs/nirdosha`. This sweeps every hardcoded `arunsoman/nirdosha` reference (74 occurrences, 21 files) to the new path.

Most load-bearing: `scripts/install.sh`/`install.ps1`'s `repo=` variable feeds every download URL behind the README's one-line installer — that one actually matters, not just cosmetics.

Everything else (README badges/links, CONTRIBUTING, GOVERNANCE, MAINTAINERS, SECURITY, both Dockerfiles' OCI source label, Helm chart URLs, ADR-0001's issue link, the macOS launcher's error string, `agent-skills/*` prompt docs, `welcome.yml`, `labels.yml`) was swept for consistency rather than relying indefinitely on GitHub's rename redirect.

**Left alone on purpose:** the Sponsor badge (`github.com/sponsors/arunsoman`) and bare `@arunsoman` maintainer attributions — those name the person, not the repo, and aren't affected by the org transfer.

Also updated the repo's `homepage` setting via the API to `kannamma-labs/nirdosha/wiki`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)