### PR TITLE
feat(compiler): compile workflow Layer 1; descope sandbox from v1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,24 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # `mq_publish_and_consume_round_trip_a_real_message` (`tests/codegen.rs`)
+    # is deliberately real, not mocked -- it needs an actual Redis at
+    # 127.0.0.1:6379 (`Ty::Mq`'s doc comment: "not a mock" is the whole
+    # point of that test). Found missing by a real CI failure ("Connection
+    # refused (os error 111)"), not anticipated in advance -- a plain
+    # `ubuntu-latest` runner has no Redis running by default. Service
+    # containers only work on Linux-hosted runners (this job), not
+    # macOS/Windows (see those jobs' own Redis setup below/omission).
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
       - name: Install system dependencies (clang, z3)
@@ -53,6 +71,16 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install system Z3 (see workflow header)
         run: brew install z3
+      # macOS runners have no service-container support (that's a
+      # Linux-runner-only GitHub Actions feature — see the `build` job's
+      # own `services:` block above) -- `mq_publish_and_consume_round_trip_
+      # a_real_message` needs a real local Redis just as much here, so
+      # it's installed and started directly instead.
+      - name: Install and start Redis (Homebrew — no service-container support on macOS runners)
+        run: |
+          brew install redis
+          brew services start redis
+          for i in $(seq 1 10); do redis-cli ping && break; sleep 1; done
       - name: Cache cargo registry and build artifacts
         uses: actions/cache@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@
 /announcements
 scratch/
 
+migrations/*.sql

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,6 +1210,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "nirdosha-plugin-native-kv"
+version = "0.1.0"
+
+[[package]]
+name = "nirdosha-plugin-native-shout"
+version = "0.1.0"
+
+[[package]]
 name = "nirdosha-presence-gateway"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,15 +5,25 @@ members = [
     "crates/grammar_check",
     "crates/grammar_export",
     "crates/presence-gateway",
-    # `crates/bench`, all six `plugin-example-*` crates, `plugin-support`,
-    # and `plugin-examples` are removed: each depended entirely on the
-    # interpreter (interpreted plugin dispatch via `PluginBuiltin`/
-    # `PluginFn`, or scoring an LLM-generated program's *interpreted*
-    # result value) — a mechanism that no longer exists now that the
-    # interpreter is gone. Native (`NativePluginBuiltin`) plugins for the
-    # compiled path are a different, scalar-only ABI these crates never
-    # used; nothing here ports mechanically. See git history if any of
-    # this is worth rebuilding against the compiled path later.
+    # rfcs/0008-native-plugin-abi-widening.md Phase 1/4: the first two
+    # real, *compiled-path* reference plugins, built against
+    # `NativePluginBuiltin` directly (a plain `#[no_mangle] extern "C"`
+    # symbol, not the deleted interpreter's `PluginBuiltin` trait) — see
+    # each crate's own README for the plugin-author and app-author
+    # sides, and `crates/compiler/tests/native_plugin_examples.rs` for
+    # the automated "compiles and the real binary runs correctly" proof.
+    "crates/plugin-example-native-shout",
+    "crates/plugin-example-native-kv",
+    # `crates/bench`, the original six interpreter-era `plugin-example-*`
+    # crates, `plugin-support`, and `plugin-examples` stay removed: each
+    # depended entirely on the interpreter (interpreted plugin dispatch
+    # via `PluginBuiltin`/`PluginFn`, or scoring an LLM-generated
+    # program's *interpreted* result value) — a mechanism that no longer
+    # exists now that the interpreter is gone. See git history if any of
+    # this (a real MySQL/Cassandra/ActiveMQ/Neo4j/HBase plugin, ported
+    # onto the compiled-path ABI above instead of the deleted trait) is
+    # worth rebuilding — rfcs/0008 Phase 4 names this as the real
+    # remaining proof, not yet done.
 ]
 
 # Rust's own integer-overflow panic is `nirdosha`'s only runtime guard for

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ zero local setup, building in about a minute.
 
 ## What Nirdosha code looks like
 
-**One function. Four independent guarantees the compiler itself checks
+**One function. Five independent guarantees the compiler itself checks
 — not comments, not conventions, not a framework's runtime middleware.**
 (Excerpt — `Text`/`main` omitted here, full runnable source linked below.)
 
@@ -71,6 +71,7 @@ struct Employee {
 
 fn get_employee(caller: RoleView, name: Text, department: Text, salary: f64) -> Employee
     effect(pure)                             // lying here is a build error, not a comment
+    requires(role: "hr_staff")               // uncallable at all without a real proof of this role
     nfr(latency_ms: 50, concurrency_max: 1000)   // real APM tracking, zero code at the call site
 {
     return Employee(name.value, department.value, salary)
@@ -80,26 +81,32 @@ fn get_employee(caller: RoleView, name: Text, department: Text, salary: f64) -> 
 ```sh
 git clone https://github.com/kannamma-labs/nirdosha.git && cd nirdosha
 cargo run -p nirdosha --release -- build examples/features/50_field_masking_and_check_role.nir -o employee && ./employee
-# 10          <- a Z3-proven Hoare contract elsewhere in the same file (see below)
+# 10           <- a Z3-proven Hoare contract elsewhere in the same file (see below)
 # 150000.000000
-# 0.000000    <- masked
+# 0.000000     <- masked
 # Ada Lovelace
+# -3.000000    <- never even reached get_employee's body
+# no_access
 ```
 
-`caller: RoleView` is the *only* thing standing between a request and a
-real salary — and a `RoleView` cannot be forged (`RoleView("admin")` is a
-compile-time error) or fabricated by this function's own logic; it can
-only come from `check_role(identity, "admin")` succeeding against a real
-`VerifiedIdentity`, itself compiled, not interpreted. Call
-`get_employee` with a `RoleView` that proves `"admin"` and `salary`
-passes through untouched; call it with any other proof — or none — and
-`salary` comes back `0.0`, unconditionally, while every other field
-still passes through. No `if` in `get_employee`'s own body decides
-that — the masking is a property of the field declaration, checked at
-every `return`, so there's no per-handler `if user.role == "admin"`
-check to forget writing, the way a hand-rolled equivalent scattered
-across every handler that touches `Employee` always eventually gets
-forgotten in one of them.
+**Two independent gates, not one mechanism wearing two hats.**
+`requires(role: "hr_staff")` on the function decides *who can call it
+at all* — `get_employee`'s name has no direct-call path once gated;
+the only way to obtain a callable value is `acquire
+get_employee(proof)`, and it demands a real `RoleView` proving
+`"hr_staff"`. `requires(role: "admin")` on the field separately decides
+*what a successful caller sees back* — `salary` masks itself to zero on
+every `return` unless the value passed as `caller` proves `"admin"`
+specifically. Neither `RoleView` can be forged
+(`RoleView("admin")` is a compile-time error) or fabricated by this
+function's own logic — the only way to get a real one is
+`check_role(identity, role)` succeeding against a real
+`VerifiedIdentity`, itself compiled, not interpreted. The result: an
+HR staffer who isn't also an admin can call the function and get real
+employee records back with salary redacted; someone who's neither
+can't obtain a callable `get_employee` in the first place — two
+different failure points, two different roles, checked independently,
+with no `if` anywhere in `get_employee`'s own body deciding either one.
 
 `effect(pure)` is checked against what the function *actually does* —
 annotate a function that performs I/O as `pure` and `nirdosha build`
@@ -236,9 +243,10 @@ Real, compiled, and running today — the highlights:
 - **Identity and data protection** — `check_role` against a real
   `VerifiedIdentity`, producing an unforgeable `RoleView`; field-level
   `requires(role/claim: ...)` masking that zeroes a struct field on
-  return unless the caller's own `RoleView`/`ClaimView` proves it —
-  both compiled, both enforced in the binary itself, no server process
-  involved.
+  return unless the caller's own `RoleView`/`ClaimView` proves it;
+  function-level `requires(role/claim: ...)` + `acquire`, gating
+  whether a function is even callable at all — all three compiled, all
+  enforced in the binary itself, no server process involved.
 - **`nfr(...)`** — non-functional requirements as a first-class,
   compiled fn annotation: automatic latency/error-rate/throughput/
   concurrency tracking via the APM kernel, with async escalation to an

--- a/README.md
+++ b/README.md
@@ -11,16 +11,26 @@
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/kannamma-labs/nirdosha?quickstart=1)
 
 > **A systems language built so an AI agent can write and run backend
-> code with no human reviewing every line first.** No garbage
+> code with no human reviewing every line first — and that humans can
+> also write with unusually strong static guarantees.** No garbage
 > collector, no data races, no deadlocks, no integer/buffer overflow —
 > proven in the compiler today, not promised for later. Linux, macOS,
 > and Windows binaries ship on every release, verified by CI on all
 > three on every push.
 
-Real, working software today: a real compiler (`crates/compiler/`) —
-**no interpreter fallback anymore**, removed entirely and deliberately
-so the compiled path can't quietly stay second-class. What that
-compiler proves and runs, natively, right now: an LL(1) grammar
+## The problem
+
+Existing languages were designed primarily for human developers. They
+assume the author understands the type system, the concurrency model,
+and the framework conventions.
+
+Nirdosha starts from a different assumption: the primary author may be
+an LLM that defaults to familiar patterns, forgets checks, and benefits
+from constraints that make entire classes of mistakes unexpressible.
+The same constraints turn out to be valuable for human developers who
+want high-assurance backend code.
+
+Real, working software today: a real compiler (`crates/compiler/`). What that compiler proves and runs, natively, right now: an LL(1) grammar
 exported to GBNF for constrained decoding, SMT-backed (Z3) integer/
 buffer-overflow proofs, ownership/affine types with no GC, real
 identity (`check_role` producing an unforgeable `RoleView`) driving

--- a/TRUSTED_PLUGINS.md
+++ b/TRUSTED_PLUGINS.md
@@ -10,10 +10,11 @@ Verified Publisher badge.
 ## What this is, and isn't
 
 A Kind-A plugin is arbitrary native Rust code, statically linked
-directly into whatever binary calls `run_with_plugins`/`serve::run` —
-full process trust, no sandbox (rfcs/0004-native-plugin-sandboxing.md's
-own open-question section explains why that's a deliberate, disclosed
-gap, not solved by this file). Appearing on this list means:
+directly into the compiled binary via `codegen::build_with_native_plugins`
+(`crates/compiler/src/codegen.rs`, `NativePluginBuiltin`) — full process
+trust, no sandbox (rfcs/0004-native-plugin-sandboxing.md's own
+open-question section explains why that's a deliberate, disclosed gap,
+not solved by this file). Appearing on this list means:
 
 - A maintainer has read the plugin's source at the version listed.
 - Its declared `[package.metadata.nirdosha]` builtins and their
@@ -35,21 +36,23 @@ Appearing on this list does **not** mean:
 
 ## Listed plugins
 
-| Crate | Version reviewed | Declared effects | Notes |
-|---|---|---|---|
-| `nirdosha-plugin-rot13` | 0.1.0 | (none — pure) | The reference plugin; trivial, no I/O. |
-| `nirdosha-plugin-mysql` | 0.1.0 | network | Sync `mysql` crate. See `crates/plugin-example-mysql/README.md`. |
-| `nirdosha-plugin-activemq` | 0.1.0 | network | Hand-rolled STOMP client, not a third-party crate — see its README for why. |
-| `nirdosha-plugin-cassandra` | 0.1.0 | network | Async `scylla` driver, bridged via `nirdosha-plugin-support`. |
-| `nirdosha-plugin-neo4j` | 0.1.0 | network | Async `neo4rs` driver, same bridge. |
-| `nirdosha-plugin-hbase` | 0.1.0 | network | `hbase-thrift` — see its README's "why this is the hardest one" for real, disclosed rough edges. |
-
-All six are reference plugins in this repository (`crates/plugin-example-*/`),
-reviewed as part of building them, not third-party submissions — this
-table's real purpose is to be the template a genuine third-party
-plugin's listing follows, and the day-one gate a future auto-discovery
-step (RFC 0001) requires before linking an unfamiliar plugin
-automatically.
+**None, as of 2026-09.** The six reference plugins this table used to
+list (`nirdosha-plugin-rot13`/`-mysql`/`-activemq`/`-cassandra`/
+`-neo4j`/`-hbase`, `crates/plugin-example-*/`) were removed entirely in
+`refactor: remove native plugin ecosystem` — every one of them
+depended on the tree-walking interpreter's own `PluginBuiltin`/
+`PluginFn` dispatch, which no longer exists (the interpreter was
+deleted in a separate pass the same session). `NativePluginBuiltin`
+(the compiled-path plugin ABI these examples never targeted, a
+different and narrower scalar-only shape) survives and is real —
+`crates/compiler/tests/native_plugin_codegen.rs` exercises it directly
+— but nothing currently plugs into it: no reference plugin crate
+implements it, and `nirdosha build`'s own CLI has no flag to load a
+native plugin at all yet (`build_with_native_plugins` is a library
+entry point with no wired-up caller). This table's real purpose is
+unchanged — the template a genuine plugin's listing follows, and the
+day-one gate a future auto-discovery step (RFC 0001) requires — it
+just currently has zero rows to show for it.
 
 ## Requesting a listing
 

--- a/crates/compiler/src/ast.rs
+++ b/crates/compiler/src/ast.rs
@@ -2513,6 +2513,16 @@ pub const BUILTIN_NAMES: &[&str] = &[
     // constant-time comparison `interpreter.rs`'s own JWT signature
     // check now uses internally (also a fixed red-team finding).
     "constant_time_str_eq",
+    // Minimal compiled string-parsing primitives (Row: compiled `serve`).
+    // Deliberately not a general string library -- just enough to
+    // hand-parse an HTTP request line: `str_index_of` finds a delimiter
+    // (a space, or `"\r\n"`), `str_slice` extracts the token either side
+    // of it, composed a few times in `.nir` source. `len(s)` (already a
+    // builtin, previously Vector-only) gained a `str` arm alongside these
+    // for the same reason. No `split`/`starts_with`/`trim`/concat --
+    // those are a real, separate follow-up, not smuggled in here.
+    "str_slice",
+    "str_index_of",
     // DB, layer 1: SQLite only (`rusqlite`, "bundled" -- statically
     // linked, no system `libsqlite3`). `Ty::Db`'s doc comment has the
     // full design; the short version: one connection handle, `stop`-able
@@ -2599,6 +2609,17 @@ pub const BUILTIN_NAMES: &[&str] = &[
     // hand" convention.
     "__workflow_submitted_by_me",
     "__workflow_history",
+    // SLA/escalation (`docs/WORKFLOW.md`'s own enterprise-catalog row,
+    // `docs/ROADMAP.md` A15's proposed design: `state { sla_seconds: N }`
+    // + a `list_<workflow>_overdue()` read fn an external scheduler
+    // polls — the queryable half; firing an escalation *automatically*
+    // with no caller involved needs the same "real cross-thread
+    // callback" mechanism this compiler's own `transact` `network`
+    // timeout already named as architecturally out of scope, so this is
+    // deliberately scoped to detection, not automatic firing). Backs
+    // every workflow-with-an-SLA's synthesized `list_<workflow>_overdue`
+    // — same "never written by hand" convention as the others.
+    "__workflow_overdue",
 ];
 
 /// `BUILTIN_NAMES` as a `HashSet`, built once. `is_builtin` runs on the

--- a/crates/compiler/src/codegen.rs
+++ b/crates/compiler/src/codegen.rs
@@ -479,10 +479,15 @@ fn llvm_ty(ty: &Ty, registry: &TypeRegistry) -> Result<String, CodegenError> {
             }
             Ok(format!("%{}", mangle_ty(ty)))
         }
-        Ty::Fn(_, _) => unsupported(
-            "codegen doesn't support `fn(..)->..` yet — first-class/privileged functions \
-             (requires/acquire) are interpreter-only for now",
-        ),
+        // A first-class function value (ordinary or `acquire`d) is a
+        // plain function-pointer word, freely copyable like any other
+        // scalar (`Ty::is_affine`'s own doc comment on why `Ty::Fn` is
+        // deliberately excluded there) — no separate handle table, no
+        // refcounting, just `ptr`. Compiled for real, 2026-09: see
+        // `Expr::Ident`'s and `Expr::Acquire`'s own codegen arms for how
+        // a value of this type is actually produced, and `Codegen::call`/
+        // `call_ptr`'s own local-variable check for how it's called.
+        Ty::Fn(_, _) => Ok("ptr".to_string()),
         Ty::Error => unreachable!("a program with a type error is never handed to codegen"),
     }
 }
@@ -521,8 +526,19 @@ fn mangle_ty(ty: &Ty) -> String {
         Ty::Named(name, args) => {
             format!("{name}${}", args.iter().map(mangle_ty).collect::<Vec<_>>().join("$"))
         }
+        // A real generic type argument since `acquire` started compiling
+        // (2026-09): `acquire fn_name(proof)` evaluates to
+        // `Result(Ty::Fn(params, ret), str)`, a genuinely new instantiation
+        // per acquired signature. `Ty::name()`'s own `"fn(i64) -> i64"`
+        // Display form contains `(`/`)`/`,`/` `/`->`, none of them legal
+        // in an unquoted LLVM identifier — a dedicated arm instead of the
+        // fallback below, which would leave the `-`/`>` from `->`
+        // unescaped and produce unparseable IR.
+        Ty::Fn(params, ret) => {
+            format!("fn{}to{}", params.iter().map(|p| format!("_{}", mangle_ty(p))).collect::<String>(), mangle_ty(ret))
+        }
         // Every other `Ty` (`Box`/`Ref`/`Thread`/`Channel`/`Sandbox`/
-        // `Tcp`/`TcpListener`/`File`/`Json`/`Db`/`Mq`/`Fn`/`Error`) is
+        // `Tcp`/`TcpListener`/`File`/`Json`/`Db`/`Mq`/`Error`) is
         // either affine (already rejected before this can run on one) or
         // otherwise never legally a struct/enum generic type argument —
         // this arm is a defensive fallback, not expected to actually run
@@ -999,10 +1015,11 @@ fn check_expr(e: &Expr, plugin_names: &std::collections::HashSet<String>, regist
             Ok(())
         }
         Expr::Join(inner, _) => check_expr(inner, plugin_names, registry),
-        Expr::Acquire(_, _, _) => unsupported(
-            "codegen doesn't support `acquire` yet — first-class/privileged functions \
-             are interpreter-only for now",
-        ),
+        // Compiled for real, 2026-09 (`Codegen::emit_acquire`) — this
+        // structural pre-pass has no type info (same reasoning
+        // `Expr::Spawn`'s own arm above already gives), so it just
+        // recurses into `proof`.
+        Expr::Acquire(_, proof, _) => check_expr(proof, plugin_names, registry),
         // `chan` construction itself needs no type info at all (every
         // `Ty::Channel` value is the same `i64` handle regardless of its
         // payload type — `llvm_ty`'s own `Ty::Channel` arm) — real per-
@@ -1115,6 +1132,16 @@ impl Scopes {
 struct FnSig {
     params: Vec<Ty>,
     ret: Ty,
+    /// `FnDecl::requires`'s own copy — `None` for a native plugin (never
+    /// gated) and for every ordinary `.nir` fn. `Some(req)` is what
+    /// `Codegen::emit_acquire` checks a `proof` against, and what makes
+    /// `name` callable only as `acquire name(proof)` rather than
+    /// directly (`typeck.rs`'s `PrivilegedFnNotAcquired`, already
+    /// enforced before codegen runs — this field exists purely so
+    /// `emit_acquire` can look the requirement back up by name, since
+    /// `Codegen` doesn't otherwise keep a reference to the whole
+    /// `Program`).
+    requires: Option<Requirement>,
 }
 
 struct Codegen<'a> {
@@ -1288,7 +1315,9 @@ fn emit_llvm_ir_impl<'a>(
     let mut sigs: HashMap<String, FnSig> = program
         .fns
         .iter()
-        .map(|f| (f.name.clone(), FnSig { params: f.params.iter().map(|p| p.ty.clone()).collect(), ret: f.ret.clone() }))
+        .map(|f| {
+            (f.name.clone(), FnSig { params: f.params.iter().map(|p| p.ty.clone()).collect(), ret: f.ret.clone(), requires: f.requires.clone() })
+        })
         .collect();
     // A native plugin's signature slots into the exact same table a
     // user `fn`'s does — `Codegen::call`'s existing generic fallback
@@ -1297,7 +1326,7 @@ fn emit_llvm_ir_impl<'a>(
     // `declare` line below (in place of a real `define`) and the linked
     // staticlib (`build_with_native_plugins`) are new.
     for np in native_plugins {
-        sigs.insert(np.name.clone(), FnSig { params: np.params.clone(), ret: np.ret.clone() });
+        sigs.insert(np.name.clone(), FnSig { params: np.params.clone(), ret: np.ret.clone(), requires: None });
     }
     // Trusts the program already passed `ownership::check_ownership` (the
     // caller's job, same as `typecheck_and_own`'s existing precedent) —
@@ -2241,7 +2270,18 @@ impl Codegen<'_> {
             Expr::Float(_, _) => Ty::F64,
             Expr::Bool(_, _) => Ty::Bool,
             Expr::Str(_, _) => Ty::Str,
-            Expr::Ident(name, _) => scopes.get(name).map(|(t, _)| t).unwrap_or(Ty::I64),
+            // A local variable first; if `name` isn't one, it's a bare
+            // reference to an ordinary (ungated) top-level `fn` used as a
+            // first-class value (`apply(double, 21)`, LANGUAGE.md §6a) —
+            // `Ty::Fn`, not `Ty::I64`. A `requires`-gated fn's name has no
+            // such reference at all (`TypeErrorKind::PrivilegedFnNotAcquired`,
+            // already enforced before codegen runs), so `self.sigs.get`
+            // finding one here always means an ungated fn.
+            Expr::Ident(name, _) => scopes
+                .get(name)
+                .map(|(t, _)| t)
+                .or_else(|| self.sigs.get(name).map(|s| Ty::Fn(s.params.clone(), Box::new(s.ret.clone()))))
+                .unwrap_or(Ty::I64),
             Expr::Unary(UnOp::Not, _, _) => Ty::Bool,
             Expr::Unary(UnOp::Neg, inner, _) => self.local_ty_of(inner, scopes),
             Expr::Binary(op, l, r, _) => match op {
@@ -2291,7 +2331,17 @@ impl Codegen<'_> {
             Expr::Call(name, args, _) if self.registry.is_struct(name) || self.registry.find_variant(name).is_some() => {
                 self.ctor_ty(name, args, scopes).unwrap_or_else(|| Ty::Named(name.to_string(), Vec::new()))
             }
-            Expr::Call(name, _, _) => self.sigs.get(name).map(|s| s.ret.clone()).unwrap_or(Ty::I64),
+            // `name` here can be a local variable holding an acquired/
+            // passed-in `Ty::Fn` value, not just a top-level `fn` —
+            // `f(x)` where `f: fn(i64) -> i64` is a parameter parses to
+            // the same `Expr::Call("f", ...)` shape a direct call does
+            // (`parser.rs::parse_call` doesn't distinguish), so `scopes`
+            // is checked first; `self.sigs` (top-level fns only) would
+            // otherwise never find `f` and wrongly fall back to `Ty::I64`.
+            Expr::Call(name, _, _) => match scopes.get(name) {
+                Some((Ty::Fn(_, ret), _)) => *ret,
+                _ => self.sigs.get(name).map(|s| s.ret.clone()).unwrap_or(Ty::I64),
+            },
             // Row 11: `base.field`'s type is `base`'s struct type's
             // substituted field type — factored through
             // `field_index_and_ty` so `expr()`/`expr_ptr()`'s own
@@ -2328,6 +2378,17 @@ impl Codegen<'_> {
             // above explains (e.g. `join spawn worker(x)` with nothing
             // ever bound to a name).
             Expr::Spawn(name, _, _) => Ty::Thread(Box::new(self.sigs.get(name).map(|s| s.ret.clone()).unwrap_or(Ty::I64))),
+            // `acquire name(proof)` -> `Result(Ty::Fn(params, ret), str)` —
+            // `name`'s own declared signature, unchanged; `acquire` only
+            // ever gates *whether* the value is obtained, never its shape.
+            Expr::Acquire(name, _, _) => {
+                let sig = self.sigs.get(name);
+                let fn_ty = Ty::Fn(
+                    sig.map(|s| s.params.clone()).unwrap_or_default(),
+                    Box::new(sig.map(|s| s.ret.clone()).unwrap_or(Ty::I64)),
+                );
+                Ty::Named("Result".to_string(), vec![fn_ty, Ty::Str])
+            }
             Expr::Join(inner, _) => match self.local_ty_of(inner, scopes) {
                 Ty::Thread(t) => *t,
                 _ => Ty::I64,
@@ -2961,10 +3022,27 @@ impl Codegen<'_> {
             return Ok("false".to_string());
         };
         let (view_ty, view_ptr) = scopes.get(&param_name).expect("scanned directly from this function's own params");
+        self.emit_str_field_eq_check(&view_ty, &view_ptr, field_name, expected)
+    }
+
+    /// The shared core `emit_requirement_check` (a `RoleView`/`ClaimView`
+    /// *parameter* of the current function) and `emit_acquire` (an
+    /// arbitrary `proof` expression's own pointer) both reduce to: GEP to
+    /// `field_name` on a value of type `view_ty` at `view_ptr`, load its
+    /// `str`, and compare against the compile-time-known `expected`
+    /// string via `nir_str_eq` — the one real runtime check either
+    /// mechanism ever does. Returns a fresh `i1` SSA register.
+    fn emit_str_field_eq_check(
+        &mut self,
+        view_ty: &Ty,
+        view_ptr: &str,
+        field_name: &str,
+        expected: &str,
+    ) -> Result<String, CodegenError> {
         let (idx, _) = self
-            .field_index_and_ty(&view_ty, field_name)
+            .field_index_and_ty(view_ty, field_name)
             .expect("RoleView/ClaimView always declares this field, ast::prelude_structs");
-        let view_llty = self.llvm_ty(&view_ty)?;
+        let view_llty = self.llvm_ty(view_ty)?;
         let field_ptr = self.fresh_reg("req_field_ptr");
         writeln!(self.out, "  {field_ptr} = getelementptr inbounds {view_llty}, ptr {view_ptr}, i32 0, i32 {idx}").unwrap();
         let field_val = self.fresh_reg("req_field_val");
@@ -3125,7 +3203,20 @@ impl Codegen<'_> {
                 Ok(full)
             }
             Expr::Ident(name, _) => {
-                let (ty, ptr) = scopes.get(name).expect("typeck.rs already proved this resolves");
+                let Some((ty, ptr)) = scopes.get(name) else {
+                    // Not a local variable — the one other thing an
+                    // `Ident` can name is a bare reference to an ordinary
+                    // (ungated) top-level `fn` used as a first-class
+                    // value (`apply(double, 21)`, LANGUAGE.md §6a). A
+                    // function's own address is a compile-time-known
+                    // constant operand in LLVM IR (`ptr @name`) — no
+                    // `load` needed, unlike a real variable's storage.
+                    // `typeck.rs`'s `PrivilegedFnNotAcquired` already
+                    // guarantees a `requires`-gated fn's name never
+                    // reaches here directly.
+                    self.sigs.get(name).expect("typeck.rs already proved this resolves (local var or top-level fn)");
+                    return Ok(format!("@{name}"));
+                };
                 if ty.is_aggregate() {
                     // Every well-behaved caller checks `is_aggregate()`
                     // first and calls `expr_ptr()` instead — this is a
@@ -3603,6 +3694,19 @@ impl Codegen<'_> {
     }
 
     fn call(&mut self, name: &str, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        // `name` is a local variable holding a `Ty::Fn` value (an
+        // acquired or passed-in first-class function), not a top-level
+        // `fn` — `f(x)` where `f` is such a variable parses to the same
+        // `Expr::Call("f", ...)` shape a direct call does
+        // (`parser.rs::parse_call`), so this has to be checked before
+        // anything below assumes `name` names a global. Only reached for
+        // a non-aggregate `sig_ret` (`local_ty_of`'s own `Ty::Fn` fork
+        // routes an aggregate-returning one to `call_ptr` instead).
+        if let Some((Ty::Fn(params, ret), fn_slot)) = scopes.get(name) {
+            let fn_ptr = self.fresh_reg(&format!("{name}.fnval"));
+            writeln!(self.out, "  {fn_ptr} = load ptr, ptr {fn_slot}").unwrap();
+            return self.call_indirect(&fn_ptr, &params, &ret, args, scopes);
+        }
         // Row 11: a struct/variant constructor is always aggregate-valued
         // (`is_aggregate()` now covers `Ty::Named`), so a scalar `expr()`
         // result is the wrong shape for it — every well-typed caller
@@ -3937,6 +4041,52 @@ impl Codegen<'_> {
             arg_vals.push(format!("{llty} {v}"));
         }
         Ok(arg_vals)
+    }
+
+    /// Calls through an already-loaded function-pointer *value*
+    /// (`fn_ptr` — a register holding the address, not a variable's own
+    /// storage slot) — the shared implementation `call()`'s and
+    /// `call_ptr()`'s own "`name` is a local `Ty::Fn` variable" branches
+    /// both route through. The only real difference from an ordinary
+    /// direct call (`call <ret> @name(...)`) is the callee operand (a
+    /// loaded `ptr` register instead of a named global) and having to
+    /// spell out the full `<ret>(<params>)` function type at the call
+    /// site — LLVM requires this for any indirect call, since the
+    /// callee isn't a named `@fn` whose own `define` already states it
+    /// (the exact same `call <functy> <callee>(<args>)` shape this
+    /// module already uses for `@printf`'s varargs signature).
+    fn call_indirect(
+        &mut self,
+        fn_ptr: &str,
+        params: &[Ty],
+        ret: &Ty,
+        args: &[Expr],
+        scopes: &mut Scopes,
+    ) -> Result<String, CodegenError> {
+        let arg_vals = self.call_args(args, params, scopes)?;
+        let param_lltys: Vec<String> =
+            params.iter().map(|p| if p.is_aggregate() { Ok("ptr".to_string()) } else { self.llvm_ty(p) }).collect::<Result<_, _>>()?;
+        if ret.is_aggregate() {
+            let agg_llty = self.llvm_ty(ret)?;
+            let dest = self.fresh_reg("indirect_call_result.addr");
+            self.emit_alloca(&dest, &agg_llty);
+            let mut all_param_lltys = vec!["ptr".to_string()];
+            all_param_lltys.extend(param_lltys);
+            let mut all_args = vec![format!("ptr {dest}")];
+            all_args.extend(arg_vals);
+            writeln!(self.out, "  call void ({}) {fn_ptr}({})", all_param_lltys.join(", "), all_args.join(", ")).unwrap();
+            Ok(dest)
+        } else {
+            let ret_llty = self.llvm_ty(ret)?;
+            if ret_llty == "void" {
+                writeln!(self.out, "  call void ({}) {fn_ptr}({})", param_lltys.join(", "), arg_vals.join(", ")).unwrap();
+                Ok("0".to_string())
+            } else {
+                let r = self.fresh_reg("indirect_call_result");
+                writeln!(self.out, "  {r} = call {ret_llty} ({}) {fn_ptr}({})", param_lltys.join(", "), arg_vals.join(", ")).unwrap();
+                Ok(self.widen_to_i64(&r, ret))
+            }
+        }
     }
 
     /// Every Phase-4 builtin that yields a plain scalar (`f64`/`i64`/
@@ -4717,6 +4867,10 @@ impl Codegen<'_> {
                 self.if_expr(cond, then_block, else_block.as_deref(), *span, scopes)
             }
             Expr::Match { scrutinee, arms, span } => self.match_expr(scrutinee, arms, *span, scopes),
+            // `acquire name(proof)` — always aggregate-valued
+            // (`Result(Ty::Fn(..), str)`), so it belongs here, not in
+            // `expr()`.
+            Expr::Acquire(name, proof, _) => self.emit_acquire(name, proof, scopes),
             _ => unsupported(
                 "codegen doesn't support this aggregate expression form yet — only \
                  identifiers, literals, assignment, binary operators, dereferencing a boxed/\
@@ -4771,6 +4925,13 @@ impl Codegen<'_> {
     /// hand that same pointer back as this call expression's own
     /// "value" — exactly `expr_ptr`'s contract.
     fn call_ptr(&mut self, name: &str, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        // Same "`name` may be a local `Ty::Fn` variable, not a global"
+        // check `call()` opens with — see its own comment for why.
+        if let Some((Ty::Fn(params, ret), fn_slot)) = scopes.get(name) {
+            let fn_ptr = self.fresh_reg(&format!("{name}.fnval"));
+            writeln!(self.out, "  {fn_ptr} = load ptr, ptr {fn_slot}").unwrap();
+            return self.call_indirect(&fn_ptr, &params, &ret, args, scopes);
+        }
         if PHASE4_BUILTINS.contains(&name)
             || matches!(name, "inv" | "solve" | "kf_update_state" | "kf_update_cov")
         {
@@ -4869,6 +5030,91 @@ impl Codegen<'_> {
         writeln!(self.out, "  {msg_partial} = insertvalue {{ptr, i64}} undef, ptr {msg_global}, 0").unwrap();
         let msg_full = self.fresh_reg("check_role_err_msg_full");
         writeln!(self.out, "  {msg_full} = insertvalue {{ptr, i64}} {msg_partial}, i64 {}, 1", MSG.len()).unwrap();
+        writeln!(self.out, "  store {{ptr, i64}} {msg_full}, ptr {payload_ptr}").unwrap();
+        writeln!(self.out, "  br label %{merge_label}").unwrap();
+
+        writeln!(self.out, "{merge_label}:").unwrap();
+        Ok(dest)
+    }
+
+    /// `acquire name(proof)` — `docs/LANGUAGE.md` §6a, compiled for real
+    /// 2026-09. `name` must be a `requires`-gated top-level fn
+    /// (`typeck.rs` already proved this; `FnSig::requires` is this
+    /// codegen's own copy of `FnDecl::requires`, looked up here since
+    /// `Codegen` doesn't otherwise keep a reference to the whole
+    /// `Program`). Builds a real `Result(Ty::Fn(params, ret), str)` by
+    /// hand, the same tag-then-payload shape `emit_check_role` already
+    /// uses: `Ok(f)` stores the target function's own address (`ptr
+    /// @name` — a compile-time-known constant operand, no instruction
+    /// needed) as the payload; `Err(reason)` stores a fresh string
+    /// literal naming exactly which requirement `proof` failed to
+    /// prove. The actual check is `emit_str_field_eq_check` against
+    /// `proof`'s own `role`/`value` field — the same runtime comparison
+    /// `emit_requirement_check` does for a *parameter*-shaped proof,
+    /// just against an arbitrary expression's pointer instead.
+    fn emit_acquire(&mut self, name: &str, proof: &Expr, scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let params = self.sigs.get(name).expect("typeck.rs already resolved this acquire target").params.clone();
+        let ret = self.sigs.get(name).expect("typeck.rs already resolved this acquire target").ret.clone();
+        let req = self
+            .sigs
+            .get(name)
+            .expect("typeck.rs already resolved this acquire target")
+            .requires
+            .clone()
+            .expect("typeck.rs only allows acquire on a requires-gated fn");
+        let fn_ty = Ty::Fn(params, Box::new(ret));
+        let result_ty = Ty::Named("Result".to_string(), vec![fn_ty, Ty::Str]);
+
+        let (proof_ty, field_name, expected): (Ty, &str, String) = match &req {
+            Requirement::Role(r) => (Ty::Named("RoleView".to_string(), vec![]), "role", r.clone()),
+            Requirement::Claim(_, v) => (Ty::Named("ClaimView".to_string(), vec![]), "value", v.clone()),
+        };
+        let proof_ptr = self.expr_ptr_expected(proof, &proof_ty, scopes)?;
+        let authorized = self.emit_str_field_eq_check(&proof_ty, &proof_ptr, field_name, &expected)?;
+
+        let result_llty = self.llvm_ty(&result_ty)?;
+        let dest = self.fresh_reg("acquire_result.addr");
+        self.emit_alloca(&dest, &result_llty);
+        let tag_ptr = self.fresh_reg("acquire_tag_ptr");
+        writeln!(self.out, "  {tag_ptr} = getelementptr inbounds {result_llty}, ptr {dest}, i32 0, i32 0").unwrap();
+        let payload_ptr = self.fresh_reg("acquire_payload_ptr");
+        writeln!(self.out, "  {payload_ptr} = getelementptr inbounds {result_llty}, ptr {dest}, i32 0, i32 1").unwrap();
+
+        let ok_label = self.fresh_label("acquire_ok");
+        let err_label = self.fresh_label("acquire_err");
+        let merge_label = self.fresh_label("acquire_merge");
+        writeln!(self.out, "  br i1 {authorized}, label %{ok_label}, label %{err_label}").unwrap();
+
+        // `Ok(f)` — variant 0. The target function's own address is a
+        // compile-time constant operand (`ptr @name`), not a value that
+        // needs computing — functions are already global values of
+        // pointer type in LLVM IR.
+        writeln!(self.out, "{ok_label}:").unwrap();
+        writeln!(self.out, "  store i64 0, ptr {tag_ptr}").unwrap();
+        writeln!(self.out, "  store ptr @{name}, ptr {payload_ptr}").unwrap();
+        writeln!(self.out, "  br label %{merge_label}").unwrap();
+
+        // `Err("...")` — variant 1. Same "the payload's first two words
+        // are directly a `str` value" shape `emit_check_role`'s own
+        // `Err` arm uses.
+        writeln!(self.out, "{err_label}:").unwrap();
+        writeln!(self.out, "  store i64 1, ptr {tag_ptr}").unwrap();
+        let msg = match &req {
+            Requirement::Role(r) => format!("{name} requires role \"{r}\", which the given proof doesn't have"),
+            Requirement::Claim(c, v) => format!("{name} requires claim \"{c}\"=\"{v}\", which the given proof doesn't have"),
+        };
+        let msg_global = self.fresh_global("acquire_err_msg");
+        writeln!(
+            self.string_globals,
+            "{msg_global} = private unnamed_addr constant [{} x i8] c\"{}\"",
+            msg.len(),
+            llvm_escape_bytes(msg.as_bytes())
+        )
+        .unwrap();
+        let msg_partial = self.fresh_reg("acquire_err_msg_partial");
+        writeln!(self.out, "  {msg_partial} = insertvalue {{ptr, i64}} undef, ptr {msg_global}, 0").unwrap();
+        let msg_full = self.fresh_reg("acquire_err_msg_full");
+        writeln!(self.out, "  {msg_full} = insertvalue {{ptr, i64}} {msg_partial}, i64 {}, 1", msg.len()).unwrap();
         writeln!(self.out, "  store {{ptr, i64}} {msg_full}, ptr {payload_ptr}").unwrap();
         writeln!(self.out, "  br label %{merge_label}").unwrap();
 

--- a/crates/compiler/src/codegen.rs
+++ b/crates/compiler/src/codegen.rs
@@ -414,9 +414,16 @@ fn llvm_ty(ty: &Ty, registry: &TypeRegistry) -> Result<String, CodegenError> {
         Ty::Dec128 => Ok("{i64, i64}".to_string()),
         Ty::Json => unsupported("codegen doesn't support `json` yet — JSON is interpreter-only for now"),
         Ty::Db => unsupported("codegen doesn't support `db` yet — DB connectivity is interpreter-only for now"),
-        Ty::Handle(kind) => unsupported(&format!(
-            "codegen doesn't support plugin handle types (`{kind}`) — plugins are interpreter-only for now"
-        )),
+        // rfcs/0008-native-plugin-abi-widening.md Phase 1: a plugin-held
+        // resource id, exactly like `Ty::Thread`/`Ty::Channel`/`Ty::File`
+        // just above — one opaque `i64` into a table this compiler never
+        // looks inside (here, a table the *plugin's own* Rust code owns,
+        // not a `runtime-kernels` one). All of its safety comes from
+        // `ownership.rs`'s affine tracking at the type level (`Ty::
+        // is_affine()` already lists `Handle(_)`, rfcs/0005 §1); codegen
+        // itself just needs to pass the word through, identically to how
+        // it already treats a spawn/channel/file handle.
+        Ty::Handle(_) => Ok("i64".to_string()),
         Ty::Mq => unsupported("codegen doesn't support `mq` yet — message-queue connectivity is interpreter-only for now"),
         // A fixed-size, two-word value — pointer to the byte data plus an
         // explicit `i64` length, never NUL-terminated-only (a `str`'s

--- a/crates/compiler/src/codegen.rs
+++ b/crates/compiler/src/codegen.rs
@@ -8941,6 +8941,26 @@ fn build_impl(
     // Unix-only.
     #[cfg(unix)]
     clang_cmd.arg("-lm");
+    // Found by a real macOS CI failure, not anticipated in advance:
+    // `native-tls`'s macOS backend (`security-framework`, pulled in
+    // for `nir_https_get`/`nir_https_post` — `Ty::Db`'s `native-tls`
+    // dependency comment) links against `Security.framework`/
+    // `CoreFoundation.framework` (`AuthorizationCreate`/`CFArrayCreate`/
+    // etc.) — real macOS system frameworks clang does **not** auto-link
+    // when the input is a bare `.ll`/staticlib pair rather than actual
+    // Objective-C/C source (unlike compiling a `.m` file, where the
+    // default SDK sysroot linking pulls these in implicitly). Every
+    // other affine-handle kernel in `RUNTIME_KERNELS_LIB` links fine
+    // without them, so this stayed invisible until a real compiled
+    // binary using the TLS path was actually linked on a real macOS
+    // runner — the same "found by testing, not review" discipline this
+    // file's own `-lm`/`NATIVE_STATIC_LIBS` comments already document
+    // for their own platforms. Harmless to pass unconditionally even
+    // for a program that never calls `https_get`/`https_post` (same
+    // reasoning as `-lm` above) — the linker only pulls in what's
+    // actually referenced.
+    #[cfg(target_os = "macos")]
+    clang_cmd.arg("-framework").arg("Security").arg("-framework").arg("CoreFoundation");
     // Windows has no equivalent hand-picked single flag — `std::net`
     // (the `nir_tcp_*` kernels) needs `ws2_32.lib`, and other stdlib
     // pieces need their own system libs beside it, so the captured,

--- a/crates/compiler/src/codegen.rs
+++ b/crates/compiler/src/codegen.rs
@@ -177,6 +177,16 @@ const PHASE5_BUILTINS: &[&str] = &["det", "inv", "solve", "rank", "kf_update_sta
 /// either, so not `call_builtin_scalar`'s).
 const STR_CRYPTO_BUILTINS: &[&str] = &["sha256_hex", "constant_time_str_eq"];
 
+/// `str_slice`/`str_index_of` — the minimal string-parsing surface a
+/// compiled HTTP `serve` needs to hand-parse a request line (`BUILTIN_NAMES`'
+/// own doc comment has the full scope). `str_slice` is pure pointer
+/// arithmetic on the existing `{ptr, i64}` `str` representation, no kernel
+/// call; `str_index_of` is the one real byte-scan, linked to
+/// `nir_str_index_of`. Own list, not folded into `STR_CRYPTO_BUILTINS`, for
+/// the same "describes something different" reason that one isn't folded
+/// into `RAND_BUILTINS`.
+const STR_BUILTINS: &[&str] = &["str_slice", "str_index_of"];
+
 /// `rand_seed`/`rand_f64`/`rand_gaussian` — a process-wide SplitMix64/
 /// Box-Muller stream in `runtime-kernels/src/lib.rs` (its own module doc on why
 /// this needed real RNG *state* in generated code, the one thing that
@@ -185,6 +195,11 @@ const STR_CRYPTO_BUILTINS: &[&str] = &["sha256_hex", "constant_time_str_eq"];
 /// `STR_CRYPTO_BUILTINS`, for the same "describes something different"
 /// reason that one isn't folded into `PHASE5_BUILTINS`.
 const RAND_BUILTINS: &[&str] = &["rand_seed", "rand_f64", "rand_gaussian"];
+
+/// `sleep_ms(ms)` — `docs/ROADMAP.md`'s own B9 ("small, currently
+/// omitted... found this session, not previously tracked anywhere"). A
+/// real wall-clock sleep, `nir_sleep_ms` (`runtime-kernels/src/lib.rs`).
+const SLEEP_BUILTINS: &[&str] = &["sleep_ms"];
 
 /// `dec_from_i64`/`dec_to_str`/`dec_round`/`dec_scale` — linked calls
 /// into `runtime-kernels/src/lib.rs`'s `rust_decimal`-backed kernels
@@ -218,24 +233,112 @@ const DEC128_BUILTINS: &[&str] = &["dec_from_i64", "dec_to_str", "dec_round", "d
 /// `check_role` — the first compiled builtin to actually construct a
 /// real `Result(_, _)` value as its return (`DEC128_BUILTINS`'s own
 /// "not yet included: `dec_from_str`" doc comment names exactly this
-/// gap; this is that convention, established for real). Deliberately
-/// scoped narrower than the interpreter's own `check_role`, which reads
-/// `identity.claims_json` as real JSON — this reads it as a plain
-/// comma-separated role list instead (`nir_check_role`,
-/// `runtime-kernels/src/lib.rs`), since a real JSON parser isn't linked
-/// into this crate. `oidc_validate_token` (the only way to produce a
-/// `VerifiedIdentity` *with* a real, cryptographically-verified
-/// `claims_json`) stays interpreter-only — `VerifiedIdentity` itself is
-/// freely constructible either way (`typeck.rs`'s own
-/// `infer_struct_construction`, unlike `RoleView`/`ClaimView`), so this
-/// compiles the real *authorization* pipeline (`check_role` producing an
-/// unforgeable `RoleView`, consumed by field masking) end to end, while
-/// *authentication* (verifying the identity claims themselves came from
-/// a real signed token) remains the disclosed, separate, larger gap
-/// it already was. `extract_claim`/`check_role_path`/
-/// `extract_claim_path` are not included — real, narrower follow-up
-/// work, not attempted here.
-const IDENTITY_BUILTINS: &[&str] = &["check_role"];
+/// gap; this is that convention, established for real). Originally
+/// scoped narrower than the interpreter's own `check_role` (a plain
+/// comma-separated role list, not real JSON, since no JSON parser was
+/// linked into `runtime-kernels`) — 2026-09: with `serde_json` now
+/// linked in for `oidc_validate_token` below, `nir_check_role`'s own
+/// body was upgraded to real JSON-array parsing too (falling back to
+/// the original comma-separated matching for a `VerifiedIdentity` built
+/// directly in `.nir` source, not through `oidc_validate_token` — see
+/// its own doc comment). No `codegen.rs` change was needed for that
+/// upgrade, only `runtime-kernels`.
+///
+/// `oidc_validate_token`/`extract_claim`/`identity_expired` (2026-09):
+/// real JWT/JWKS signature verification (`nir_oidc_validate_token`,
+/// `jsonwebtoken`-backed, same `kty`-locks-`alg` guard
+/// `crates/presence-gateway/src/jwt.rs` already uses) plus real JSON
+/// claim extraction (`nir_extract_claim`). `identity_expired` needs no
+/// kernel at all — `VerifiedIdentity.expires_at` is a plain `i64`
+/// field, so it's `now > identity.expires_at` via GEP+load+`icmp`,
+/// inline in `Codegen::call` (see its own dispatch arm). Authentication
+/// (verifying the identity claims themselves came from a real signed
+/// token) is now real, closing the gap this comment used to name as
+/// separate from `check_role`'s own *authorization* pipeline.
+/// `check_role_path`/`extract_claim_path` and the rest of Row 12
+/// (sessions/refresh/revocation/`validate_api_key`) remain real,
+/// narrower follow-up work, not attempted here.
+const IDENTITY_BUILTINS: &[&str] = &["check_role", "oidc_validate_token", "extract_claim", "identity_expired"];
+
+/// `db_connect`/`db_query`/`db_execute` — real SQLite connectivity
+/// (`Ty::Db`'s own doc comment, `nir_db_*`, `runtime-kernels/src/lib.rs`'s
+/// "db kernels" section). Layer 1 only: SQLite via `rusqlite`'s
+/// `bundled` feature; a Postgres connection string (`postgres://`/
+/// `postgresql://`) is a real, deferred follow-up (dynamic TLS linking),
+/// not silently dropped.
+const DB_BUILTINS: &[&str] = &["db_connect", "db_query", "db_execute"];
+
+/// `json_parse`/`json_get`/`json_get_str`/`json_get_i64`/`json_get_f64`/
+/// `json_get_bool`/`json_array_get`/`json_array_len`/`json_set_str` —
+/// real JSON navigation (`Ty::Json`'s own doc comment). Compiles
+/// `Ty::Json` as the raw text itself (same `{ptr, i64}` representation
+/// `Ty::Str` already has), each accessor re-parsing via `nir_json_*` —
+/// see `Ty::Json`'s `llvm_ty` arm and `nir_db_query`'s doc comment for
+/// the full reasoning on this representation choice.
+const JSON_BUILTINS: &[&str] =
+    &["json_parse", "json_get", "json_get_str", "json_get_i64", "json_get_f64", "json_get_bool", "json_array_get", "json_array_len", "json_set_str"];
+
+/// `mq_connect`/`mq_publish`/`mq_consume` — real Redis connectivity
+/// (`Ty::Mq`'s own doc comment, `nir_mq_*`, `runtime-kernels/src/lib.rs`'s
+/// "mq kernels" section). `mq_connect_via` (the plugin-dispatched
+/// external-service-boundary path, `rfcs/0003-plugin-abi-v2.md`) is
+/// deliberately not included here — a separate mechanism, owned
+/// elsewhere.
+const MQ_BUILTINS: &[&str] = &["mq_connect", "mq_publish", "mq_consume"];
+
+/// `http_get`/`http_post`/`https_get`/`https_post` — real HTTP(S) client
+/// calls (`ast::BUILTIN_NAMES`'s own doc comment has the full, already-
+/// locked design). No new `Ty` — `HttpResponse` is a plain prelude
+/// struct, and every call here is a one-shot request/response, never a
+/// persisted connection handle.
+const HTTP_BUILTINS: &[&str] = &["http_get", "http_post", "https_get", "https_post"];
+
+/// `workflow` Layer 1 (`docs/WORKFLOW.md`) — every builtin
+/// `workflow_lower.rs` desugars a `workflow` block's synthesized
+/// functions into, plus `__workflow_overdue` (`docs/ROADMAP.md` A15,
+/// added alongside this). `__workflow_pending_for_me`/
+/// `__workflow_submitted_by_me`/`__workflow_history` are included here
+/// (real, compiled, runtime-`Err`-producing — `Codegen::
+/// emit_workflow_unsupported_query`'s own doc comment) rather than
+/// rejected at compile time, because `workflow_lower.rs` synthesizes
+/// `list_<w>_pending_for_me`/`list_<w>_submitted_by_me`/
+/// `get_<w>_history` **unconditionally** for *every* `workflow` block —
+/// unlike `__workflow_link_advance` (only synthesized when a `link`-
+/// marked transition actually exists), a `check_expr`-time rejection of
+/// these three would make *every* workflow fail to compile, not just
+/// ones that call them. `__workflow_link_advance` is deliberately
+/// **not** included here — magic-link consumption needs real durable
+/// storage this Layer 1 doesn't have, and since its own `*_via_link` fn
+/// only exists for a workflow that actually declares a `link` transition,
+/// rejecting it at compile time (`check_expr`'s pre-pass) narrows
+/// correctly, to exactly those programs, instead of blocking everything.
+const WORKFLOW_BUILTINS: &[&str] = &[
+    "__workflow_start",
+    "__workflow_advance",
+    "__workflow_overdue",
+    "__workflow_pending_for_me",
+    "__workflow_submitted_by_me",
+    "__workflow_history",
+];
+
+/// `send_email`/`send_sms`/`send_push`/`notify` (`docs/WORKFLOW.md`) —
+/// a real, generic, provider-agnostic authenticated HTTPS POST for the
+/// first three; `notify` always takes the documented *offline* path
+/// (falls back to `send_email`) since nothing in this round populates a
+/// real presence table (`nir_notify`'s own doc comment).
+const NOTIFY_BUILTINS: &[&str] = &["send_email", "send_sms", "send_push", "notify"];
+
+/// `db_execute`/`db_query`'s trailing `?`-placeholder bind values —
+/// `emit_db_binds` builds a `[N x NIR_BIND_VALUE_LLTY]` array of these,
+/// GEP'd into by field index like any other named-struct-shaped value in
+/// this file (`agg_byte_size_operand`'s own "trust the target's natural
+/// layout, don't hand-replicate it" stance applies here too: a plain,
+/// non-packed anonymous struct type follows the same C-layout rules
+/// Rust's `#[repr(C)]` does for `runtime-kernels/src/lib.rs`'s
+/// `NirBindValue` — same field order, same primitive types, both sides
+/// agree without either one computing offsets by hand). Field order:
+/// `tag`(i32) / `i`(i64) / `f`(double) / `s_ptr`(ptr) / `s_len`(i64).
+const NIR_BIND_VALUE_LLTY: &str = "{ i32, i64, double, ptr, i64 }";
 
 /// WGS84 ellipsoid constants — mirrors `interpreter.rs`'s own
 /// `WGS84_A`/`WGS84_F`/`wgs84_e2()` exactly (same values, same derived
@@ -293,6 +396,15 @@ fn affine_codegen_supported_visiting(registry: &TypeRegistry, ty: &Ty, visiting:
     match ty {
         Ty::Box(inner) => affine_codegen_supported_visiting(registry, inner, visiting),
         Ty::Tcp | Ty::TcpListener => true,
+        // `db_connect`'s own `Result(db, str)` is the first affine handle
+        // nested inside a prelude enum's payload (`File`/`Thread`/
+        // `Channel` are all returned bare, never `Result`-wrapped, so
+        // this arm was never needed until now) — a `db` handle is one
+        // opaque `i64` either way, same as `Tcp`/`TcpListener` above.
+        Ty::Db => true,
+        // Same reason as `Ty::Db` just above — `mq_connect`'s own
+        // `Result(mq, str)`.
+        Ty::Mq => true,
         Ty::Named(name, args) => {
             if visiting.iter().any(|v| v == name.as_str()) {
                 return true;
@@ -412,8 +524,25 @@ fn llvm_ty(ty: &Ty, registry: &TypeRegistry) -> Result<String, CodegenError> {
         // already does, never through the pointer-based aggregate path
         // Vector/Matrix use.
         Ty::Dec128 => Ok("{i64, i64}".to_string()),
-        Ty::Json => unsupported("codegen doesn't support `json` yet — JSON is interpreter-only for now"),
-        Ty::Db => unsupported("codegen doesn't support `db` yet — DB connectivity is interpreter-only for now"),
+        // A `json` value compiles as the same `{ptr, i64}` two-word
+        // value `Ty::Str` already is — the raw JSON text itself, not a
+        // persisted parsed-tree handle. `json_get`/`json_array_get`/etc.
+        // (`Codegen::call_ptr`'s dispatch) re-parse that text via
+        // `nir_json_*` (`runtime-kernels/src/lib.rs`) on every call — the
+        // simplest thing that reuses an existing representation with
+        // zero new runtime value type, at the cost of re-parsing instead
+        // of a persisted tree. Disclosed, not hidden — see `Ty::Json`'s
+        // own doc comment and `nir_db_query`'s.
+        Ty::Json => Ok("{ptr, i64}".to_string()),
+        // A `db` connection handle — one opaque `i64` into
+        // `runtime-kernels`' own `HandleTable<rusqlite::Connection>`
+        // (`db_table()`, `lib.rs`'s "db kernels" section), same "the
+        // handle itself is just a word, the real resource lives in a
+        // kernel-owned table" shape `Ty::Thread`/`Ty::Channel` above
+        // already use — a `rusqlite::Connection` isn't reconstructible
+        // from a bare integer the way a `tcp`/`file` fd is, so a table
+        // (not a raw fd) backs this one.
+        Ty::Db => Ok("i64".to_string()),
         // rfcs/0008-native-plugin-abi-widening.md Phase 1: a plugin-held
         // resource id, exactly like `Ty::Thread`/`Ty::Channel`/`Ty::File`
         // just above — one opaque `i64` into a table this compiler never
@@ -424,7 +553,10 @@ fn llvm_ty(ty: &Ty, registry: &TypeRegistry) -> Result<String, CodegenError> {
         // itself just needs to pass the word through, identically to how
         // it already treats a spawn/channel/file handle.
         Ty::Handle(_) => Ok("i64".to_string()),
-        Ty::Mq => unsupported("codegen doesn't support `mq` yet — message-queue connectivity is interpreter-only for now"),
+        // A `mq` (Redis) connection handle — same "opaque `i64` into a
+        // `HandleTable`" shape as `Ty::Db` just above (`mq_table()`,
+        // `lib.rs`'s "mq kernels" section).
+        Ty::Mq => Ok("i64".to_string()),
         // A fixed-size, two-word value — pointer to the byte data plus an
         // explicit `i64` length, never NUL-terminated-only (a `str`'s
         // bytes are whatever the source literal's escapes resolved to,
@@ -932,21 +1064,53 @@ fn check_expr(e: &Expr, plugin_names: &std::collections::HashSet<String>, regist
                 // existing `arg_ty.is_aggregate()` check there), same as
                 // before. Each argument still gets walked for its own
                 // recursive validity by the shared loop below.
+            } else if name == "__workflow_link_advance" {
+                // `WORKFLOW_BUILTINS`'s own doc comment: magic-link
+                // consumption needs real durable storage (a
+                // `workflow_log.rs`-shaped table keyed by instance id,
+                // surviving process restarts) that this Layer 1 compiled
+                // backend doesn't have — `WorkflowInstance`
+                // (`runtime-kernels/src/lib.rs`) is a plain in-process
+                // `HashMap`, gone the moment the binary exits. Rejected
+                // here (rather than at runtime, like
+                // `__workflow_pending_for_me`/`__workflow_submitted_by_me`/
+                // `__workflow_history`) because a `*_via_link` fn only
+                // exists for a workflow that actually declares a `link`
+                // transition, so this narrows correctly to exactly those
+                // programs — same "specific reason, not a generic
+                // fallthrough" treatment `network_retry`/`network_timeout`
+                // already get in `emit_transact`.
+                return unsupported(format!(
+                    "codegen doesn't support `{name}` yet — magic-link advance needs real \
+                     durable, restart-surviving storage that this compiled backend's Layer 1 \
+                     workflow runtime doesn't have (an in-process table only, see \
+                     `runtime-kernels`'s `WorkflowInstance`); use `advance_<workflow>`/state \
+                     transitions instead"
+                ));
             } else if is_builtin(name)
                 && !PHASE4_BUILTINS.contains(&name.as_str())
                 && !PHASE5_BUILTINS.contains(&name.as_str())
                 && !STR_CRYPTO_BUILTINS.contains(&name.as_str())
+                && !STR_BUILTINS.contains(&name.as_str())
                 && !RAND_BUILTINS.contains(&name.as_str())
                 && !DEC128_BUILTINS.contains(&name.as_str())
                 && !IDENTITY_BUILTINS.contains(&name.as_str())
+                && !DB_BUILTINS.contains(&name.as_str())
+                && !JSON_BUILTINS.contains(&name.as_str())
+                && !SLEEP_BUILTINS.contains(&name.as_str())
+                && !MQ_BUILTINS.contains(&name.as_str())
+                && !HTTP_BUILTINS.contains(&name.as_str())
+                && !WORKFLOW_BUILTINS.contains(&name.as_str())
+                && !NOTIFY_BUILTINS.contains(&name.as_str())
             {
                 // Every builtin not in `PHASE4_BUILTINS` (unrolled IR),
-                // `PHASE5_BUILTINS`/`STR_CRYPTO_BUILTINS` (linked runtime
-                // call), or `RAND_BUILTINS` (linked call into a
-                // process-wide RNG stream) is rejected here with a
-                // specific reason rather than falling through to
-                // `check_expr`'s per-argument walk, which would report a
-                // less specific one.
+                // `PHASE5_BUILTINS`/`STR_CRYPTO_BUILTINS`/`STR_BUILTINS`
+                // (linked runtime call), `RAND_BUILTINS` (linked call
+                // into a process-wide RNG stream), or `DB_BUILTINS`/
+                // `JSON_BUILTINS` (linked SQLite/JSON kernel calls) is
+                // rejected here with a specific reason rather than
+                // falling through to `check_expr`'s per-argument walk,
+                // which would report a less specific one.
                 return unsupported(format!(
                     "codegen doesn't support `{name}` yet — this builtin is interpreter-only \
                      for now (numeric codegen lands in a later phase)"
@@ -1088,16 +1252,57 @@ fn check_expr(e: &Expr, plugin_names: &std::collections::HashSet<String>, regist
             }
             Ok(())
         }
-        // `docs/TRANSACT.md`'s own decision: "Compiled backend (codegen.rs) is
-        // out of scope until the interpreter version is proven" — same
-        // "reject, don't mis-compile" treatment every other unimplemented
-        // construct gets (`thread`, `chan`, `sandbox`, `struct`/`enum`/
-        // `match`, `db`/`mq`/`json` — see `docs/LANGUAGE.md` §10 for the
-        // current list; `box`/`tcp` compile now, so they've dropped off
-        // it). `transact` joins the still-unsupported list, not an
-        // exception to it.
-        Expr::Transact { .. } => {
-            unsupported("codegen doesn't support `transact` yet — interpreter-only for now")
+        // `transact { ... }` — compiled 2026-09 (`Codegen::emit_transact`'s
+        // own doc comment has the full scope: Layer 1 control flow only,
+        // no retry/timeout/durability/replay). `network_retry`/
+        // `network_timeout` are the one part of the construct genuinely
+        // rejected here, not just deferred — a compiled trap is an
+        // unrecoverable `abort()`, and `network`'s own declared return
+        // type is restricted to a bare scalar (`Ty::is_transact_scalar`,
+        // never `Result(_, _)`), so there is no non-trapping failure
+        // signal for a retry loop to react to at all. Every slot's own
+        // arguments are still walked structurally (same as `Expr::Call`'s
+        // own args), so a still-unsupported construct nested inside one
+        // is caught with its own specific reason.
+        Expr::Transact { precheck, network, network_retry, network_timeout, verify, commit, compensate, log, .. } => {
+            if network_retry.is_some() || network_timeout.is_some() {
+                return unsupported(
+                    "codegen doesn't support `network`'s `retry`/`timeout` modifiers yet — the \
+                     now-deleted interpreter's retry-on-trap semantics relied on catching an \
+                     internal RuntimeError before it ever unwound; a compiled trap calls abort() \
+                     directly (this language's trap model everywhere else), which is unrecoverable, \
+                     so there is no non-trapping way to detect a failed `network` call to retry \
+                     (`network`'s own declared return type is restricted to a bare scalar by \
+                     Ty::is_transact_scalar, never Result(_, _), so there's no Err to react to \
+                     either) — omit `retry`/`timeout` on `network` for now"
+                        .to_string(),
+                );
+            }
+            if let Some(p) = precheck {
+                for a in &p.args {
+                    check_expr(a, plugin_names, registry)?;
+                }
+            }
+            for a in &network.args {
+                check_expr(a, plugin_names, registry)?;
+            }
+            for a in &verify.args {
+                check_expr(a, plugin_names, registry)?;
+            }
+            for a in &commit.args {
+                check_expr(a, plugin_names, registry)?;
+            }
+            if let Some(c) = compensate {
+                for a in &c.args {
+                    check_expr(a, plugin_names, registry)?;
+                }
+            }
+            if let Some(l) = log {
+                for a in &l.args {
+                    check_expr(a, plugin_names, registry)?;
+                }
+            }
+            Ok(())
         }
     }
 }
@@ -1279,6 +1484,17 @@ struct Codegen<'a> {
     /// just prepended instead because a named type must textually precede
     /// any `define` that mentions it.
     named_type_decls: String,
+    /// `program.workflows` — `emit_workflow_start`/`emit_workflow_advance`'s
+    /// own doc comments have the full reasoning: `workflow_lower.rs`
+    /// desugars every `workflow` block into ordinary `FnDecl`s whose body
+    /// is a single call to `__workflow_start`/`__workflow_advance`/etc.
+    /// with the workflow's own name baked in as a compile-time `str`
+    /// literal — never a runtime value — so codegen can resolve which
+    /// `WorkflowDecl` a given call site means at compile time and emit
+    /// bespoke, inlined control flow per workflow, the same way
+    /// `emit_check_role`/`emit_transact` hand-build IR for their own
+    /// specific builtins rather than a generic runtime dispatch table.
+    workflows: &'a [WorkflowDecl],
 }
 
 pub fn emit_llvm_ir<'a>(program: &'a Program, smt_report: &'a SmtReport) -> Result<String, CodegenError> {
@@ -1363,6 +1579,7 @@ fn emit_llvm_ir_impl<'a>(
             registry,
             declared_named_types: HashSet::new(),
             named_type_decls: String::new(),
+            workflows: &program.workflows,
         };
 
     writeln!(cg.out, "declare i32 @printf(ptr, ...)").unwrap();
@@ -1413,6 +1630,10 @@ fn emit_llvm_ir_impl<'a>(
     // doc comment.
     writeln!(cg.out, "declare void @nir_sha256_hex(ptr, i64, ptr, i64, ptr)").unwrap();
     writeln!(cg.out, "declare i32 @nir_constant_time_str_eq(ptr, i64, ptr, i64)").unwrap();
+    // `str_index_of` — `STR_BUILTINS`' doc comment. `str_slice`/`len(str)`
+    // need no declare here: both are pure pointer arithmetic in generated
+    // IR, no linked kernel call.
+    writeln!(cg.out, "declare i64 @nir_str_index_of(ptr, i64, ptr, i64)").unwrap();
     // `rand_seed`/`rand_f64`/`rand_gaussian` — `RAND_BUILTINS`' doc comment.
     writeln!(cg.out, "declare void @nir_rand_seed(i64)").unwrap();
     writeln!(cg.out, "declare double @nir_rand_f64()").unwrap();
@@ -1475,9 +1696,62 @@ fn emit_llvm_ir_impl<'a>(
     writeln!(cg.out, "declare i64 @nir_nfr_call_begin(i64)").unwrap();
     writeln!(cg.out, "declare void @nir_nfr_call_end(i64, i64, i32)").unwrap();
     // `check_role`'s real implementation (`IDENTITY_BUILTINS`'s own doc
-    // comment) — `1` if `role` appears in `claims`'s comma-separated
-    // list, `0` otherwise.
+    // comment) — `1` if `role` is present in `claims` (real JSON roles
+    // array, falling back to a comma-separated list), `0` otherwise.
     writeln!(cg.out, "declare i32 @nir_check_role(ptr, i64, ptr, i64)").unwrap();
+    // `oidc_validate_token`/`extract_claim` (`IDENTITY_BUILTINS`'s own
+    // doc comment) — real JWT/JWKS signature verification and JSON claim
+    // extraction. Every `out_*` param is a `ptr` (either `{ptr, i64}`'s
+    // own two words, or a plain `i64`) written into directly, matching
+    // `emit_oidc_validate_token`'s own field-pointer-as-out-param design.
+    writeln!(
+        cg.out,
+        "declare i32 @nir_oidc_validate_token(ptr, i64, ptr, i64, ptr, i64, ptr, i64, ptr, ptr, ptr, ptr, ptr, ptr, ptr)"
+    )
+    .unwrap();
+    writeln!(cg.out, "declare i32 @nir_extract_claim(ptr, i64, ptr, i64, ptr)").unwrap();
+    // `db`/`json` (`DB_BUILTINS`/`JSON_BUILTINS`'s own doc comments) —
+    // real SQLite connectivity and JSON navigation. Every bind-value
+    // param below is `ptr` to a `[N x NIR_BIND_VALUE_LLTY]` array (or
+    // `null` for the zero-bind case).
+    writeln!(cg.out, "declare i32 @nir_db_connect(ptr, i64, ptr, ptr)").unwrap();
+    writeln!(cg.out, "declare i32 @nir_db_stop(i64)").unwrap();
+    writeln!(cg.out, "declare i32 @nir_db_execute(i64, ptr, i64, ptr, i64, ptr, ptr)").unwrap();
+    writeln!(cg.out, "declare i32 @nir_db_query(i64, ptr, i64, ptr, i64, ptr, ptr)").unwrap();
+    writeln!(cg.out, "declare i32 @nir_json_validate(ptr, i64, ptr)").unwrap();
+    writeln!(cg.out, "declare i32 @nir_json_get(ptr, i64, ptr, i64, ptr, ptr)").unwrap();
+    writeln!(cg.out, "declare i32 @nir_json_array_get(ptr, i64, i64, ptr, ptr)").unwrap();
+    writeln!(cg.out, "declare i32 @nir_json_array_len(ptr, i64, ptr, ptr)").unwrap();
+    writeln!(cg.out, "declare i32 @nir_json_get_str(ptr, i64, ptr, i64, ptr, ptr)").unwrap();
+    writeln!(cg.out, "declare i32 @nir_json_get_i64(ptr, i64, ptr, i64, ptr, ptr)").unwrap();
+    writeln!(cg.out, "declare i32 @nir_json_get_f64(ptr, i64, ptr, i64, ptr, ptr)").unwrap();
+    writeln!(cg.out, "declare i32 @nir_json_get_bool(ptr, i64, ptr, i64, ptr, ptr)").unwrap();
+    writeln!(cg.out, "declare i32 @nir_json_set_str(ptr, i64, ptr, i64, ptr, i64, ptr, ptr)").unwrap();
+    // `transact { ... }` (`docs/TRANSACT.md`, `Codegen::emit_transact`'s
+    // own doc comment has the compiled-backend scope). `txn_id`'s real
+    // implementation; `sleep_ms`, ordinary compiled `sleep_ms(ms)` (`B9`).
+    writeln!(cg.out, "declare void @nir_transact_gen_txn_id(ptr)").unwrap();
+    writeln!(cg.out, "declare void @nir_sleep_ms(i64)").unwrap();
+    // `mq`/`http`/`https` (`MQ_BUILTINS`/`HTTP_BUILTINS`'s own doc
+    // comments) — real Redis connectivity and HTTP(S) client calls.
+    writeln!(cg.out, "declare i32 @nir_mq_connect(ptr, i64, i64, ptr, ptr)").unwrap();
+    writeln!(cg.out, "declare i32 @nir_mq_stop(i64)").unwrap();
+    writeln!(cg.out, "declare i32 @nir_mq_publish(i64, ptr, i64, ptr, i64, ptr)").unwrap();
+    writeln!(cg.out, "declare i32 @nir_mq_consume(i64, ptr, i64, i64, ptr, ptr)").unwrap();
+    writeln!(cg.out, "declare i32 @nir_http_get(ptr, i64, i64, ptr, i64, ptr, ptr, ptr)").unwrap();
+    writeln!(cg.out, "declare i32 @nir_http_post(ptr, i64, i64, ptr, i64, ptr, i64, ptr, ptr, ptr)").unwrap();
+    writeln!(cg.out, "declare i32 @nir_https_get(ptr, i64, i64, ptr, i64, ptr, ptr, ptr)").unwrap();
+    writeln!(cg.out, "declare i32 @nir_https_post(ptr, i64, i64, ptr, i64, ptr, i64, ptr, ptr, ptr)").unwrap();
+    // `workflow` Layer 1 (`docs/WORKFLOW.md`, `Codegen::emit_workflow_start`'s
+    // own doc comment has the full scope) — the in-memory instance
+    // table, SLA/escalation detection, and the four notification
+    // channels.
+    writeln!(cg.out, "declare i32 @nir_workflow_create_instance(ptr, i64, ptr, i64, ptr)").unwrap();
+    writeln!(cg.out, "declare i32 @nir_workflow_get_state(ptr, i64, i64, ptr)").unwrap();
+    writeln!(cg.out, "declare i32 @nir_workflow_set_state(ptr, i64, i64, ptr, i64)").unwrap();
+    writeln!(cg.out, "declare i32 @nir_workflow_list_overdue(ptr, i64, ptr, i64, ptr, ptr)").unwrap();
+    writeln!(cg.out, "declare i32 @nir_workflow_send(ptr, i64, i64, ptr, i64, ptr, i64, ptr, i64, ptr)").unwrap();
+    writeln!(cg.out, "declare i32 @nir_notify(i64, i64, ptr, i64, ptr, i64, ptr, i64, ptr)").unwrap();
     // The APM kernel's flight recorder (`runtime-kernels/src/kernel/
     // mod.rs`'s own doc comment) — declared unconditionally like every
     // other kernel here, called exactly once by `emit_c_main` on every
@@ -2316,13 +2590,77 @@ impl Codegen<'_> {
             // wrongly report `Ty::I64` for these two builtins.
             Expr::Call(name, _, _) if name == "sha256_hex" => Ty::Str,
             Expr::Call(name, _, _) if name == "constant_time_str_eq" => Ty::Bool,
+            Expr::Call(name, _, _) if name == "str_slice" => Ty::Str,
+            Expr::Call(name, _, _) if name == "str_index_of" => Ty::I64,
             Expr::Call(name, _, _) if name == "rand_f64" || name == "rand_gaussian" => Ty::F64,
             Expr::Call(name, _, _) if name == "rand_seed" => Ty::Unit,
+            Expr::Call(name, _, _) if name == "sleep_ms" => Ty::Unit,
             Expr::Call(name, _, _) if name == "dec_from_i64" || name == "dec_round" => Ty::Dec128,
             Expr::Call(name, _, _) if name == "dec_to_str" => Ty::Str,
             Expr::Call(name, _, _) if name == "dec_scale" => Ty::U32,
             Expr::Call(name, _, _) if name == "check_role" => {
                 Ty::Named("Result".to_string(), vec![Ty::Named("RoleView".to_string(), vec![]), Ty::Str])
+            }
+            Expr::Call(name, _, _) if name == "oidc_validate_token" => {
+                Ty::Named("Result".to_string(), vec![Ty::Named("VerifiedIdentity".to_string(), vec![]), Ty::Str])
+            }
+            Expr::Call(name, _, _) if name == "extract_claim" => {
+                Ty::Named("Result".to_string(), vec![Ty::Named("ClaimView".to_string(), vec![]), Ty::Str])
+            }
+            Expr::Call(name, _, _) if name == "identity_expired" => Ty::Bool,
+            Expr::Call(name, _, _) if name == "db_connect" => {
+                Ty::Named("Result".to_string(), vec![Ty::Db, Ty::Str])
+            }
+            Expr::Call(name, _, _) if name == "db_execute" => {
+                Ty::Named("Result".to_string(), vec![Ty::I64, Ty::Str])
+            }
+            Expr::Call(name, _, _) if name == "db_query" => {
+                Ty::Named("Result".to_string(), vec![Ty::Json, Ty::Str])
+            }
+            Expr::Call(name, _, _) if name == "json_parse" || name == "json_get" || name == "json_array_get" => {
+                Ty::Named("Result".to_string(), vec![Ty::Json, Ty::Str])
+            }
+            Expr::Call(name, _, _) if name == "json_get_str" => {
+                Ty::Named("Result".to_string(), vec![Ty::Str, Ty::Str])
+            }
+            Expr::Call(name, _, _) if name == "json_get_i64" || name == "json_array_len" => {
+                Ty::Named("Result".to_string(), vec![Ty::I64, Ty::Str])
+            }
+            Expr::Call(name, _, _) if name == "json_get_f64" => {
+                Ty::Named("Result".to_string(), vec![Ty::F64, Ty::Str])
+            }
+            Expr::Call(name, _, _) if name == "json_get_bool" => {
+                Ty::Named("Result".to_string(), vec![Ty::Bool, Ty::Str])
+            }
+            Expr::Call(name, _, _) if name == "json_set_str" => {
+                Ty::Named("Result".to_string(), vec![Ty::Json, Ty::Str])
+            }
+            Expr::Call(name, _, _) if name == "mq_connect" => {
+                Ty::Named("Result".to_string(), vec![Ty::Mq, Ty::Str])
+            }
+            Expr::Call(name, _, _) if name == "mq_publish" => {
+                Ty::Named("Result".to_string(), vec![Ty::Unit, Ty::Str])
+            }
+            Expr::Call(name, _, _) if name == "mq_consume" => {
+                Ty::Named("Result".to_string(), vec![Ty::Str, Ty::Str])
+            }
+            Expr::Call(name, _, _) if name == "http_get" || name == "http_post" || name == "https_get" || name == "https_post" => {
+                Ty::Named("Result".to_string(), vec![Ty::Named("HttpResponse".to_string(), vec![]), Ty::Str])
+            }
+            // `workflow` Layer 1 (`WORKFLOW_BUILTINS`/`NOTIFY_BUILTINS`'
+            // own doc comments) — every one of these returns
+            // `Result(_, WorkflowActionError)`, matching `typeck.rs`'s
+            // own `workflow_result_of` calls for the same names exactly.
+            Expr::Call(name, _, _) if name == "__workflow_start" => workflow_result_of(Ty::I64),
+            Expr::Call(name, _, _) if name == "__workflow_advance" => workflow_result_of(Ty::Bool),
+            Expr::Call(name, _, _) if name == "__workflow_overdue" => workflow_result_of(Ty::Json),
+            Expr::Call(name, _, _)
+                if name == "__workflow_pending_for_me" || name == "__workflow_submitted_by_me" || name == "__workflow_history" =>
+            {
+                workflow_result_of(Ty::Json)
+            }
+            Expr::Call(name, _, _) if name == "send_email" || name == "send_sms" || name == "send_push" || name == "notify" => {
+                workflow_result_of(Ty::Bool)
             }
             // Row 11: a struct/variant constructor call produces a
             // `Ty::Named` value (the struct's own type, or the owning
@@ -3239,6 +3577,17 @@ impl Codegen<'_> {
                          through a function call"
                     ));
                 }
+                if ty == Ty::Unit {
+                    // No data to load — `Ty::Unit`'s own `llvm_ty` is
+                    // `void`, and `load void` is invalid LLVM IR. Only
+                    // reachable via a match arm that binds a `Ty::Unit`
+                    // payload and then references it directly (e.g.
+                    // `Ok(u) => u`) — the same placeholder value every
+                    // other unit-shaped result in this file already
+                    // uses ("its own value is unit; never [meaningfully]
+                    // read").
+                    return Ok("0".to_string());
+                }
                 let llty = self.llvm_ty(&ty)?;
                 let reg = self.fresh_reg(&format!("{name}.val"));
                 writeln!(self.out, "  {reg} = load {llty}, ptr {ptr}").unwrap();
@@ -3295,8 +3644,18 @@ impl Codegen<'_> {
                 // need to know it came from an assignment specifically.
                 Ok(val)
             }
-            Expr::Acquire(_, _, _) | Expr::SpawnSandbox(_, _, _) | Expr::Transact { .. } => {
+            Expr::Acquire(_, _, _) | Expr::SpawnSandbox(_, _, _) => {
                 unreachable!("check_supported already rejected this program")
+            }
+            // `transact { ... }` — always `Ty::Bool`-valued, never
+            // aggregate, so it belongs here in `expr()`, not `expr_ptr()`
+            // (unlike `Expr::Acquire`/`Expr::If`/`Expr::Match`, which can
+            // be either and so are dispatched from both). `network_retry`/
+            // `network_timeout` are already rejected in `check_expr`'s
+            // pre-pass if present — `emit_transact`'s own doc comment has
+            // the full scope.
+            Expr::Transact { precheck, network, verify, commit, compensate, log, .. } => {
+                self.emit_transact(precheck, network, verify, commit, compensate, log, scopes)
             }
             // `chan`'s own construction — one opaque `i64` handle,
             // identical for every payload type `T` (`llvm_ty`'s own
@@ -3645,7 +4004,17 @@ impl Codegen<'_> {
                     writeln!(self.out, "  call i32 @nir_file_stop(i64 {fd})").unwrap();
                     Ok("0".to_string())
                 }
-                _ => unreachable!("typeck.rs already restricted stop's operand to sandbox/tcp/tcp_listener/file"),
+                Ty::Db => {
+                    let handle = self.expr(inner, scopes)?;
+                    writeln!(self.out, "  call i32 @nir_db_stop(i64 {handle})").unwrap();
+                    Ok("0".to_string())
+                }
+                Ty::Mq => {
+                    let handle = self.expr(inner, scopes)?;
+                    writeln!(self.out, "  call i32 @nir_mq_stop(i64 {handle})").unwrap();
+                    Ok("0".to_string())
+                }
+                _ => unreachable!("typeck.rs already restricted stop's operand to sandbox/tcp/tcp_listener/file/db/mq"),
             },
             // `v[i]` / `m[i, j]` — always yields a scalar element, so this
             // belongs in `expr()`, not `expr_ptr()`, even though the base
@@ -3769,11 +4138,20 @@ impl Codegen<'_> {
                 let v = self.expr(a, scopes)?;
                 if arg_ty == Ty::F64 {
                     writeln!(self.out, "  call i32 (ptr, ...) @printf(ptr @.float_fmt, double {v})").unwrap();
-                } else if arg_ty == Ty::Str {
+                } else if arg_ty == Ty::Str || arg_ty == Ty::Json {
                     // `%.*s`, not `%s` — the buffer isn't guaranteed
                     // NUL-terminated by this design (`Ty::Str`'s note in
                     // `llvm_ty`), so the explicit length has to drive how
-                    // many bytes `printf` reads, not a NUL scan.
+                    // many bytes `printf` reads, not a NUL scan. `Ty::Json`
+                    // rides the same branch: it's the identical `{ptr,
+                    // i64}` raw-JSON-text representation (`Ty::Json`'s own
+                    // `llvm_ty` doc comment), so `print(a_json_value)` — a
+                    // `db_query`/`list_<workflow>_overdue()` result, say —
+                    // prints its real JSON text, not a wrong `i64`-shaped
+                    // read of a two-word struct (which is what falling
+                    // through to the `else` arm below would have done).
+                    // Found by actually trying to `print` a `json` value,
+                    // not designed in advance.
                     let ptr_reg = self.fresh_reg("str_print_ptr");
                     writeln!(self.out, "  {ptr_reg} = extractvalue {{ptr, i64}} {v}, 0").unwrap();
                     let len_reg = self.fresh_reg("str_print_len");
@@ -3867,6 +4245,55 @@ impl Codegen<'_> {
             .unwrap();
             return self.icmp("ne", "i32", &raw, "0");
         }
+        // `str_slice`/`str_index_of` (`STR_BUILTINS`'s own doc comment) —
+        // `str_slice` is pure pointer arithmetic on the existing `{ptr,
+        // i64}` representation, no kernel call; `str_index_of` is the one
+        // genuine byte-scan, linked to `nir_str_index_of`.
+        if name == "str_slice" {
+            let (s_ptr, s_len) = self.str_parts(&args[0], scopes)?;
+            let start = self.expr(&args[1], scopes)?;
+            let end = self.expr(&args[2], scopes)?;
+            self.guard_str_bounds_ok(&start, &end, &s_len);
+            let new_ptr = self.fresh_reg("slice_ptr");
+            writeln!(self.out, "  {new_ptr} = getelementptr i8, ptr {s_ptr}, i64 {start}").unwrap();
+            let new_len = self.fresh_reg("slice_len");
+            writeln!(self.out, "  {new_len} = sub i64 {end}, {start}").unwrap();
+            let partial = self.fresh_reg("slice_str_partial");
+            writeln!(self.out, "  {partial} = insertvalue {{ptr, i64}} undef, ptr {new_ptr}, 0").unwrap();
+            let result = self.fresh_reg("slice_str");
+            writeln!(self.out, "  {result} = insertvalue {{ptr, i64}} {partial}, i64 {new_len}, 1").unwrap();
+            return Ok(result);
+        }
+        if name == "str_index_of" {
+            let (hay_ptr, hay_len) = self.str_parts(&args[0], scopes)?;
+            let (needle_ptr, needle_len) = self.str_parts(&args[1], scopes)?;
+            let idx = self.fresh_reg("str_index_of");
+            writeln!(
+                self.out,
+                "  {idx} = call i64 @nir_str_index_of(ptr {hay_ptr}, i64 {hay_len}, ptr {needle_ptr}, i64 {needle_len})"
+            )
+            .unwrap();
+            return Ok(idx);
+        }
+        // `identity_expired(identity, now) -> bool` — no kernel at all,
+        // unlike its `IDENTITY_BUILTINS` siblings: `VerifiedIdentity.
+        // expires_at` is a plain `i64` field, so this is a GEP+load+
+        // `icmp`, unconditionally inline, the same "no linked call
+        // needed" shape `len(Vector)` already has for a different
+        // reason (there it's compile-time-known; here it's one memory
+        // read).
+        if name == "identity_expired" {
+            let identity_ty = Ty::Named("VerifiedIdentity".to_string(), vec![]);
+            let identity_ptr = self.expr_ptr_expected(&args[0], &identity_ty, scopes)?;
+            let (idx, _) = self.field_index_and_ty(&identity_ty, "expires_at").expect("VerifiedIdentity always has expires_at, ast::prelude_structs");
+            let identity_llty = self.llvm_ty(&identity_ty)?;
+            let field_ptr = self.fresh_reg("identity_expires_at_ptr");
+            writeln!(self.out, "  {field_ptr} = getelementptr inbounds {identity_llty}, ptr {identity_ptr}, i32 0, i32 {idx}").unwrap();
+            let expires_at = self.fresh_reg("identity_expires_at");
+            writeln!(self.out, "  {expires_at} = load i64, ptr {field_ptr}").unwrap();
+            let now = self.expr(&args[1], scopes)?;
+            return self.icmp("sgt", "i64", &now, &expires_at);
+        }
         if name == "rand_seed" {
             // Every integer-typed `expr()` result is already `i64`
             // (module doc) regardless of `rand_seed`'s argument's own
@@ -3875,6 +4302,11 @@ impl Codegen<'_> {
             let seed = self.expr(&args[0], scopes)?;
             writeln!(self.out, "  call void @nir_rand_seed(i64 {seed})").unwrap();
             return Ok("0".to_string()); // rand_seed's own "value" is unit; never read
+        }
+        if name == "sleep_ms" {
+            let ms = self.expr(&args[0], scopes)?;
+            writeln!(self.out, "  call void @nir_sleep_ms(i64 {ms})").unwrap();
+            return Ok("0".to_string()); // sleep_ms's own "value" is unit; never read
         }
         if name == "rand_f64" {
             let r = self.fresh_reg("rand_f64");
@@ -4141,15 +4573,20 @@ impl Codegen<'_> {
                 }
                 Ok(acc)
             }
-            "len" => {
-                let Ty::Vector(_, n) = self.local_ty_of(&args[0], scopes) else {
-                    unreachable!("typeck.rs already proved this is a Vector")
-                };
-                // `len` is genuinely O(1): a `Vector`'s length is baked
-                // into its `Ty`, known at codegen time -- no load at all,
-                // unlike every other builtin here.
-                Ok(n.to_string())
-            }
+            "len" => match self.local_ty_of(&args[0], scopes) {
+                // A `Vector`'s length is baked into its `Ty`, known at
+                // codegen time -- no load at all, genuinely O(1).
+                Ty::Vector(_, n) => Ok(n.to_string()),
+                // A `str`'s length is a runtime value (the second field
+                // of its `{ptr, i64}` representation), not a compile-time
+                // constant like Vector's -- one `extractvalue`, same as
+                // `str_parts`'s own len half.
+                Ty::Str => {
+                    let (_, len) = self.str_parts(&args[0], scopes)?;
+                    Ok(len)
+                }
+                _ => unreachable!("typeck.rs already proved this is a Vector or str"),
+            },
             "norm" | "frobenius_norm" => {
                 let (_, len) = agg_elem_and_len(&self.local_ty_of(&args[0], scopes));
                 let a_ptr = self.expr_ptr(&args[0], scopes)?;
@@ -4947,6 +5384,93 @@ impl Codegen<'_> {
         if name == "check_role" {
             return self.emit_check_role(args, scopes);
         }
+        if name == "oidc_validate_token" {
+            return self.emit_oidc_validate_token(args, scopes);
+        }
+        if name == "extract_claim" {
+            return self.emit_extract_claim(args, scopes);
+        }
+        if name == "db_connect" {
+            return self.emit_db_connect(args, scopes);
+        }
+        if name == "db_execute" {
+            return self.emit_db_execute(args, scopes);
+        }
+        if name == "db_query" {
+            return self.emit_db_query(args, scopes);
+        }
+        if name == "json_parse" {
+            return self.emit_json_parse(args, scopes);
+        }
+        if name == "json_get" {
+            return self.emit_json_get(args, scopes);
+        }
+        if name == "json_array_get" {
+            return self.emit_json_array_get(args, scopes);
+        }
+        if name == "json_array_len" {
+            return self.emit_json_array_len(args, scopes);
+        }
+        if name == "json_get_str" {
+            return self.emit_json_get_str(args, scopes);
+        }
+        if name == "json_get_i64" {
+            return self.emit_json_get_i64(args, scopes);
+        }
+        if name == "json_get_f64" {
+            return self.emit_json_get_f64(args, scopes);
+        }
+        if name == "json_get_bool" {
+            return self.emit_json_get_bool(args, scopes);
+        }
+        if name == "json_set_str" {
+            return self.emit_json_set_str(args, scopes);
+        }
+        if name == "mq_connect" {
+            return self.emit_mq_connect(args, scopes);
+        }
+        if name == "mq_publish" {
+            return self.emit_mq_publish(args, scopes);
+        }
+        if name == "mq_consume" {
+            return self.emit_mq_consume(args, scopes);
+        }
+        if name == "http_get" {
+            return self.emit_http_call("nir_http_get", args, false, scopes);
+        }
+        if name == "http_post" {
+            return self.emit_http_call("nir_http_post", args, true, scopes);
+        }
+        if name == "https_get" {
+            return self.emit_http_call("nir_https_get", args, false, scopes);
+        }
+        if name == "https_post" {
+            return self.emit_http_call("nir_https_post", args, true, scopes);
+        }
+        if name == "__workflow_start" {
+            return self.emit_workflow_start(args, scopes);
+        }
+        if name == "__workflow_advance" {
+            return self.emit_workflow_advance(args, scopes);
+        }
+        if name == "__workflow_overdue" {
+            return self.emit_workflow_overdue(args, scopes);
+        }
+        if name == "__workflow_pending_for_me" || name == "__workflow_submitted_by_me" || name == "__workflow_history" {
+            return self.emit_workflow_unsupported_query(name);
+        }
+        if name == "send_email" {
+            return self.emit_send_notification("email", args, scopes);
+        }
+        if name == "send_sms" {
+            return self.emit_send_notification("sms", args, scopes);
+        }
+        if name == "send_push" {
+            return self.emit_send_notification("push", args, scopes);
+        }
+        if name == "notify" {
+            return self.emit_notify(args, scopes);
+        }
         let sig_params = self.sigs.get(name).expect("typeck.rs already resolved this call").params.clone();
         let sig_ret = self.sigs.get(name).expect("typeck.rs already resolved this call").ret.clone();
         let arg_vals = self.call_args(args, &sig_params, scopes)?;
@@ -5042,6 +5566,1524 @@ impl Codegen<'_> {
 
         writeln!(self.out, "{merge_label}:").unwrap();
         Ok(dest)
+    }
+
+    /// `oidc_validate_token(token, expected_issuer, expected_audience,
+    /// jwks_json) -> Result(VerifiedIdentity, str)` — real JWT/JWKS
+    /// signature verification (`nir_oidc_validate_token`,
+    /// `IDENTITY_BUILTINS`'s own doc comment has the full scope). Unlike
+    /// `emit_check_role`'s single-`str`-field `RoleView` payload,
+    /// `VerifiedIdentity` has six fields, so this writes the kernel's
+    /// out-params **directly into a scratch `VerifiedIdentity`'s own
+    /// field pointers** (via `field_index_and_ty`, same helper
+    /// `emit_check_role` uses to *read* `claims_json`) rather than
+    /// double-buffering through intermediate locals, then `memcpy`s that
+    /// whole struct into the `Result`'s payload on success — the same
+    /// "GEP to the field, no intermediate copy" discipline
+    /// `construct_variant`'s generic path already uses for aggregate
+    /// payloads. Same tag-then-payload/br/merge shape as
+    /// `emit_check_role` otherwise; the one real difference is the `Err`
+    /// message is a genuine runtime `str` value from the kernel's own
+    /// `out_err`, not a compile-time literal (a malformed token/JWKS
+    /// produces a different message than a bad issuer/audience/
+    /// signature, and callers of a real relying-party check deserve to
+    /// know which).
+    fn emit_oidc_validate_token(&mut self, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let identity_ty = Ty::Named("VerifiedIdentity".to_string(), vec![]);
+        let result_ty = Ty::Named("Result".to_string(), vec![identity_ty.clone(), Ty::Str]);
+
+        let (token_ptr, token_len) = self.str_parts(&args[0], scopes)?;
+        let (issuer_ptr, issuer_len) = self.str_parts(&args[1], scopes)?;
+        let (audience_ptr, audience_len) = self.str_parts(&args[2], scopes)?;
+        let (jwks_ptr, jwks_len) = self.str_parts(&args[3], scopes)?;
+
+        // A scratch `VerifiedIdentity`, written to directly by the
+        // kernel call below on success — its own field pointers *are*
+        // the kernel's `out_subject`/`out_issuer`/etc. arguments, no
+        // separate out-param locals to copy from afterward.
+        let identity_llty = self.llvm_ty(&identity_ty)?;
+        let identity_scratch = self.fresh_reg("oidc_identity_scratch");
+        self.emit_alloca(&identity_scratch, &identity_llty);
+        let field_ptr = |cg: &mut Self, field: &str| -> String {
+            let (idx, _) = cg.field_index_and_ty(&identity_ty, field).expect("VerifiedIdentity always has this field, ast::prelude_structs");
+            let ptr = cg.fresh_reg(&format!("oidc_{field}_ptr"));
+            writeln!(cg.out, "  {ptr} = getelementptr inbounds {identity_llty}, ptr {identity_scratch}, i32 0, i32 {idx}").unwrap();
+            ptr
+        };
+        let subject_ptr = field_ptr(self, "subject");
+        let issuer_ptr_out = field_ptr(self, "issuer");
+        let audience_ptr_out = field_ptr(self, "audience");
+        let expires_at_ptr = field_ptr(self, "expires_at");
+        let issued_at_ptr = field_ptr(self, "issued_at");
+        let claims_json_ptr = field_ptr(self, "claims_json");
+
+        let err_scratch = self.fresh_reg("oidc_err_scratch");
+        self.emit_alloca(&err_scratch, "{ptr, i64}");
+
+        let found = self.fresh_reg("oidc_ok");
+        writeln!(
+            self.out,
+            "  {found} = call i32 @nir_oidc_validate_token(ptr {token_ptr}, i64 {token_len}, ptr {issuer_ptr}, i64 {issuer_len}, \
+             ptr {audience_ptr}, i64 {audience_len}, ptr {jwks_ptr}, i64 {jwks_len}, ptr {subject_ptr}, ptr {issuer_ptr_out}, \
+             ptr {audience_ptr_out}, ptr {expires_at_ptr}, ptr {issued_at_ptr}, ptr {claims_json_ptr}, ptr {err_scratch})"
+        )
+        .unwrap();
+        let is_ok = self.fresh_reg("oidc_is_ok");
+        writeln!(self.out, "  {is_ok} = icmp ne i32 {found}, 0").unwrap();
+
+        let result_llty = self.llvm_ty(&result_ty)?;
+        let dest = self.fresh_reg("oidc_result.addr");
+        self.emit_alloca(&dest, &result_llty);
+        let tag_ptr = self.fresh_reg("oidc_tag_ptr");
+        writeln!(self.out, "  {tag_ptr} = getelementptr inbounds {result_llty}, ptr {dest}, i32 0, i32 0").unwrap();
+        let payload_ptr = self.fresh_reg("oidc_payload_ptr");
+        writeln!(self.out, "  {payload_ptr} = getelementptr inbounds {result_llty}, ptr {dest}, i32 0, i32 1").unwrap();
+
+        let ok_label = self.fresh_label("oidc_ok");
+        let err_label = self.fresh_label("oidc_err");
+        let merge_label = self.fresh_label("oidc_merge");
+        writeln!(self.out, "  br i1 {is_ok}, label %{ok_label}, label %{err_label}").unwrap();
+
+        writeln!(self.out, "{ok_label}:").unwrap();
+        writeln!(self.out, "  store i64 0, ptr {tag_ptr}").unwrap();
+        let identity_bytes = agg_byte_size_operand(&identity_ty, &self.registry);
+        writeln!(self.out, "  call void @llvm.memcpy.p0.p0.i64(ptr {payload_ptr}, ptr {identity_scratch}, i64 {identity_bytes}, i1 false)").unwrap();
+        writeln!(self.out, "  br label %{merge_label}").unwrap();
+
+        writeln!(self.out, "{err_label}:").unwrap();
+        writeln!(self.out, "  store i64 1, ptr {tag_ptr}").unwrap();
+        let err_val = self.fresh_reg("oidc_err_val");
+        writeln!(self.out, "  {err_val} = load {{ptr, i64}}, ptr {err_scratch}").unwrap();
+        writeln!(self.out, "  store {{ptr, i64}} {err_val}, ptr {payload_ptr}").unwrap();
+        writeln!(self.out, "  br label %{merge_label}").unwrap();
+
+        writeln!(self.out, "{merge_label}:").unwrap();
+        Ok(dest)
+    }
+
+    /// `extract_claim(identity, name) -> Result(ClaimView, str)` — real
+    /// JSON claim extraction (`nir_extract_claim`). `ClaimView`'s sole
+    /// field (`value: str`) makes this structurally identical to
+    /// `emit_check_role`: one kernel call producing a bool-shaped status
+    /// plus (on success) a single `str` out-param that *is* the whole
+    /// `Ok` payload, same tag-then-payload/br/merge shape, same
+    /// compile-time `Err` literal (unlike `oidc_validate_token`, a
+    /// missing/non-string claim has exactly one reason, so no dynamic
+    /// message is needed from the kernel).
+    fn emit_extract_claim(&mut self, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let identity_ty = Ty::Named("VerifiedIdentity".to_string(), vec![]);
+        let claim_view_ty = Ty::Named("ClaimView".to_string(), vec![]);
+        let result_ty = Ty::Named("Result".to_string(), vec![claim_view_ty.clone(), Ty::Str]);
+
+        let identity_ptr = self.expr_ptr_expected(&args[0], &identity_ty, scopes)?;
+        let (claims_idx, _) = self.field_index_and_ty(&identity_ty, "claims_json").expect("VerifiedIdentity always has claims_json, ast::prelude_structs");
+        let identity_llty = self.llvm_ty(&identity_ty)?;
+        let claims_field_ptr = self.fresh_reg("extract_claim_claims_ptr");
+        writeln!(self.out, "  {claims_field_ptr} = getelementptr inbounds {identity_llty}, ptr {identity_ptr}, i32 0, i32 {claims_idx}").unwrap();
+        let claims_val = self.fresh_reg("extract_claim_claims_val");
+        writeln!(self.out, "  {claims_val} = load {{ptr, i64}}, ptr {claims_field_ptr}").unwrap();
+        let claims_ptr = self.fresh_reg("extract_claim_claims_data_ptr");
+        writeln!(self.out, "  {claims_ptr} = extractvalue {{ptr, i64}} {claims_val}, 0").unwrap();
+        let claims_len = self.fresh_reg("extract_claim_claims_len");
+        writeln!(self.out, "  {claims_len} = extractvalue {{ptr, i64}} {claims_val}, 1").unwrap();
+
+        let (name_ptr, name_len) = self.str_parts(&args[1], scopes)?;
+
+        let out_scratch = self.fresh_reg("extract_claim_out_scratch");
+        self.emit_alloca(&out_scratch, "{ptr, i64}");
+        let found = self.fresh_reg("extract_claim_found");
+        writeln!(
+            self.out,
+            "  {found} = call i32 @nir_extract_claim(ptr {claims_ptr}, i64 {claims_len}, ptr {name_ptr}, i64 {name_len}, ptr {out_scratch})"
+        )
+        .unwrap();
+        let is_found = self.fresh_reg("extract_claim_is_found");
+        writeln!(self.out, "  {is_found} = icmp ne i32 {found}, 0").unwrap();
+
+        let result_llty = self.llvm_ty(&result_ty)?;
+        let dest = self.fresh_reg("extract_claim_result.addr");
+        self.emit_alloca(&dest, &result_llty);
+        let tag_ptr = self.fresh_reg("extract_claim_tag_ptr");
+        writeln!(self.out, "  {tag_ptr} = getelementptr inbounds {result_llty}, ptr {dest}, i32 0, i32 0").unwrap();
+        let payload_ptr = self.fresh_reg("extract_claim_payload_ptr");
+        writeln!(self.out, "  {payload_ptr} = getelementptr inbounds {result_llty}, ptr {dest}, i32 0, i32 1").unwrap();
+
+        let ok_label = self.fresh_label("extract_claim_ok");
+        let err_label = self.fresh_label("extract_claim_err");
+        let merge_label = self.fresh_label("extract_claim_merge");
+        writeln!(self.out, "  br i1 {is_found}, label %{ok_label}, label %{err_label}").unwrap();
+
+        writeln!(self.out, "{ok_label}:").unwrap();
+        writeln!(self.out, "  store i64 0, ptr {tag_ptr}").unwrap();
+        let value_val = self.fresh_reg("extract_claim_value");
+        writeln!(self.out, "  {value_val} = load {{ptr, i64}}, ptr {out_scratch}").unwrap();
+        writeln!(self.out, "  store {{ptr, i64}} {value_val}, ptr {payload_ptr}").unwrap();
+        writeln!(self.out, "  br label %{merge_label}").unwrap();
+
+        writeln!(self.out, "{err_label}:").unwrap();
+        writeln!(self.out, "  store i64 1, ptr {tag_ptr}").unwrap();
+        let msg_global = self.fresh_global("extract_claim_err_msg");
+        const MSG: &str = "claim not present in identity's claims";
+        writeln!(self.string_globals, "{msg_global} = private unnamed_addr constant [{} x i8] c\"{}\"", MSG.len(), llvm_escape_bytes(MSG.as_bytes()))
+            .unwrap();
+        let msg_partial = self.fresh_reg("extract_claim_err_msg_partial");
+        writeln!(self.out, "  {msg_partial} = insertvalue {{ptr, i64}} undef, ptr {msg_global}, 0").unwrap();
+        let msg_full = self.fresh_reg("extract_claim_err_msg_full");
+        writeln!(self.out, "  {msg_full} = insertvalue {{ptr, i64}} {msg_partial}, i64 {}, 1", MSG.len()).unwrap();
+        writeln!(self.out, "  store {{ptr, i64}} {msg_full}, ptr {payload_ptr}").unwrap();
+        writeln!(self.out, "  br label %{merge_label}").unwrap();
+
+        writeln!(self.out, "{merge_label}:").unwrap();
+        Ok(dest)
+    }
+
+    /// Shared tag-then-payload/branch/merge shape for a `Result(_, str)`
+    /// builtin whose success/failure was decided by one already-called
+    /// linked kernel — every `db`/`json` builtin below uses this
+    /// (`emit_check_role`/`emit_oidc_validate_token` predate this helper
+    /// and aren't refactored onto it, but follow the identical shape).
+    /// `is_ok`/`ok_val`/`err_val` are all already-computed SSA values by
+    /// the time this is called — `ok_val` loaded from wherever the
+    /// kernel wrote it (harmless to load unconditionally even on the
+    /// failure path: an uninitialized-but-never-dereferenced `{ptr,i64}`
+    /// bit pattern is not a memory access), `err_val` the same. Every
+    /// caller here has exactly one payload value per variant (never more
+    /// than one field), so — like `emit_check_role`'s own doc comment
+    /// already established for its single-`str`-field case — storing
+    /// directly at `payload_ptr` (word offset 0) is exactly equivalent
+    /// to `construct_variant`'s general per-field GEP addressing.
+    fn emit_result_merge(
+        &mut self,
+        result_ty: &Ty,
+        is_ok: &str,
+        ok_llty: &str,
+        ok_val: &str,
+        err_val: &str,
+        label_prefix: &str,
+    ) -> Result<String, CodegenError> {
+        let result_llty = self.llvm_ty(result_ty)?;
+        let dest = self.fresh_reg(&format!("{label_prefix}_result_addr"));
+        self.emit_alloca(&dest, &result_llty);
+        let tag_ptr = self.fresh_reg(&format!("{label_prefix}_tag_ptr"));
+        writeln!(self.out, "  {tag_ptr} = getelementptr inbounds {result_llty}, ptr {dest}, i32 0, i32 0").unwrap();
+        let payload_ptr = self.fresh_reg(&format!("{label_prefix}_payload_ptr"));
+        writeln!(self.out, "  {payload_ptr} = getelementptr inbounds {result_llty}, ptr {dest}, i32 0, i32 1").unwrap();
+
+        let ok_label = self.fresh_label(&format!("{label_prefix}_ok"));
+        let err_label = self.fresh_label(&format!("{label_prefix}_err"));
+        let merge_label = self.fresh_label(&format!("{label_prefix}_merge"));
+        writeln!(self.out, "  br i1 {is_ok}, label %{ok_label}, label %{err_label}").unwrap();
+
+        writeln!(self.out, "{ok_label}:").unwrap();
+        writeln!(self.out, "  store i64 0, ptr {tag_ptr}").unwrap();
+        writeln!(self.out, "  store {ok_llty} {ok_val}, ptr {payload_ptr}").unwrap();
+        writeln!(self.out, "  br label %{merge_label}").unwrap();
+
+        writeln!(self.out, "{err_label}:").unwrap();
+        writeln!(self.out, "  store i64 1, ptr {tag_ptr}").unwrap();
+        writeln!(self.out, "  store {{ptr, i64}} {err_val}, ptr {payload_ptr}").unwrap();
+        writeln!(self.out, "  br label %{merge_label}").unwrap();
+
+        writeln!(self.out, "{merge_label}:").unwrap();
+        Ok(dest)
+    }
+
+    /// Builds the `[N x NIR_BIND_VALUE_LLTY]` array `db_execute`/
+    /// `db_query`'s trailing `?`-placeholder arguments become
+    /// (`runtime-kernels/src/lib.rs`'s `NirBindValue`'s own doc comment
+    /// has the exact field layout this mirrors). Returns `("null", "0")`
+    /// for the zero-bind case (the bare 2-arg form) — the same "no real
+    /// buffer needed when the length says not to dereference it"
+    /// convention `sha256_hex`'s 1-arg form already established for
+    /// `b_ptr`/`b_len`.
+    fn emit_db_binds(&mut self, binds: &[Expr], scopes: &mut Scopes) -> Result<(String, String), CodegenError> {
+        if binds.is_empty() {
+            return Ok(("null".to_string(), "0".to_string()));
+        }
+        let n = binds.len();
+        let arr_llty = format!("[{n} x {NIR_BIND_VALUE_LLTY}]");
+        let arr_ptr = self.fresh_reg("db_binds_arr");
+        self.emit_alloca(&arr_ptr, &arr_llty);
+        for (i, arg) in binds.iter().enumerate() {
+            let elem_ptr = self.fresh_reg("db_bind_elem_ptr");
+            writeln!(self.out, "  {elem_ptr} = getelementptr inbounds {arr_llty}, ptr {arr_ptr}, i32 0, i32 {i}").unwrap();
+            let tag_ptr = self.fresh_reg("db_bind_tag_ptr");
+            writeln!(self.out, "  {tag_ptr} = getelementptr inbounds {NIR_BIND_VALUE_LLTY}, ptr {elem_ptr}, i32 0, i32 0").unwrap();
+            let i_ptr = self.fresh_reg("db_bind_i_ptr");
+            writeln!(self.out, "  {i_ptr} = getelementptr inbounds {NIR_BIND_VALUE_LLTY}, ptr {elem_ptr}, i32 0, i32 1").unwrap();
+            let f_ptr = self.fresh_reg("db_bind_f_ptr");
+            writeln!(self.out, "  {f_ptr} = getelementptr inbounds {NIR_BIND_VALUE_LLTY}, ptr {elem_ptr}, i32 0, i32 2").unwrap();
+            let sptr_ptr = self.fresh_reg("db_bind_sptr_ptr");
+            writeln!(self.out, "  {sptr_ptr} = getelementptr inbounds {NIR_BIND_VALUE_LLTY}, ptr {elem_ptr}, i32 0, i32 3").unwrap();
+            let slen_ptr = self.fresh_reg("db_bind_slen_ptr");
+            writeln!(self.out, "  {slen_ptr} = getelementptr inbounds {NIR_BIND_VALUE_LLTY}, ptr {elem_ptr}, i32 0, i32 4").unwrap();
+
+            // Zero every field first, so the kernel never reads a stale/
+            // uninitialized value out of the field(s) this arg's own
+            // tag doesn't select.
+            writeln!(self.out, "  store i64 0, ptr {i_ptr}").unwrap();
+            writeln!(self.out, "  store double 0.0, ptr {f_ptr}").unwrap();
+            writeln!(self.out, "  store ptr null, ptr {sptr_ptr}").unwrap();
+            writeln!(self.out, "  store i64 0, ptr {slen_ptr}").unwrap();
+
+            let arg_ty = self.local_ty_of(arg, scopes);
+            if arg_ty == Ty::Str {
+                writeln!(self.out, "  store i32 2, ptr {tag_ptr}").unwrap();
+                let (ptr, len) = self.str_parts(arg, scopes)?;
+                writeln!(self.out, "  store ptr {ptr}, ptr {sptr_ptr}").unwrap();
+                writeln!(self.out, "  store i64 {len}, ptr {slen_ptr}").unwrap();
+            } else if arg_ty == Ty::F64 {
+                writeln!(self.out, "  store i32 1, ptr {tag_ptr}").unwrap();
+                let v = self.expr(arg, scopes)?;
+                writeln!(self.out, "  store double {v}, ptr {f_ptr}").unwrap();
+            } else if arg_ty == Ty::Bool {
+                writeln!(self.out, "  store i32 3, ptr {tag_ptr}").unwrap();
+                let v = self.expr(arg, scopes)?;
+                let widened = self.fresh_reg("db_bind_bool_widened");
+                writeln!(self.out, "  {widened} = zext i1 {v} to i64").unwrap();
+                writeln!(self.out, "  store i64 {widened}, ptr {i_ptr}").unwrap();
+            } else {
+                // Every other bind-value type `typeck.rs`'s `infer` (not
+                // `check`) allowed through is some integer width — widen
+                // to i64 the same way every other integer-typed value
+                // already does on its way into a linked kernel call.
+                writeln!(self.out, "  store i32 0, ptr {tag_ptr}").unwrap();
+                let v = self.expr(arg, scopes)?;
+                let widened = self.widen_to_i64(&v, &arg_ty);
+                writeln!(self.out, "  store i64 {widened}, ptr {i_ptr}").unwrap();
+            }
+        }
+        Ok((arr_ptr, n.to_string()))
+    }
+
+    /// `db_connect(path) -> Result(db, str)`.
+    fn emit_db_connect(&mut self, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let result_ty = Ty::Named("Result".to_string(), vec![Ty::Db, Ty::Str]);
+        let (path_ptr, path_len) = self.str_parts(&args[0], scopes)?;
+        let handle_scratch = self.fresh_reg("db_connect_handle_scratch");
+        self.emit_alloca(&handle_scratch, "i64");
+        let err_scratch = self.fresh_reg("db_connect_err_scratch");
+        self.emit_alloca(&err_scratch, "{ptr, i64}");
+        let found = self.fresh_reg("db_connect_ok");
+        writeln!(self.out, "  {found} = call i32 @nir_db_connect(ptr {path_ptr}, i64 {path_len}, ptr {handle_scratch}, ptr {err_scratch})").unwrap();
+        let is_ok = self.icmp("ne", "i32", &found, "0")?;
+        let handle_val = self.fresh_reg("db_connect_handle");
+        writeln!(self.out, "  {handle_val} = load i64, ptr {handle_scratch}").unwrap();
+        let err_val = self.fresh_reg("db_connect_err_val");
+        writeln!(self.out, "  {err_val} = load {{ptr, i64}}, ptr {err_scratch}").unwrap();
+        self.emit_result_merge(&result_ty, &is_ok, "i64", &handle_val, &err_val, "db_connect")
+    }
+
+    /// `db_execute(conn, sql, ...binds) -> Result(i64, str)` — everything
+    /// except `SELECT`; the affected-row count.
+    fn emit_db_execute(&mut self, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let result_ty = Ty::Named("Result".to_string(), vec![Ty::I64, Ty::Str]);
+        let conn = self.expr(&args[0], scopes)?; // Ty::Db is scalar (i64), not aggregate
+        let (sql_ptr, sql_len) = self.str_parts(&args[1], scopes)?;
+        let (binds_ptr, binds_len) = self.emit_db_binds(&args[2..], scopes)?;
+        let affected_scratch = self.fresh_reg("db_execute_affected_scratch");
+        self.emit_alloca(&affected_scratch, "i64");
+        let err_scratch = self.fresh_reg("db_execute_err_scratch");
+        self.emit_alloca(&err_scratch, "{ptr, i64}");
+        let found = self.fresh_reg("db_execute_ok");
+        writeln!(
+            self.out,
+            "  {found} = call i32 @nir_db_execute(i64 {conn}, ptr {sql_ptr}, i64 {sql_len}, ptr {binds_ptr}, i64 {binds_len}, ptr {affected_scratch}, ptr {err_scratch})"
+        )
+        .unwrap();
+        let is_ok = self.icmp("ne", "i32", &found, "0")?;
+        let affected_val = self.fresh_reg("db_execute_affected");
+        writeln!(self.out, "  {affected_val} = load i64, ptr {affected_scratch}").unwrap();
+        let err_val = self.fresh_reg("db_execute_err_val");
+        writeln!(self.out, "  {err_val} = load {{ptr, i64}}, ptr {err_scratch}").unwrap();
+        self.emit_result_merge(&result_ty, &is_ok, "i64", &affected_val, &err_val, "db_execute")
+    }
+
+    /// `db_query(conn, sql, ...binds) -> Result(json, str)` — `SELECT`
+    /// statements; every row comes back as one JSON object, the whole
+    /// result set a JSON array (`nir_db_query`'s own doc comment).
+    fn emit_db_query(&mut self, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let result_ty = Ty::Named("Result".to_string(), vec![Ty::Json, Ty::Str]);
+        let conn = self.expr(&args[0], scopes)?;
+        let (sql_ptr, sql_len) = self.str_parts(&args[1], scopes)?;
+        let (binds_ptr, binds_len) = self.emit_db_binds(&args[2..], scopes)?;
+        let json_scratch = self.fresh_reg("db_query_json_scratch");
+        self.emit_alloca(&json_scratch, "{ptr, i64}");
+        let err_scratch = self.fresh_reg("db_query_err_scratch");
+        self.emit_alloca(&err_scratch, "{ptr, i64}");
+        let found = self.fresh_reg("db_query_ok");
+        writeln!(
+            self.out,
+            "  {found} = call i32 @nir_db_query(i64 {conn}, ptr {sql_ptr}, i64 {sql_len}, ptr {binds_ptr}, i64 {binds_len}, ptr {json_scratch}, ptr {err_scratch})"
+        )
+        .unwrap();
+        let is_ok = self.icmp("ne", "i32", &found, "0")?;
+        let json_val = self.fresh_reg("db_query_json");
+        writeln!(self.out, "  {json_val} = load {{ptr, i64}}, ptr {json_scratch}").unwrap();
+        let err_val = self.fresh_reg("db_query_err_val");
+        writeln!(self.out, "  {err_val} = load {{ptr, i64}}, ptr {err_scratch}").unwrap();
+        self.emit_result_merge(&result_ty, &is_ok, "{ptr, i64}", &json_val, &err_val, "db_query")
+    }
+
+    /// `json_parse(s) -> Result(json, str)` — an identity function on
+    /// success under this representation (`Ty::Json` compiles as `s`'s
+    /// own raw text, `Ty::Json`'s `llvm_ty` arm), so only validity needs
+    /// checking; the `Ok` payload reuses `s`'s own already-computed
+    /// `{ptr, i64}` value directly rather than re-evaluating `s`.
+    fn emit_json_parse(&mut self, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let result_ty = Ty::Named("Result".to_string(), vec![Ty::Json, Ty::Str]);
+        let json_val = self.expr(&args[0], scopes)?;
+        let json_ptr = self.fresh_reg("json_parse_ptr");
+        writeln!(self.out, "  {json_ptr} = extractvalue {{ptr, i64}} {json_val}, 0").unwrap();
+        let json_len = self.fresh_reg("json_parse_len");
+        writeln!(self.out, "  {json_len} = extractvalue {{ptr, i64}} {json_val}, 1").unwrap();
+        let err_scratch = self.fresh_reg("json_parse_err_scratch");
+        self.emit_alloca(&err_scratch, "{ptr, i64}");
+        let found = self.fresh_reg("json_parse_ok");
+        writeln!(self.out, "  {found} = call i32 @nir_json_validate(ptr {json_ptr}, i64 {json_len}, ptr {err_scratch})").unwrap();
+        let is_ok = self.icmp("ne", "i32", &found, "0")?;
+        let err_val = self.fresh_reg("json_parse_err_val");
+        writeln!(self.out, "  {err_val} = load {{ptr, i64}}, ptr {err_scratch}").unwrap();
+        self.emit_result_merge(&result_ty, &is_ok, "{ptr, i64}", &json_val, &err_val, "json_parse")
+    }
+
+    /// `json_get(doc, key) -> Result(json, str)`.
+    fn emit_json_get(&mut self, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let result_ty = Ty::Named("Result".to_string(), vec![Ty::Json, Ty::Str]);
+        let (doc_ptr, doc_len) = self.str_parts(&args[0], scopes)?;
+        let (key_ptr, key_len) = self.str_parts(&args[1], scopes)?;
+        let json_scratch = self.fresh_reg("json_get_json_scratch");
+        self.emit_alloca(&json_scratch, "{ptr, i64}");
+        let err_scratch = self.fresh_reg("json_get_err_scratch");
+        self.emit_alloca(&err_scratch, "{ptr, i64}");
+        let found = self.fresh_reg("json_get_ok");
+        writeln!(self.out, "  {found} = call i32 @nir_json_get(ptr {doc_ptr}, i64 {doc_len}, ptr {key_ptr}, i64 {key_len}, ptr {json_scratch}, ptr {err_scratch})").unwrap();
+        let is_ok = self.icmp("ne", "i32", &found, "0")?;
+        let json_val = self.fresh_reg("json_get_json_val");
+        writeln!(self.out, "  {json_val} = load {{ptr, i64}}, ptr {json_scratch}").unwrap();
+        let err_val = self.fresh_reg("json_get_err_val");
+        writeln!(self.out, "  {err_val} = load {{ptr, i64}}, ptr {err_scratch}").unwrap();
+        self.emit_result_merge(&result_ty, &is_ok, "{ptr, i64}", &json_val, &err_val, "json_get")
+    }
+
+    /// `json_array_get(doc, idx) -> Result(json, str)` — same shape as
+    /// `json_get`, indexed by position instead of key.
+    fn emit_json_array_get(&mut self, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let result_ty = Ty::Named("Result".to_string(), vec![Ty::Json, Ty::Str]);
+        let (doc_ptr, doc_len) = self.str_parts(&args[0], scopes)?;
+        let idx = self.expr(&args[1], scopes)?;
+        let json_scratch = self.fresh_reg("json_array_get_json_scratch");
+        self.emit_alloca(&json_scratch, "{ptr, i64}");
+        let err_scratch = self.fresh_reg("json_array_get_err_scratch");
+        self.emit_alloca(&err_scratch, "{ptr, i64}");
+        let found = self.fresh_reg("json_array_get_ok");
+        writeln!(self.out, "  {found} = call i32 @nir_json_array_get(ptr {doc_ptr}, i64 {doc_len}, i64 {idx}, ptr {json_scratch}, ptr {err_scratch})").unwrap();
+        let is_ok = self.icmp("ne", "i32", &found, "0")?;
+        let json_val = self.fresh_reg("json_array_get_json_val");
+        writeln!(self.out, "  {json_val} = load {{ptr, i64}}, ptr {json_scratch}").unwrap();
+        let err_val = self.fresh_reg("json_array_get_err_val");
+        writeln!(self.out, "  {err_val} = load {{ptr, i64}}, ptr {err_scratch}").unwrap();
+        self.emit_result_merge(&result_ty, &is_ok, "{ptr, i64}", &json_val, &err_val, "json_array_get")
+    }
+
+    /// `json_array_len(doc) -> Result(i64, str)`.
+    fn emit_json_array_len(&mut self, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let result_ty = Ty::Named("Result".to_string(), vec![Ty::I64, Ty::Str]);
+        let (doc_ptr, doc_len) = self.str_parts(&args[0], scopes)?;
+        let value_scratch = self.fresh_reg("json_array_len_value_scratch");
+        self.emit_alloca(&value_scratch, "i64");
+        let err_scratch = self.fresh_reg("json_array_len_err_scratch");
+        self.emit_alloca(&err_scratch, "{ptr, i64}");
+        let found = self.fresh_reg("json_array_len_ok");
+        writeln!(self.out, "  {found} = call i32 @nir_json_array_len(ptr {doc_ptr}, i64 {doc_len}, ptr {value_scratch}, ptr {err_scratch})").unwrap();
+        let is_ok = self.icmp("ne", "i32", &found, "0")?;
+        let value_val = self.fresh_reg("json_array_len_value");
+        writeln!(self.out, "  {value_val} = load i64, ptr {value_scratch}").unwrap();
+        let err_val = self.fresh_reg("json_array_len_err_val");
+        writeln!(self.out, "  {err_val} = load {{ptr, i64}}, ptr {err_scratch}").unwrap();
+        self.emit_result_merge(&result_ty, &is_ok, "i64", &value_val, &err_val, "json_array_len")
+    }
+
+    /// `json_get_str(doc, key) -> Result(str, str)`.
+    fn emit_json_get_str(&mut self, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let result_ty = Ty::Named("Result".to_string(), vec![Ty::Str, Ty::Str]);
+        let (doc_ptr, doc_len) = self.str_parts(&args[0], scopes)?;
+        let (key_ptr, key_len) = self.str_parts(&args[1], scopes)?;
+        let value_scratch = self.fresh_reg("json_get_str_value_scratch");
+        self.emit_alloca(&value_scratch, "{ptr, i64}");
+        let err_scratch = self.fresh_reg("json_get_str_err_scratch");
+        self.emit_alloca(&err_scratch, "{ptr, i64}");
+        let found = self.fresh_reg("json_get_str_ok");
+        writeln!(self.out, "  {found} = call i32 @nir_json_get_str(ptr {doc_ptr}, i64 {doc_len}, ptr {key_ptr}, i64 {key_len}, ptr {value_scratch}, ptr {err_scratch})").unwrap();
+        let is_ok = self.icmp("ne", "i32", &found, "0")?;
+        let value_val = self.fresh_reg("json_get_str_value");
+        writeln!(self.out, "  {value_val} = load {{ptr, i64}}, ptr {value_scratch}").unwrap();
+        let err_val = self.fresh_reg("json_get_str_err_val");
+        writeln!(self.out, "  {err_val} = load {{ptr, i64}}, ptr {err_scratch}").unwrap();
+        self.emit_result_merge(&result_ty, &is_ok, "{ptr, i64}", &value_val, &err_val, "json_get_str")
+    }
+
+    /// `json_get_i64(doc, key) -> Result(i64, str)`.
+    fn emit_json_get_i64(&mut self, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let result_ty = Ty::Named("Result".to_string(), vec![Ty::I64, Ty::Str]);
+        let (doc_ptr, doc_len) = self.str_parts(&args[0], scopes)?;
+        let (key_ptr, key_len) = self.str_parts(&args[1], scopes)?;
+        let value_scratch = self.fresh_reg("json_get_i64_value_scratch");
+        self.emit_alloca(&value_scratch, "i64");
+        let err_scratch = self.fresh_reg("json_get_i64_err_scratch");
+        self.emit_alloca(&err_scratch, "{ptr, i64}");
+        let found = self.fresh_reg("json_get_i64_ok");
+        writeln!(self.out, "  {found} = call i32 @nir_json_get_i64(ptr {doc_ptr}, i64 {doc_len}, ptr {key_ptr}, i64 {key_len}, ptr {value_scratch}, ptr {err_scratch})").unwrap();
+        let is_ok = self.icmp("ne", "i32", &found, "0")?;
+        let value_val = self.fresh_reg("json_get_i64_value");
+        writeln!(self.out, "  {value_val} = load i64, ptr {value_scratch}").unwrap();
+        let err_val = self.fresh_reg("json_get_i64_err_val");
+        writeln!(self.out, "  {err_val} = load {{ptr, i64}}, ptr {err_scratch}").unwrap();
+        self.emit_result_merge(&result_ty, &is_ok, "i64", &value_val, &err_val, "json_get_i64")
+    }
+
+    /// `json_get_f64(doc, key) -> Result(f64, str)`.
+    fn emit_json_get_f64(&mut self, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let result_ty = Ty::Named("Result".to_string(), vec![Ty::F64, Ty::Str]);
+        let (doc_ptr, doc_len) = self.str_parts(&args[0], scopes)?;
+        let (key_ptr, key_len) = self.str_parts(&args[1], scopes)?;
+        let value_scratch = self.fresh_reg("json_get_f64_value_scratch");
+        self.emit_alloca(&value_scratch, "double");
+        let err_scratch = self.fresh_reg("json_get_f64_err_scratch");
+        self.emit_alloca(&err_scratch, "{ptr, i64}");
+        let found = self.fresh_reg("json_get_f64_ok");
+        writeln!(self.out, "  {found} = call i32 @nir_json_get_f64(ptr {doc_ptr}, i64 {doc_len}, ptr {key_ptr}, i64 {key_len}, ptr {value_scratch}, ptr {err_scratch})").unwrap();
+        let is_ok = self.icmp("ne", "i32", &found, "0")?;
+        let value_val = self.fresh_reg("json_get_f64_value");
+        writeln!(self.out, "  {value_val} = load double, ptr {value_scratch}").unwrap();
+        let err_val = self.fresh_reg("json_get_f64_err_val");
+        writeln!(self.out, "  {err_val} = load {{ptr, i64}}, ptr {err_scratch}").unwrap();
+        self.emit_result_merge(&result_ty, &is_ok, "double", &value_val, &err_val, "json_get_f64")
+    }
+
+    /// `json_get_bool(doc, key) -> Result(bool, str)`.
+    fn emit_json_get_bool(&mut self, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let result_ty = Ty::Named("Result".to_string(), vec![Ty::Bool, Ty::Str]);
+        let (doc_ptr, doc_len) = self.str_parts(&args[0], scopes)?;
+        let (key_ptr, key_len) = self.str_parts(&args[1], scopes)?;
+        let value_scratch = self.fresh_reg("json_get_bool_value_scratch");
+        self.emit_alloca(&value_scratch, "i32");
+        let err_scratch = self.fresh_reg("json_get_bool_err_scratch");
+        self.emit_alloca(&err_scratch, "{ptr, i64}");
+        let found = self.fresh_reg("json_get_bool_ok");
+        writeln!(self.out, "  {found} = call i32 @nir_json_get_bool(ptr {doc_ptr}, i64 {doc_len}, ptr {key_ptr}, i64 {key_len}, ptr {value_scratch}, ptr {err_scratch})").unwrap();
+        let is_ok = self.icmp("ne", "i32", &found, "0")?;
+        let raw = self.fresh_reg("json_get_bool_raw");
+        writeln!(self.out, "  {raw} = load i32, ptr {value_scratch}").unwrap();
+        let value_val = self.icmp("ne", "i32", &raw, "0")?;
+        let err_val = self.fresh_reg("json_get_bool_err_val");
+        writeln!(self.out, "  {err_val} = load {{ptr, i64}}, ptr {err_scratch}").unwrap();
+        self.emit_result_merge(&result_ty, &is_ok, "i1", &value_val, &err_val, "json_get_bool")
+    }
+
+    /// `json_set_str(doc, key, value) -> Result(json, str)`.
+    fn emit_json_set_str(&mut self, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let result_ty = Ty::Named("Result".to_string(), vec![Ty::Json, Ty::Str]);
+        let (doc_ptr, doc_len) = self.str_parts(&args[0], scopes)?;
+        let (key_ptr, key_len) = self.str_parts(&args[1], scopes)?;
+        let (value_ptr, value_len) = self.str_parts(&args[2], scopes)?;
+        let json_scratch = self.fresh_reg("json_set_str_json_scratch");
+        self.emit_alloca(&json_scratch, "{ptr, i64}");
+        let err_scratch = self.fresh_reg("json_set_str_err_scratch");
+        self.emit_alloca(&err_scratch, "{ptr, i64}");
+        let found = self.fresh_reg("json_set_str_ok");
+        writeln!(
+            self.out,
+            "  {found} = call i32 @nir_json_set_str(ptr {doc_ptr}, i64 {doc_len}, ptr {key_ptr}, i64 {key_len}, ptr {value_ptr}, i64 {value_len}, ptr {json_scratch}, ptr {err_scratch})"
+        )
+        .unwrap();
+        let is_ok = self.icmp("ne", "i32", &found, "0")?;
+        let json_val = self.fresh_reg("json_set_str_json_val");
+        writeln!(self.out, "  {json_val} = load {{ptr, i64}}, ptr {json_scratch}").unwrap();
+        let err_val = self.fresh_reg("json_set_str_err_val");
+        writeln!(self.out, "  {err_val} = load {{ptr, i64}}, ptr {err_scratch}").unwrap();
+        self.emit_result_merge(&result_ty, &is_ok, "{ptr, i64}", &json_val, &err_val, "json_set_str")
+    }
+
+    /// `mq_connect(host, port) -> Result(mq, str)`.
+    fn emit_mq_connect(&mut self, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let result_ty = Ty::Named("Result".to_string(), vec![Ty::Mq, Ty::Str]);
+        let (host_ptr, host_len) = self.str_parts(&args[0], scopes)?;
+        let port = self.expr(&args[1], scopes)?;
+        let handle_scratch = self.fresh_reg("mq_connect_handle_scratch");
+        self.emit_alloca(&handle_scratch, "i64");
+        let err_scratch = self.fresh_reg("mq_connect_err_scratch");
+        self.emit_alloca(&err_scratch, "{ptr, i64}");
+        let found = self.fresh_reg("mq_connect_ok");
+        writeln!(self.out, "  {found} = call i32 @nir_mq_connect(ptr {host_ptr}, i64 {host_len}, i64 {port}, ptr {handle_scratch}, ptr {err_scratch})").unwrap();
+        let is_ok = self.icmp("ne", "i32", &found, "0")?;
+        let handle_val = self.fresh_reg("mq_connect_handle");
+        writeln!(self.out, "  {handle_val} = load i64, ptr {handle_scratch}").unwrap();
+        let err_val = self.fresh_reg("mq_connect_err_val");
+        writeln!(self.out, "  {err_val} = load {{ptr, i64}}, ptr {err_scratch}").unwrap();
+        self.emit_result_merge(&result_ty, &is_ok, "i64", &handle_val, &err_val, "mq_connect")
+    }
+
+    /// `mq_publish(conn, queue, message) -> Result(unit, str)`.
+    fn emit_mq_publish(&mut self, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let result_ty = Ty::Named("Result".to_string(), vec![Ty::Unit, Ty::Str]);
+        let conn = self.expr(&args[0], scopes)?;
+        let (queue_ptr, queue_len) = self.str_parts(&args[1], scopes)?;
+        let (msg_ptr, msg_len) = self.str_parts(&args[2], scopes)?;
+        let err_scratch = self.fresh_reg("mq_publish_err_scratch");
+        self.emit_alloca(&err_scratch, "{ptr, i64}");
+        let found = self.fresh_reg("mq_publish_ok");
+        writeln!(self.out, "  {found} = call i32 @nir_mq_publish(i64 {conn}, ptr {queue_ptr}, i64 {queue_len}, ptr {msg_ptr}, i64 {msg_len}, ptr {err_scratch})").unwrap();
+        let is_ok = self.icmp("ne", "i32", &found, "0")?;
+        let err_val = self.fresh_reg("mq_publish_err_val");
+        writeln!(self.out, "  {err_val} = load {{ptr, i64}}, ptr {err_scratch}").unwrap();
+        // `unit`'s own value is always the same placeholder `i64 0`
+        // every other unit-returning site in this file already uses.
+        self.emit_result_merge(&result_ty, &is_ok, "i64", "0", &err_val, "mq_publish")
+    }
+
+    /// `mq_consume(conn, queue, timeout_secs) -> Result(str, str)`.
+    fn emit_mq_consume(&mut self, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let result_ty = Ty::Named("Result".to_string(), vec![Ty::Str, Ty::Str]);
+        let conn = self.expr(&args[0], scopes)?;
+        let (queue_ptr, queue_len) = self.str_parts(&args[1], scopes)?;
+        let timeout_secs = self.expr(&args[2], scopes)?;
+        let msg_scratch = self.fresh_reg("mq_consume_msg_scratch");
+        self.emit_alloca(&msg_scratch, "{ptr, i64}");
+        let err_scratch = self.fresh_reg("mq_consume_err_scratch");
+        self.emit_alloca(&err_scratch, "{ptr, i64}");
+        let found = self.fresh_reg("mq_consume_ok");
+        writeln!(
+            self.out,
+            "  {found} = call i32 @nir_mq_consume(i64 {conn}, ptr {queue_ptr}, i64 {queue_len}, i64 {timeout_secs}, ptr {msg_scratch}, ptr {err_scratch})"
+        )
+        .unwrap();
+        let is_ok = self.icmp("ne", "i32", &found, "0")?;
+        let msg_val = self.fresh_reg("mq_consume_msg");
+        writeln!(self.out, "  {msg_val} = load {{ptr, i64}}, ptr {msg_scratch}").unwrap();
+        let err_val = self.fresh_reg("mq_consume_err_val");
+        writeln!(self.out, "  {err_val} = load {{ptr, i64}}, ptr {err_scratch}").unwrap();
+        self.emit_result_merge(&result_ty, &is_ok, "{ptr, i64}", &msg_val, &err_val, "mq_consume")
+    }
+
+    /// `http_get`/`http_post`/`https_get`/`https_post` — shared shape,
+    /// differing only in which kernel is linked and whether a request
+    /// `body` argument exists. `HttpResponse { status: i64, body: str }`
+    /// is a real two-field struct payload (unlike every other builtin in
+    /// this file's own `emit_result_merge` uses, which all have exactly
+    /// one payload value) — built in a scratch alloca via `field_index_
+    /// and_ty`/GEP (the same shape `emit_oidc_validate_token` already
+    /// uses for its own multi-field `VerifiedIdentity` payload), then
+    /// `memcpy`'d into the `Result`'s payload directly rather than going
+    /// through `emit_result_merge` at all.
+    fn emit_http_call(&mut self, kernel_name: &str, args: &[Expr], has_body: bool, scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let http_response_ty = Ty::Named("HttpResponse".to_string(), vec![]);
+        let result_ty = Ty::Named("Result".to_string(), vec![http_response_ty.clone(), Ty::Str]);
+
+        let (host_ptr, host_len) = self.str_parts(&args[0], scopes)?;
+        let port = self.expr(&args[1], scopes)?;
+        let (path_ptr, path_len) = self.str_parts(&args[2], scopes)?;
+
+        let status_scratch = self.fresh_reg("http_status_scratch");
+        self.emit_alloca(&status_scratch, "i64");
+        let body_scratch = self.fresh_reg("http_body_scratch");
+        self.emit_alloca(&body_scratch, "{ptr, i64}");
+        let err_scratch = self.fresh_reg("http_err_scratch");
+        self.emit_alloca(&err_scratch, "{ptr, i64}");
+
+        let found = self.fresh_reg("http_ok");
+        if has_body {
+            let (req_body_ptr, req_body_len) = self.str_parts(&args[3], scopes)?;
+            writeln!(
+                self.out,
+                "  {found} = call i32 @{kernel_name}(ptr {host_ptr}, i64 {host_len}, i64 {port}, ptr {path_ptr}, i64 {path_len}, \
+                 ptr {req_body_ptr}, i64 {req_body_len}, ptr {status_scratch}, ptr {body_scratch}, ptr {err_scratch})"
+            )
+            .unwrap();
+        } else {
+            writeln!(
+                self.out,
+                "  {found} = call i32 @{kernel_name}(ptr {host_ptr}, i64 {host_len}, i64 {port}, ptr {path_ptr}, i64 {path_len}, \
+                 ptr {status_scratch}, ptr {body_scratch}, ptr {err_scratch})"
+            )
+            .unwrap();
+        }
+        let is_ok = self.icmp("ne", "i32", &found, "0")?;
+
+        let http_llty = self.llvm_ty(&http_response_ty)?;
+        let http_scratch = self.fresh_reg("http_response_scratch");
+        self.emit_alloca(&http_scratch, &http_llty);
+        let (status_idx, _) =
+            self.field_index_and_ty(&http_response_ty, "status").expect("HttpResponse always has status, ast::prelude_structs");
+        let (body_idx, _) = self.field_index_and_ty(&http_response_ty, "body").expect("HttpResponse always has body, ast::prelude_structs");
+        let status_field_ptr = self.fresh_reg("http_status_field_ptr");
+        writeln!(self.out, "  {status_field_ptr} = getelementptr inbounds {http_llty}, ptr {http_scratch}, i32 0, i32 {status_idx}").unwrap();
+        let status_val = self.fresh_reg("http_status_val");
+        writeln!(self.out, "  {status_val} = load i64, ptr {status_scratch}").unwrap();
+        writeln!(self.out, "  store i64 {status_val}, ptr {status_field_ptr}").unwrap();
+        let body_field_ptr = self.fresh_reg("http_body_field_ptr");
+        writeln!(self.out, "  {body_field_ptr} = getelementptr inbounds {http_llty}, ptr {http_scratch}, i32 0, i32 {body_idx}").unwrap();
+        let body_val = self.fresh_reg("http_body_val");
+        writeln!(self.out, "  {body_val} = load {{ptr, i64}}, ptr {body_scratch}").unwrap();
+        writeln!(self.out, "  store {{ptr, i64}} {body_val}, ptr {body_field_ptr}").unwrap();
+
+        let err_val = self.fresh_reg("http_err_val");
+        writeln!(self.out, "  {err_val} = load {{ptr, i64}}, ptr {err_scratch}").unwrap();
+
+        let result_llty = self.llvm_ty(&result_ty)?;
+        let dest = self.fresh_reg("http_result_addr");
+        self.emit_alloca(&dest, &result_llty);
+        let tag_ptr = self.fresh_reg("http_tag_ptr");
+        writeln!(self.out, "  {tag_ptr} = getelementptr inbounds {result_llty}, ptr {dest}, i32 0, i32 0").unwrap();
+        let payload_ptr = self.fresh_reg("http_payload_ptr");
+        writeln!(self.out, "  {payload_ptr} = getelementptr inbounds {result_llty}, ptr {dest}, i32 0, i32 1").unwrap();
+
+        let ok_label = self.fresh_label("http_ok");
+        let err_label = self.fresh_label("http_err");
+        let merge_label = self.fresh_label("http_merge");
+        writeln!(self.out, "  br i1 {is_ok}, label %{ok_label}, label %{err_label}").unwrap();
+
+        writeln!(self.out, "{ok_label}:").unwrap();
+        writeln!(self.out, "  store i64 0, ptr {tag_ptr}").unwrap();
+        let http_bytes = agg_byte_size_operand(&http_response_ty, &self.registry);
+        writeln!(self.out, "  call void @llvm.memcpy.p0.p0.i64(ptr {payload_ptr}, ptr {http_scratch}, i64 {http_bytes}, i1 false)").unwrap();
+        writeln!(self.out, "  br label %{merge_label}").unwrap();
+
+        writeln!(self.out, "{err_label}:").unwrap();
+        writeln!(self.out, "  store i64 1, ptr {tag_ptr}").unwrap();
+        writeln!(self.out, "  store {{ptr, i64}} {err_val}, ptr {payload_ptr}").unwrap();
+        writeln!(self.out, "  br label %{merge_label}").unwrap();
+
+        writeln!(self.out, "{merge_label}:").unwrap();
+        Ok(dest)
+    }
+
+    /// Calls a `transact` slot's callee — always a plain top-level `fn`,
+    /// never a builtin (`typeck::infer_transact_slot`'s own doc comment)
+    /// — and hands back its value plus its declared return type,
+    /// regardless of whether that type is aggregate or scalar. Every
+    /// other call site in this file already picks `call()` vs.
+    /// `call_ptr()` based on the *caller's* own known context (an
+    /// expected type, an aggregate check done ahead of time); a
+    /// `transact` slot has neither — `precheck`/`verify`'s return type is
+    /// fixed at `bool` but `commit`/`compensate`/`log`'s is genuinely
+    /// unconstrained (`docs/TRANSACT.md`'s own decision) — so this is the
+    /// one call site in `emit_transact` that has to branch on
+    /// `sig_ret.is_aggregate()` itself, mirroring `call()`'s and
+    /// `call_ptr()`'s own near-identical tails rather than forcing every
+    /// slot through one or the other ahead of time.
+    fn emit_transact_call(&mut self, slot: &TransactSlot, scopes: &mut Scopes) -> Result<(String, Ty), CodegenError> {
+        let sig_params = self.sigs.get(&slot.name).expect("typeck.rs already resolved this call").params.clone();
+        let sig_ret = self.sigs.get(&slot.name).expect("typeck.rs already resolved this call").ret.clone();
+        let arg_vals = self.call_args(&slot.args, &sig_params, scopes)?;
+        if sig_ret.is_aggregate() {
+            let agg_llty = self.llvm_ty(&sig_ret)?;
+            let dest = self.fresh_reg("transact_call_result_addr");
+            self.emit_alloca(&dest, &agg_llty);
+            let mut all_args = vec![format!("ptr {dest}")];
+            all_args.extend(arg_vals);
+            writeln!(self.out, "  call void @{}({})", slot.name, all_args.join(", ")).unwrap();
+            Ok((dest, sig_ret))
+        } else {
+            let ret_llty = self.llvm_ty(&sig_ret)?;
+            if ret_llty == "void" {
+                writeln!(self.out, "  call void @{}({})", slot.name, arg_vals.join(", ")).unwrap();
+                Ok(("0".to_string(), sig_ret))
+            } else {
+                let r = self.fresh_reg("transact_call_result");
+                writeln!(self.out, "  {r} = call {ret_llty} @{}({})", slot.name, arg_vals.join(", ")).unwrap();
+                Ok((self.widen_to_i64(&r, &sig_ret), sig_ret))
+            }
+        }
+    }
+
+    /// `transact { precheck?/network/verify/commit/compensate?/log? }` —
+    /// `docs/TRANSACT.md`, compiled for real 2026-09, Layer 1 only (the
+    /// same scope the now-deleted interpreter itself shipped *first*,
+    /// before retry/timeout/durability/replay — "layers, not a syntax
+    /// spec," the doc's own section title). Real, compiled control flow:
+    /// `txn_id` generated (`nir_transact_gen_txn_id`), `precheck` (if
+    /// present) aborting the whole block to `false` immediately on a
+    /// `false` return, `network`/`verify` becoming real implicit local
+    /// bindings later slots' arguments resolve through the ordinary
+    /// `Expr::Ident`/`scopes` mechanism (no special-casing needed there —
+    /// `call_args`'s existing argument evaluation already handles it),
+    /// `verify`'s result choosing `commit` or `compensate`, `log` (if
+    /// present) always running last. The whole expression is a real
+    /// `i1` value, `true`/`false` exactly as documented.
+    ///
+    /// **Deliberately not attempted here, and not simply deferred by
+    /// oversight — architecturally blocked by the compiled trap model,
+    /// found while designing this, not assumed in advance:** `network`'s
+    /// `retry`/`timeout` modifiers (rejected explicitly in
+    /// `check_expr`'s pre-pass, with a specific reason, before this
+    /// function is ever reached). The interpreter's own retry-on-trap
+    /// semantics relied on catching an internal `RuntimeError` before it
+    /// ever unwound; a compiled trap calls `abort()` directly (every
+    /// `guard_*` in this file), an unrecoverable process exit — and
+    /// `network`'s own declared return type is restricted to a bare
+    /// scalar by `Ty::is_transact_scalar` (never `Result(_, _)`), so
+    /// there is no non-trapping failure signal for `network` to react to
+    /// either, unlike `commit`/`compensate` (whose return types are
+    /// genuinely unconstrained). This is a real, narrower gap, not a
+    /// missing feature: no bounded amount of engineering time closes it
+    /// without either giving compiled traps a catchable/unwinding
+    /// semantics (a much larger, unrelated language change) or changing
+    /// `is_transact_scalar`'s already-locked durability-boundary rule.
+    ///
+    /// **Also deferred, named, not attempted**: `commit`/`compensate`'s
+    /// own retry-with-backoff-then-trap-on-exhaustion (theoretically
+    /// possible when their return type happens to be `Result(_, _)`,
+    /// since that one *is* unconstrained — but genuinely new, untested
+    /// control flow this pass didn't have budget to build and verify
+    /// carefully in the same round as the rest of Layer 1); the
+    /// durability log (`transact_log.rs`, deleted along with the
+    /// interpreter) and crash replay — a real, separate, much larger
+    /// follow-up, not a small addition to this function.
+    #[allow(clippy::too_many_arguments)]
+    fn emit_transact(
+        &mut self,
+        precheck: &Option<TransactSlot>,
+        network: &TransactSlot,
+        verify: &TransactSlot,
+        commit: &TransactSlot,
+        compensate: &Option<TransactSlot>,
+        log: &Option<TransactSlot>,
+        scopes: &mut Scopes,
+    ) -> Result<String, CodegenError> {
+        scopes.push();
+
+        let result_slot = self.fresh_reg("transact_result_addr");
+        self.emit_alloca(&result_slot, "i1");
+
+        // `txn_id` — generated before `precheck` even runs, in scope for
+        // every slot (`typeck::infer_transact`'s own ordering), even
+        // though only `network` is required to actually reference it.
+        let txn_id_slot = self.fresh_reg("transact_txn_id_addr");
+        self.emit_alloca(&txn_id_slot, "{ptr, i64}");
+        writeln!(self.out, "  call void @nir_transact_gen_txn_id(ptr {txn_id_slot})").unwrap();
+        scopes.define("txn_id", Ty::Str, txn_id_slot.clone());
+
+        let after_precheck_label = self.fresh_label("transact_after_precheck");
+        if let Some(p) = precheck {
+            let (precheck_val, _) = self.emit_transact_call(p, scopes)?;
+            let precheck_true = self.fresh_label("transact_precheck_true");
+            let precheck_false = self.fresh_label("transact_precheck_false");
+            writeln!(self.out, "  br i1 {precheck_val}, label %{precheck_true}, label %{precheck_false}").unwrap();
+            writeln!(self.out, "{precheck_false}:").unwrap();
+            writeln!(self.out, "  store i1 false, ptr {result_slot}").unwrap();
+            writeln!(self.out, "  br label %{after_precheck_label}").unwrap();
+            writeln!(self.out, "{precheck_true}:").unwrap();
+        }
+
+        // `network` — always a bare scalar return (`Ty::is_transact_scalar`,
+        // never aggregate), so this is always the plain `store <llty>`
+        // path, never a `memcpy`.
+        let (network_val, network_ty) = self.emit_transact_call(network, scopes)?;
+        let network_llty = self.llvm_ty(&network_ty)?;
+        let network_slot = self.fresh_reg("transact_network_addr");
+        self.emit_alloca(&network_slot, &network_llty);
+        writeln!(self.out, "  store {network_llty} {network_val}, ptr {network_slot}").unwrap();
+        scopes.define("network", network_ty, network_slot);
+
+        // `verify` — its own return type is already forced to `bool` by
+        // `typeck.rs`, so `verify_val` is directly usable as a branch
+        // condition with no extra `icmp`/widening needed.
+        let (verify_val, verify_ty) = self.emit_transact_call(verify, scopes)?;
+        let verify_slot = self.fresh_reg("transact_verify_addr");
+        self.emit_alloca(&verify_slot, "i1");
+        writeln!(self.out, "  store i1 {verify_val}, ptr {verify_slot}").unwrap();
+        scopes.define("verify", verify_ty, verify_slot);
+
+        let commit_label = self.fresh_label("transact_commit");
+        let compensate_label = self.fresh_label("transact_compensate");
+        let after_verify_label = self.fresh_label("transact_after_verify");
+        writeln!(self.out, "  br i1 {verify_val}, label %{commit_label}, label %{compensate_label}").unwrap();
+
+        writeln!(self.out, "{commit_label}:").unwrap();
+        self.emit_transact_call(commit, scopes)?; // return value unconstrained, discarded
+        writeln!(self.out, "  store i1 true, ptr {result_slot}").unwrap();
+        writeln!(self.out, "  br label %{after_verify_label}").unwrap();
+
+        writeln!(self.out, "{compensate_label}:").unwrap();
+        if let Some(c) = compensate {
+            self.emit_transact_call(c, scopes)?; // return value unconstrained, discarded
+        }
+        writeln!(self.out, "  store i1 false, ptr {result_slot}").unwrap();
+        writeln!(self.out, "  br label %{after_verify_label}").unwrap();
+
+        writeln!(self.out, "{after_verify_label}:").unwrap();
+        if let Some(l) = log {
+            // Best-effort per `docs/TRANSACT.md` — but unlike the deleted
+            // interpreter, a trap inside `log` is *not* swallowed here:
+            // every compiled trap is an unconditional `abort()`, the same
+            // as anywhere else in this language. A real, disclosed
+            // difference, not a silent one.
+            self.emit_transact_call(l, scopes)?;
+        }
+        writeln!(self.out, "  br label %{after_precheck_label}").unwrap();
+
+        writeln!(self.out, "{after_precheck_label}:").unwrap();
+        let result = self.fresh_reg("transact_result");
+        writeln!(self.out, "  {result} = load i1, ptr {result_slot}").unwrap();
+
+        scopes.pop();
+        Ok(result)
+    }
+
+    /// Resolves a `workflow_lower.rs`-synthesized call's compile-time-
+    /// literal `workflow_name` argument back to the original
+    /// `WorkflowDecl` it names (`Codegen.workflows`, populated from
+    /// `program.workflows` at construction — the lowering pass keeps the
+    /// source `WorkflowDecl` around for exactly this) — and rejects,
+    /// with a specific reason, the one Layer 1 restriction not already
+    /// caught by `check_expr`'s pre-pass: a workflow whose `data { ... }`
+    /// block is non-empty. `nir_workflow_create_instance` (`runtime-
+    /// kernels`) takes no `data` parameter at all — an instance's
+    /// `WorkflowInstance` row has no `data_json` field to persist one
+    /// into — so a `data.<field>` reference inside any state's
+    /// `on_entry`/`on_exit` *other* than the very first state's (whose
+    /// actions run inline, inside `start_<workflow>`'s own generated
+    /// function body, sharing its still-live `data` parameter — see
+    /// `emit_workflow_start`) could never resolve once an `advance_*`
+    /// call has moved the instance on. Rather than track which
+    /// individual action bodies happen to reference `data` (fragile,
+    /// easy to silently miscompile a workflow edited later to add one),
+    /// this rejects the whole workflow up front — the same "reject
+    /// early and specifically, not partially and silently" posture this
+    /// file takes throughout.
+    fn resolve_workflow_layer1(&self, name_expr: &Expr) -> Result<&WorkflowDecl, CodegenError> {
+        let Expr::Str(name, _) = name_expr else {
+            return unsupported(
+                "workflow codegen expects a compile-time string literal workflow name (always \
+                 true for workflow_lower.rs-synthesized calls)"
+                    .to_string(),
+            );
+        };
+        let wf = self
+            .workflows
+            .iter()
+            .find(|w| &w.name == name)
+            .ok_or_else(|| CodegenError { message: format!("no `workflow {name}` declaration found for this compiled program") })?;
+        if !wf.data.is_empty() {
+            return unsupported(format!(
+                "codegen doesn't support `workflow {name}` yet — its `data {{ ... }}` block is \
+                 non-empty, and this compiled backend's Layer 1 workflow runtime has nowhere \
+                 durable to persist a `data` value past the initial `start_*` call \
+                 (`nir_workflow_create_instance` takes no `data` parameter at all — an \
+                 instance's `WorkflowInstance` row has no `data_json` field); a workflow with an \
+                 empty `data {{ }}` block compiles now"
+            ));
+        }
+        Ok(wf)
+    }
+
+    /// Runs one `on_entry`/`on_exit` action slot (`TransactSlot`, same
+    /// shape `transact`'s own `precheck`/`verify`/... slots use) for its
+    /// side effect only, discarding its return value —
+    /// `docs/WORKFLOW.md`'s grammar restricts an action call to a bare
+    /// `name(args)`, so nothing here would use the value even if kept.
+    /// Deliberately **not** `emit_transact_call` (whose
+    /// `self.sigs.get(&slot.name).expect(...)` only resolves user-
+    /// defined functions): a workflow action's callee may just as often
+    /// be a builtin (`send_email` etc. are exactly the point) —
+    /// reusing `Stmt::Expr`'s own `is_aggregate()`-routed dispatch
+    /// instead naturally supports both, through the same `call()`/
+    /// `call_ptr()` machinery every other call in this file already
+    /// goes through.
+    fn emit_workflow_action(&mut self, slot: &TransactSlot, scopes: &mut Scopes) -> Result<(), CodegenError> {
+        let call_expr = Expr::Call(slot.name.clone(), slot.args.clone(), slot.span);
+        if self.local_ty_of(&call_expr, scopes).is_aggregate() {
+            self.expr_ptr(&call_expr, scopes)?;
+        } else {
+            self.expr(&call_expr, scopes)?;
+        }
+        Ok(())
+    }
+
+    /// Builds a scratch `WorkflowActionError` value with the given
+    /// variant's tag (`ast::prelude_enums`' own declaration order —
+    /// `NoRecipientsForRole`=0 through `NotStateOwner`=8) and, for the
+    /// one payload-carrying case a caller needs, its `str` payload —
+    /// returns a pointer to it, ready for the caller's own
+    /// `llvm.memcpy` into a `Result(_, WorkflowActionError)`'s payload
+    /// field (this file's "build the aggregate fully, then one memcpy"
+    /// convention — `emit_http_call`'s doc comment). A zero-payload
+    /// variant's payload buffer is left exactly as `emit_alloca` leaves
+    /// it (uninitialized, never read — `construct_variant`'s own
+    /// zero-payload path already leaves the very same buffer untouched
+    /// for a hand-written `Err(SomeZeroPayloadVariant)` anywhere else in
+    /// this language, so this isn't a new risk).
+    fn emit_workflow_error(&mut self, variant_tag: i64, str_payload: Option<&str>) -> Result<String, CodegenError> {
+        let err_ty = Ty::Named("WorkflowActionError".to_string(), vec![]);
+        let err_llty = self.llvm_ty(&err_ty)?;
+        let scratch = self.fresh_reg("workflow_err_scratch");
+        self.emit_alloca(&scratch, &err_llty);
+        let tag_ptr = self.fresh_reg("workflow_err_tag_ptr");
+        writeln!(self.out, "  {tag_ptr} = getelementptr inbounds {err_llty}, ptr {scratch}, i32 0, i32 0").unwrap();
+        writeln!(self.out, "  store i64 {variant_tag}, ptr {tag_ptr}").unwrap();
+        if let Some(v) = str_payload {
+            let payload_ptr = self.fresh_reg("workflow_err_payload_ptr");
+            writeln!(self.out, "  {payload_ptr} = getelementptr inbounds {err_llty}, ptr {scratch}, i32 0, i32 1").unwrap();
+            writeln!(self.out, "  store {{ptr, i64}} {v}, ptr {payload_ptr}").unwrap();
+        }
+        Ok(scratch)
+    }
+
+    /// Stores tag `1` (`Err`, `ast::prelude_enums`' `Result` declaration
+    /// order) into an already-GEP'd `Result(_, WorkflowActionError)`'s
+    /// `tag_ptr`, then `memcpy`s a `WorkflowActionError` scratch value
+    /// (built by `emit_workflow_error`) into its `payload_ptr` — shared
+    /// tail every `emit_workflow_*`/`emit_send_notification`/
+    /// `emit_notify` error path uses.
+    fn emit_workflow_err_into_result(&mut self, tag_ptr: &str, payload_ptr: &str, err_scratch: &str) {
+        writeln!(self.out, "  store i64 1, ptr {tag_ptr}").unwrap();
+        let err_ty = Ty::Named("WorkflowActionError".to_string(), vec![]);
+        let bytes = agg_byte_size_operand(&err_ty, &self.registry);
+        writeln!(self.out, "  call void @llvm.memcpy.p0.p0.i64(ptr {payload_ptr}, ptr {err_scratch}, i64 {bytes}, i1 false)").unwrap();
+    }
+
+    /// `__workflow_start(workflow_name, identity, data) ->
+    /// Result(i64, WorkflowActionError)` — Layer 1 (`WORKFLOW_BUILTINS`'
+    /// own doc comment). Creates a fresh, in-process instance
+    /// (`nir_workflow_create_instance`) in the workflow's first-declared
+    /// state, then runs that state's `on_entry` actions — `instance_id`/
+    /// `data.<field>` (`docs/WORKFLOW.md`'s implicit-binding rules) both
+    /// resolve for free here: this codegen runs *inside*
+    /// `start_<workflow>`'s own generated function body, which already
+    /// has `data` as a real parameter (`workflow_lower.rs`), and a fresh
+    /// `instance_id` local is bound into `scopes` just for the duration
+    /// of these actions. `identity` (`args[1]`) is accepted and
+    /// typechecked but not yet durably recorded as `started_by_subject`
+    /// — no `WorkflowInstance` field for it exists yet (Layer 1's
+    /// disclosed narrower cut, same posture as everything else this
+    /// file names explicitly rather than silently drops).
+    fn emit_workflow_start(&mut self, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let wf = self.resolve_workflow_layer1(&args[0])?.clone();
+        let result_ty = workflow_result_of(Ty::I64);
+
+        let (name_ptr, name_len) = self.str_parts(&args[0], scopes)?;
+        let first_state = wf.states.first().expect("parser rejects a workflow with zero states");
+        let initial_global = self.fresh_global("workflow_start_initial_state");
+        writeln!(
+            self.string_globals,
+            "{initial_global} = private unnamed_addr constant [{} x i8] c\"{}\"",
+            first_state.name.len(),
+            llvm_escape_bytes(first_state.name.as_bytes())
+        )
+        .unwrap();
+
+        let instance_scratch = self.fresh_reg("workflow_start_instance_scratch");
+        self.emit_alloca(&instance_scratch, "i64");
+        let found = self.fresh_reg("workflow_start_ok");
+        writeln!(
+            self.out,
+            "  {found} = call i32 @nir_workflow_create_instance(ptr {name_ptr}, i64 {name_len}, ptr {initial_global}, i64 {}, ptr {instance_scratch})",
+            first_state.name.len()
+        )
+        .unwrap();
+        let is_ok = self.icmp("ne", "i32", &found, "0")?;
+
+        let result_llty = self.llvm_ty(&result_ty)?;
+        let dest = self.fresh_reg("workflow_start_result_addr");
+        self.emit_alloca(&dest, &result_llty);
+        let tag_ptr = self.fresh_reg("workflow_start_tag_ptr");
+        writeln!(self.out, "  {tag_ptr} = getelementptr inbounds {result_llty}, ptr {dest}, i32 0, i32 0").unwrap();
+        let payload_ptr = self.fresh_reg("workflow_start_payload_ptr");
+        writeln!(self.out, "  {payload_ptr} = getelementptr inbounds {result_llty}, ptr {dest}, i32 0, i32 1").unwrap();
+
+        let ok_label = self.fresh_label("workflow_start_ok");
+        let err_label = self.fresh_label("workflow_start_err");
+        let merge_label = self.fresh_label("workflow_start_merge");
+        writeln!(self.out, "  br i1 {is_ok}, label %{ok_label}, label %{err_label}").unwrap();
+
+        writeln!(self.out, "{ok_label}:").unwrap();
+        let instance_val = self.fresh_reg("workflow_start_instance_id");
+        writeln!(self.out, "  {instance_val} = load i64, ptr {instance_scratch}").unwrap();
+        scopes.push();
+        let instance_slot = self.fresh_reg("workflow_start_instance_slot");
+        self.emit_alloca(&instance_slot, "i64");
+        writeln!(self.out, "  store i64 {instance_val}, ptr {instance_slot}").unwrap();
+        scopes.define("instance_id", Ty::I64, instance_slot);
+        for action in &first_state.on_entry {
+            self.emit_workflow_action(action, scopes)?;
+        }
+        scopes.pop();
+        writeln!(self.out, "  store i64 0, ptr {tag_ptr}").unwrap();
+        writeln!(self.out, "  store i64 {instance_val}, ptr {payload_ptr}").unwrap();
+        writeln!(self.out, "  br label %{merge_label}").unwrap();
+
+        writeln!(self.out, "{err_label}:").unwrap();
+        // Can't-really-happen in practice: `nir_workflow_create_instance`
+        // only returns `0` for an invalid-UTF8 workflow/initial-state
+        // name, and both are always compile-time source identifiers here
+        // — but a well-typed `Err` arm is still required. `InstanceNotFound`
+        // is the closest available "the operation didn't succeed" signal;
+        // `WorkflowActionError` has no dedicated catch-all variant.
+        let err_scratch = self.emit_workflow_error(4, None)?; // InstanceNotFound
+        self.emit_workflow_err_into_result(&tag_ptr, &payload_ptr, &err_scratch);
+        writeln!(self.out, "  br label %{merge_label}").unwrap();
+
+        writeln!(self.out, "{merge_label}:").unwrap();
+        Ok(dest)
+    }
+
+    /// `__workflow_advance(workflow_name, identity, instance_id, event,
+    /// payload) -> Result(bool, WorkflowActionError)` — Layer 1. Looks up
+    /// the instance's current state (`Err(InstanceNotFound)` if it
+    /// doesn't exist for this workflow), then a sequential per-state
+    /// `nir_str_eq` comparison chain — the same shape `match_literal`'s
+    /// own `Ty::Str` arm uses — finds the matching state, and within it,
+    /// a sequential comparison of the runtime `event` argument's enum
+    /// tag against each of that state's own transitions' compile-time-
+    /// known variant index in the desugared `<Workflow>Event` enum
+    /// (`self.registry.enum_variants`, so this never has to re-derive
+    /// `workflow_lower.rs`'s own first-appearance event-numbering by
+    /// hand). On a match: runs the *old* state's `on_exit` actions, then
+    /// `nir_workflow_set_state`, then the *new* state's `on_entry`
+    /// actions — `instance_id` (`docs/WORKFLOW.md`'s implicit binding)
+    /// resolves for free in every one of these actions, since this
+    /// codegen runs *inside* `advance_<workflow>`'s own generated
+    /// function body, which already has `instance_id: i64` as a real
+    /// parameter; no separate binding needed the way `emit_workflow_start`
+    /// needs one for its own fresh instance id. No matching state name
+    /// or no matching transition both fall through to a shared
+    /// `Err(NoSuchTransition)` — `payload` (`args[4]`) is accepted and
+    /// typechecked but not yet threaded into any binding
+    /// (`docs/WORKFLOW.md`'s own disclosed gap, unchanged here). State
+    /// ownership (`owner: role(...)`/`owner: claim(...)`) is accepted
+    /// syntactically (`typeck.rs::check_workflow_decl`) but not enforced
+    /// by this Layer 1 runtime — no `NotStateOwner` is ever produced.
+    fn emit_workflow_advance(&mut self, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let wf = self.resolve_workflow_layer1(&args[0])?.clone();
+        let result_ty = workflow_result_of(Ty::Bool);
+        let event_ty = Ty::Named(format!("{}Event", wf.name), vec![]);
+        let event_variants: Vec<Variant> = self
+            .registry
+            .enum_variants(&format!("{}Event", wf.name))
+            .expect("workflow_lower.rs always synthesizes <Workflow>Event")
+            .to_vec();
+
+        let (name_ptr, name_len) = self.str_parts(&args[0], scopes)?;
+        let instance_id_val = self.expr(&args[2], scopes)?;
+
+        let state_scratch = self.fresh_reg("workflow_advance_state_scratch");
+        self.emit_alloca(&state_scratch, "{ptr, i64}");
+        let found_instance = self.fresh_reg("workflow_advance_found_instance");
+        writeln!(
+            self.out,
+            "  {found_instance} = call i32 @nir_workflow_get_state(ptr {name_ptr}, i64 {name_len}, i64 {instance_id_val}, ptr {state_scratch})"
+        )
+        .unwrap();
+        let instance_found = self.icmp("ne", "i32", &found_instance, "0")?;
+
+        let result_llty = self.llvm_ty(&result_ty)?;
+        let dest = self.fresh_reg("workflow_advance_result_addr");
+        self.emit_alloca(&dest, &result_llty);
+        let tag_ptr = self.fresh_reg("workflow_advance_tag_ptr");
+        writeln!(self.out, "  {tag_ptr} = getelementptr inbounds {result_llty}, ptr {dest}, i32 0, i32 0").unwrap();
+        let payload_ptr = self.fresh_reg("workflow_advance_payload_ptr");
+        writeln!(self.out, "  {payload_ptr} = getelementptr inbounds {result_llty}, ptr {dest}, i32 0, i32 1").unwrap();
+
+        let found_label = self.fresh_label("workflow_advance_instance_found");
+        let not_found_label = self.fresh_label("workflow_advance_instance_not_found");
+        let no_such_transition_label = self.fresh_label("workflow_advance_no_such_transition");
+        let merge_label = self.fresh_label("workflow_advance_merge");
+        writeln!(self.out, "  br i1 {instance_found}, label %{found_label}, label %{not_found_label}").unwrap();
+
+        writeln!(self.out, "{not_found_label}:").unwrap();
+        let err_scratch_nf = self.emit_workflow_error(4, None)?; // InstanceNotFound
+        self.emit_workflow_err_into_result(&tag_ptr, &payload_ptr, &err_scratch_nf);
+        writeln!(self.out, "  br label %{merge_label}").unwrap();
+
+        writeln!(self.out, "{found_label}:").unwrap();
+        let current_state = self.fresh_reg("workflow_advance_current_state");
+        writeln!(self.out, "  {current_state} = load {{ptr, i64}}, ptr {state_scratch}").unwrap();
+        let cur_ptr = self.fresh_reg("workflow_advance_cur_ptr");
+        writeln!(self.out, "  {cur_ptr} = extractvalue {{ptr, i64}} {current_state}, 0").unwrap();
+        let cur_len = self.fresh_reg("workflow_advance_cur_len");
+        writeln!(self.out, "  {cur_len} = extractvalue {{ptr, i64}} {current_state}, 1").unwrap();
+
+        let event_ptr = self.expr_ptr_expected(&args[3], &event_ty, scopes)?;
+        let event_llty = self.llvm_ty(&event_ty)?;
+        let event_tag_ptr = self.fresh_reg("workflow_advance_event_tag_ptr");
+        writeln!(self.out, "  {event_tag_ptr} = getelementptr inbounds {event_llty}, ptr {event_ptr}, i32 0, i32 0").unwrap();
+        let event_tag = self.fresh_reg("workflow_advance_event_tag");
+        writeln!(self.out, "  {event_tag} = load i64, ptr {event_tag_ptr}").unwrap();
+
+        let state_cmp_labels: Vec<String> = wf.states.iter().map(|_| self.fresh_label("workflow_advance_state_cmp")).collect();
+        writeln!(self.out, "  br label %{}", state_cmp_labels[0]).unwrap();
+
+        for (i, s) in wf.states.iter().enumerate() {
+            let cmp_label = &state_cmp_labels[i];
+            let next_state_label = state_cmp_labels.get(i + 1).unwrap_or(&no_such_transition_label);
+            writeln!(self.out, "{cmp_label}:").unwrap();
+            let state_global = self.fresh_global("workflow_advance_state_lit");
+            writeln!(
+                self.string_globals,
+                "{state_global} = private unnamed_addr constant [{} x i8] c\"{}\"",
+                s.name.len(),
+                llvm_escape_bytes(s.name.as_bytes())
+            )
+            .unwrap();
+            let state_eq_raw = self.fresh_reg("workflow_advance_state_eq");
+            writeln!(
+                self.out,
+                "  {state_eq_raw} = call i32 @nir_str_eq(ptr {cur_ptr}, i64 {cur_len}, ptr {state_global}, i64 {})",
+                s.name.len()
+            )
+            .unwrap();
+            let state_eq = self.icmp("ne", "i32", &state_eq_raw, "0")?;
+            let state_body_label = self.fresh_label("workflow_advance_state_body");
+            writeln!(self.out, "  br i1 {state_eq}, label %{state_body_label}, label %{next_state_label}").unwrap();
+
+            writeln!(self.out, "{state_body_label}:").unwrap();
+            let transition_cmp_labels: Vec<String> =
+                s.transitions.iter().map(|_| self.fresh_label("workflow_advance_event_cmp")).collect();
+            if transition_cmp_labels.is_empty() {
+                writeln!(self.out, "  br label %{no_such_transition_label}").unwrap();
+            } else {
+                writeln!(self.out, "  br label %{}", transition_cmp_labels[0]).unwrap();
+            }
+            for (j, t) in s.transitions.iter().enumerate() {
+                let event_idx = event_variants
+                    .iter()
+                    .position(|v| v.name == t.event)
+                    .expect("typeck.rs already validated every transition event exists in <Workflow>Event");
+                let cmp_label = &transition_cmp_labels[j];
+                let next_event_label = transition_cmp_labels.get(j + 1).unwrap_or(&no_such_transition_label);
+                writeln!(self.out, "{cmp_label}:").unwrap();
+                let event_eq = self.icmp("eq", "i64", &event_tag, &event_idx.to_string())?;
+                let action_label = self.fresh_label("workflow_advance_action");
+                writeln!(self.out, "  br i1 {event_eq}, label %{action_label}, label %{next_event_label}").unwrap();
+
+                writeln!(self.out, "{action_label}:").unwrap();
+                for action in &s.on_exit {
+                    self.emit_workflow_action(action, scopes)?;
+                }
+                let target_state = wf.states.iter().find(|st| st.name == t.target).expect("workflow_lower.rs already validated target state exists");
+                let target_global = self.fresh_global("workflow_advance_target_state");
+                writeln!(
+                    self.string_globals,
+                    "{target_global} = private unnamed_addr constant [{} x i8] c\"{}\"",
+                    target_state.name.len(),
+                    llvm_escape_bytes(target_state.name.as_bytes())
+                )
+                .unwrap();
+                let set_ok = self.fresh_reg("workflow_advance_set_ok");
+                writeln!(
+                    self.out,
+                    "  {set_ok} = call i32 @nir_workflow_set_state(ptr {name_ptr}, i64 {name_len}, i64 {instance_id_val}, ptr {target_global}, i64 {})",
+                    target_state.name.len()
+                )
+                .unwrap();
+                // `set_ok`'s own failure is the same can't-really-happen
+                // case `emit_workflow_start`'s own `err_label` doc comment
+                // already names (this instance and workflow name were
+                // just proven to match above) — not checked separately.
+                for action in &target_state.on_entry {
+                    self.emit_workflow_action(action, scopes)?;
+                }
+                writeln!(self.out, "  store i64 0, ptr {tag_ptr}").unwrap();
+                writeln!(self.out, "  store i1 true, ptr {payload_ptr}").unwrap();
+                writeln!(self.out, "  br label %{merge_label}").unwrap();
+            }
+        }
+
+        writeln!(self.out, "{no_such_transition_label}:").unwrap();
+        let err_scratch_nt = self.emit_workflow_error(3, None)?; // NoSuchTransition
+        self.emit_workflow_err_into_result(&tag_ptr, &payload_ptr, &err_scratch_nt);
+        writeln!(self.out, "  br label %{merge_label}").unwrap();
+
+        writeln!(self.out, "{merge_label}:").unwrap();
+        Ok(dest)
+    }
+
+    /// `__workflow_overdue(workflow_name) -> Result(json,
+    /// WorkflowActionError)` — `docs/ROADMAP.md` A15's SLA/escalation
+    /// design, only reachable for a workflow that declares at least one
+    /// `sla_seconds` entry (`workflow_lower.rs` only synthesizes
+    /// `list_<workflow>_overdue` in that case). Builds a compile-time
+    /// JSON literal `{"State":seconds,...}` from every
+    /// `state { sla_seconds: N }` entry (`typeck.rs::check_workflow_decl`
+    /// already proved every such value a non-negative literal `i64`) and
+    /// hands it to `nir_workflow_list_overdue`, which does the actual
+    /// now-vs-`entered_at` comparison against every live
+    /// `WorkflowInstance` row for this workflow.
+    fn emit_workflow_overdue(&mut self, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let wf = self.resolve_workflow_layer1(&args[0])?.clone();
+        let result_ty = workflow_result_of(Ty::Json);
+        let (name_ptr, name_len) = self.str_parts(&args[0], scopes)?;
+
+        let mut sla_json = String::from("{");
+        let mut first = true;
+        for s in &wf.states {
+            if let Some((_, value)) = s.entries.iter().find(|(k, _)| k == "sla_seconds") {
+                let Expr::Int(n, _) = value else {
+                    unreachable!("typeck.rs::check_workflow_decl only accepts a literal i64 for sla_seconds")
+                };
+                if !first {
+                    sla_json.push(',');
+                }
+                first = false;
+                sla_json.push_str(&format!("{:?}:{}", s.name, n));
+            }
+        }
+        sla_json.push('}');
+
+        let sla_global = self.fresh_global("workflow_overdue_sla_json");
+        writeln!(
+            self.string_globals,
+            "{sla_global} = private unnamed_addr constant [{} x i8] c\"{}\"",
+            sla_json.len(),
+            llvm_escape_bytes(sla_json.as_bytes())
+        )
+        .unwrap();
+
+        let json_scratch = self.fresh_reg("workflow_overdue_json_scratch");
+        self.emit_alloca(&json_scratch, "{ptr, i64}");
+        let err_scratch = self.fresh_reg("workflow_overdue_err_scratch");
+        self.emit_alloca(&err_scratch, "{ptr, i64}");
+        let found = self.fresh_reg("workflow_overdue_ok");
+        writeln!(
+            self.out,
+            "  {found} = call i32 @nir_workflow_list_overdue(ptr {name_ptr}, i64 {name_len}, ptr {sla_global}, i64 {}, ptr {json_scratch}, ptr {err_scratch})",
+            sla_json.len()
+        )
+        .unwrap();
+        let is_ok = self.icmp("ne", "i32", &found, "0")?;
+        let json_val = self.fresh_reg("workflow_overdue_json_val");
+        writeln!(self.out, "  {json_val} = load {{ptr, i64}}, ptr {json_scratch}").unwrap();
+        let err_val = self.fresh_reg("workflow_overdue_err_val");
+        writeln!(self.out, "  {err_val} = load {{ptr, i64}}, ptr {err_scratch}").unwrap();
+
+        let result_llty = self.llvm_ty(&result_ty)?;
+        let dest = self.fresh_reg("workflow_overdue_result_addr");
+        self.emit_alloca(&dest, &result_llty);
+        let tag_ptr = self.fresh_reg("workflow_overdue_tag_ptr");
+        writeln!(self.out, "  {tag_ptr} = getelementptr inbounds {result_llty}, ptr {dest}, i32 0, i32 0").unwrap();
+        let payload_ptr = self.fresh_reg("workflow_overdue_payload_ptr");
+        writeln!(self.out, "  {payload_ptr} = getelementptr inbounds {result_llty}, ptr {dest}, i32 0, i32 1").unwrap();
+
+        let ok_label = self.fresh_label("workflow_overdue_ok");
+        let err_label = self.fresh_label("workflow_overdue_err");
+        let merge_label = self.fresh_label("workflow_overdue_merge");
+        writeln!(self.out, "  br i1 {is_ok}, label %{ok_label}, label %{err_label}").unwrap();
+
+        writeln!(self.out, "{ok_label}:").unwrap();
+        writeln!(self.out, "  store i64 0, ptr {tag_ptr}").unwrap();
+        writeln!(self.out, "  store {{ptr, i64}} {json_val}, ptr {payload_ptr}").unwrap();
+        writeln!(self.out, "  br label %{merge_label}").unwrap();
+
+        writeln!(self.out, "{err_label}:").unwrap();
+        // `nir_workflow_list_overdue`'s own failure mode is a plain `str`
+        // message (bad UTF-8 — the SLA JSON itself can't be malformed,
+        // it's a compile-time-built literal), not a `WorkflowActionError`
+        // — wrapped here as `ProviderRequestFailed(msg)`, reusing the one
+        // variant with a `str` payload as the generic "something went
+        // wrong, here's why" carrier (closest fit, not a perfect name
+        // match: this is an ops/admin query, not a notification send —
+        // `WorkflowActionError` has no dedicated catch-all variant).
+        let err_scratch2 = self.emit_workflow_error(2, Some(&err_val))?; // ProviderRequestFailed(msg)
+        self.emit_workflow_err_into_result(&tag_ptr, &payload_ptr, &err_scratch2);
+        writeln!(self.out, "  br label %{merge_label}").unwrap();
+
+        writeln!(self.out, "{merge_label}:").unwrap();
+        Ok(dest)
+    }
+
+    /// `__workflow_pending_for_me`/`__workflow_submitted_by_me`/
+    /// `__workflow_history` — real, compiled, always-`Err` (never a
+    /// trap) implementations. `workflow_lower.rs` synthesizes
+    /// `list_<w>_pending_for_me`/`list_<w>_submitted_by_me`/
+    /// `get_<w>_history` **unconditionally** for every `workflow` block,
+    /// so unlike `__workflow_link_advance` these three can't be rejected
+    /// at compile time without breaking every workflow, including ones
+    /// that never call them (`WORKFLOW_BUILTINS`'s own doc comment).
+    /// State ownership (`owner: role(...)`), "who submitted this," and
+    /// the audit trail all need data this Layer 1 runtime genuinely
+    /// doesn't keep — `WorkflowInstance` (`runtime-kernels/src/lib.rs`)
+    /// has no `owner`/`started_by_subject`/history fields at all — so
+    /// each of these three real, compiled functions always returns a
+    /// real `Err(ProviderRequestFailed(msg))`, naming exactly which
+    /// tracking is missing, rather than a misleading `Ok("[]")` that a
+    /// caller could read as "you truly have zero pending items" instead
+    /// of "this isn't tracked." `ProviderRequestFailed` is reused as the
+    /// generic "something went wrong, here's why" carrier (the same
+    /// "closest fit, not a perfect name match" reuse `emit_workflow_overdue`
+    /// already makes) since `WorkflowActionError` has no dedicated
+    /// catch-all variant of its own.
+    fn emit_workflow_unsupported_query(&mut self, name: &str) -> Result<String, CodegenError> {
+        let result_ty = workflow_result_of(Ty::Json);
+        let reason = format!(
+            "`{name}` needs real durable, restart-surviving storage (state ownership/started-by/\
+             audit-trail tracking) that this compiled backend's Layer 1 workflow runtime doesn't \
+             have — `WorkflowInstance` (runtime-kernels) tracks only the current state"
+        );
+        let msg_global = self.fresh_global("workflow_unsupported_query_msg");
+        writeln!(
+            self.string_globals,
+            "{msg_global} = private unnamed_addr constant [{} x i8] c\"{}\"",
+            reason.len(),
+            llvm_escape_bytes(reason.as_bytes())
+        )
+        .unwrap();
+        let msg_partial = self.fresh_reg("workflow_unsupported_query_msg_partial");
+        writeln!(self.out, "  {msg_partial} = insertvalue {{ptr, i64}} undef, ptr {msg_global}, 0").unwrap();
+        let msg_full = self.fresh_reg("workflow_unsupported_query_msg_full");
+        writeln!(self.out, "  {msg_full} = insertvalue {{ptr, i64}} {msg_partial}, i64 {}, 1", reason.len()).unwrap();
+
+        let result_llty = self.llvm_ty(&result_ty)?;
+        let dest = self.fresh_reg("workflow_unsupported_query_result_addr");
+        self.emit_alloca(&dest, &result_llty);
+        let tag_ptr = self.fresh_reg("workflow_unsupported_query_tag_ptr");
+        writeln!(self.out, "  {tag_ptr} = getelementptr inbounds {result_llty}, ptr {dest}, i32 0, i32 0").unwrap();
+        let payload_ptr = self.fresh_reg("workflow_unsupported_query_payload_ptr");
+        writeln!(self.out, "  {payload_ptr} = getelementptr inbounds {result_llty}, ptr {dest}, i32 0, i32 1").unwrap();
+        let err_scratch = self.emit_workflow_error(2, Some(&msg_full))?; // ProviderRequestFailed(msg)
+        self.emit_workflow_err_into_result(&tag_ptr, &payload_ptr, &err_scratch);
+        Ok(dest)
+    }
+
+    /// Shared 3-way branch every `send_email`/`send_sms`/`send_push`/
+    /// `notify` builtin ends with, once its own kernel call has already
+    /// produced `status` (`nir_workflow_send`/`nir_notify`'s shared
+    /// status convention: `0` ok, `1` provider not configured, anything
+    /// else a request failure whose message is in `err_scratch`) — an
+    /// LLVM `switch` rather than a linear `icmp` chain, so "any value
+    /// that isn't 0 or 1" (not just literally `2`) safely falls to the
+    /// request-failed case as the `default`.
+    fn emit_notify_result(&mut self, result_ty: &Ty, status: &str, err_scratch: &str) -> Result<String, CodegenError> {
+        let result_llty = self.llvm_ty(result_ty)?;
+        let dest = self.fresh_reg("notify_result_addr");
+        self.emit_alloca(&dest, &result_llty);
+        let tag_ptr = self.fresh_reg("notify_tag_ptr");
+        writeln!(self.out, "  {tag_ptr} = getelementptr inbounds {result_llty}, ptr {dest}, i32 0, i32 0").unwrap();
+        let payload_ptr = self.fresh_reg("notify_payload_ptr");
+        writeln!(self.out, "  {payload_ptr} = getelementptr inbounds {result_llty}, ptr {dest}, i32 0, i32 1").unwrap();
+
+        let ok_label = self.fresh_label("notify_ok");
+        let not_configured_label = self.fresh_label("notify_not_configured");
+        let request_failed_label = self.fresh_label("notify_request_failed");
+        let merge_label = self.fresh_label("notify_merge");
+        writeln!(
+            self.out,
+            "  switch i32 {status}, label %{request_failed_label} [ i32 0, label %{ok_label}  i32 1, label %{not_configured_label} ]"
+        )
+        .unwrap();
+
+        writeln!(self.out, "{ok_label}:").unwrap();
+        writeln!(self.out, "  store i64 0, ptr {tag_ptr}").unwrap();
+        writeln!(self.out, "  store i1 true, ptr {payload_ptr}").unwrap();
+        writeln!(self.out, "  br label %{merge_label}").unwrap();
+
+        writeln!(self.out, "{not_configured_label}:").unwrap();
+        let not_configured_scratch = self.emit_workflow_error(1, None)?; // ProviderNotConfigured
+        self.emit_workflow_err_into_result(&tag_ptr, &payload_ptr, &not_configured_scratch);
+        writeln!(self.out, "  br label %{merge_label}").unwrap();
+
+        writeln!(self.out, "{request_failed_label}:").unwrap();
+        let err_val = self.fresh_reg("notify_err_val");
+        writeln!(self.out, "  {err_val} = load {{ptr, i64}}, ptr {err_scratch}").unwrap();
+        let request_failed_scratch = self.emit_workflow_error(2, Some(&err_val))?; // ProviderRequestFailed(msg)
+        self.emit_workflow_err_into_result(&tag_ptr, &payload_ptr, &request_failed_scratch);
+        writeln!(self.out, "  br label %{merge_label}").unwrap();
+
+        writeln!(self.out, "{merge_label}:").unwrap();
+        Ok(dest)
+    }
+
+    /// `send_email`/`send_sms`/`send_push(conn, to, template, vars) ->
+    /// Result(bool, WorkflowActionError)` — shared shape, differing only
+    /// in which literal `channel` string (`"email"`/`"sms"`/`"push"`) is
+    /// passed to `nir_workflow_send` (`runtime-kernels`'s "send/notify
+    /// section" — a real, generic authenticated HTTPS POST against an
+    /// admin-configured provider row, `docs/WORKFLOW.md`'s own design).
+    /// `to: Recipient`'s `str` payload sits at the same word offset (1)
+    /// for both `BySubject`/`ByRole` (`ast::prelude_enums`) — extracted
+    /// without branching on the tag, same "both variants agree, so skip
+    /// the dispatch" shape `RoleView`/`ClaimView`'s own single-field
+    /// payloads already get.
+    fn emit_send_notification(&mut self, channel: &str, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let result_ty = workflow_result_of(Ty::Bool);
+        let recipient_ty = Ty::Named("Recipient".to_string(), vec![]);
+
+        let conn = self.expr(&args[0], scopes)?; // Ty::Db is scalar (i64)
+        let recipient_ptr = self.expr_ptr_expected(&args[1], &recipient_ty, scopes)?;
+        let recipient_llty = self.llvm_ty(&recipient_ty)?;
+        let recipient_payload_ptr = self.fresh_reg("send_notification_recipient_payload_ptr");
+        writeln!(self.out, "  {recipient_payload_ptr} = getelementptr inbounds {recipient_llty}, ptr {recipient_ptr}, i32 0, i32 1").unwrap();
+        let to_val = self.fresh_reg("send_notification_to_val");
+        writeln!(self.out, "  {to_val} = load {{ptr, i64}}, ptr {recipient_payload_ptr}").unwrap();
+        let to_ptr = self.fresh_reg("send_notification_to_ptr");
+        writeln!(self.out, "  {to_ptr} = extractvalue {{ptr, i64}} {to_val}, 0").unwrap();
+        let to_len = self.fresh_reg("send_notification_to_len");
+        writeln!(self.out, "  {to_len} = extractvalue {{ptr, i64}} {to_val}, 1").unwrap();
+
+        let (template_ptr, template_len) = self.str_parts(&args[2], scopes)?;
+        let (vars_ptr, vars_len) = self.str_parts(&args[3], scopes)?;
+
+        let channel_global = self.fresh_global("send_notification_channel");
+        writeln!(
+            self.string_globals,
+            "{channel_global} = private unnamed_addr constant [{} x i8] c\"{}\"",
+            channel.len(),
+            llvm_escape_bytes(channel.as_bytes())
+        )
+        .unwrap();
+
+        let err_scratch = self.fresh_reg("send_notification_err_scratch");
+        self.emit_alloca(&err_scratch, "{ptr, i64}");
+        let status = self.fresh_reg("send_notification_status");
+        writeln!(
+            self.out,
+            "  {status} = call i32 @nir_workflow_send(ptr {channel_global}, i64 {}, i64 {conn}, ptr {to_ptr}, i64 {to_len}, \
+             ptr {template_ptr}, i64 {template_len}, ptr {vars_ptr}, i64 {vars_len}, ptr {err_scratch})",
+            channel.len()
+        )
+        .unwrap();
+
+        self.emit_notify_result(&result_ty, &status, &err_scratch)
+    }
+
+    /// `notify(conn, mq, to, template, vars) -> Result(bool,
+    /// WorkflowActionError)` — same shape as `emit_send_notification`,
+    /// but the callee kernel is `nir_notify` (no channel string — it
+    /// always takes the documented *offline* path, delegating to the
+    /// email channel; see that kernel's own doc comment for why the
+    /// presence-bridge online path isn't reachable this round) and `mq`
+    /// (`args[1]`) is accepted/typechecked but otherwise unused here.
+    fn emit_notify(&mut self, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let result_ty = workflow_result_of(Ty::Bool);
+        let recipient_ty = Ty::Named("Recipient".to_string(), vec![]);
+
+        let conn = self.expr(&args[0], scopes)?;
+        let mq = self.expr(&args[1], scopes)?; // Ty::Mq is scalar (i64); unused by nir_notify itself
+        let recipient_ptr = self.expr_ptr_expected(&args[2], &recipient_ty, scopes)?;
+        let recipient_llty = self.llvm_ty(&recipient_ty)?;
+        let recipient_payload_ptr = self.fresh_reg("notify_recipient_payload_ptr");
+        writeln!(self.out, "  {recipient_payload_ptr} = getelementptr inbounds {recipient_llty}, ptr {recipient_ptr}, i32 0, i32 1").unwrap();
+        let to_val = self.fresh_reg("notify_to_val");
+        writeln!(self.out, "  {to_val} = load {{ptr, i64}}, ptr {recipient_payload_ptr}").unwrap();
+        let to_ptr = self.fresh_reg("notify_to_ptr");
+        writeln!(self.out, "  {to_ptr} = extractvalue {{ptr, i64}} {to_val}, 0").unwrap();
+        let to_len = self.fresh_reg("notify_to_len");
+        writeln!(self.out, "  {to_len} = extractvalue {{ptr, i64}} {to_val}, 1").unwrap();
+
+        let (template_ptr, template_len) = self.str_parts(&args[3], scopes)?;
+        let (vars_ptr, vars_len) = self.str_parts(&args[4], scopes)?;
+
+        let err_scratch = self.fresh_reg("notify_err_scratch");
+        self.emit_alloca(&err_scratch, "{ptr, i64}");
+        let status = self.fresh_reg("notify_status");
+        writeln!(
+            self.out,
+            "  {status} = call i32 @nir_notify(i64 {conn}, i64 {mq}, ptr {to_ptr}, i64 {to_len}, ptr {template_ptr}, i64 {template_len}, \
+             ptr {vars_ptr}, i64 {vars_len}, ptr {err_scratch})"
+        )
+        .unwrap();
+
+        self.emit_notify_result(&result_ty, &status, &err_scratch)
     }
 
     /// `acquire name(proof)` — `docs/LANGUAGE.md` §6a, compiled for real
@@ -5386,6 +7428,36 @@ impl Codegen<'_> {
         // recorder that goes silent on exactly the failures worth
         // recording (a trap, an admission denial) would defeat the
         // point of having one.
+        writeln!(self.out, "  call void @nir_kernel_flight_recorder_dump()").unwrap();
+        writeln!(self.out, "  call void @abort()").unwrap();
+        writeln!(self.out, "  unreachable").unwrap();
+        writeln!(self.out, "{ok}:").unwrap();
+    }
+
+    /// `str_slice(s, start, end)`'s bounds check — traps unless `0 <=
+    /// start <= end <= len`, same `abort()`-after-flight-recorder-dump
+    /// trap idiom as `guard_io_ok`/`guard_recv_ok`. A wrong bounds check
+    /// here would either read out-of-bounds memory or spuriously abort on
+    /// every valid slice, so this is deliberately three separate `icmp`s
+    /// ANDed together rather than one clever combined comparison.
+    fn guard_str_bounds_ok(&mut self, start: &str, end: &str, len: &str) {
+        if self.audited {
+            return;
+        }
+        let start_neg = self.fresh_reg("slice_start_neg");
+        writeln!(self.out, "  {start_neg} = icmp slt i64 {start}, 0").unwrap();
+        let start_gt_end = self.fresh_reg("slice_start_gt_end");
+        writeln!(self.out, "  {start_gt_end} = icmp sgt i64 {start}, {end}").unwrap();
+        let end_gt_len = self.fresh_reg("slice_end_gt_len");
+        writeln!(self.out, "  {end_gt_len} = icmp sgt i64 {end}, {len}").unwrap();
+        let bad1 = self.fresh_reg("slice_bad1");
+        writeln!(self.out, "  {bad1} = or i1 {start_neg}, {start_gt_end}").unwrap();
+        let is_fail = self.fresh_reg("slice_out_of_bounds");
+        writeln!(self.out, "  {is_fail} = or i1 {bad1}, {end_gt_len}").unwrap();
+        let trap = self.fresh_label("slice_trap");
+        let ok = self.fresh_label("slice_ok");
+        writeln!(self.out, "  br i1 {is_fail}, label %{trap}, label %{ok}").unwrap();
+        writeln!(self.out, "{trap}:").unwrap();
         writeln!(self.out, "  call void @nir_kernel_flight_recorder_dump()").unwrap();
         writeln!(self.out, "  call void @abort()").unwrap();
         writeln!(self.out, "  unreachable").unwrap();
@@ -6271,6 +8343,24 @@ impl Codegen<'_> {
             let mut word_off: u64 = 0;
             for (name, decl_ty) in arm.bindings.iter().zip(variant.payload.iter()) {
                 let field_ty = substitute_ty(decl_ty, &subst);
+                // A `Ty::Unit` payload (e.g. `mq_publish`'s own
+                // `Result(unit, str)`) carries no data at all —
+                // `llvm_ty(Unit)` is `void`, and `alloca void`/`load
+                // void` are both invalid LLVM IR, so this skips the
+                // whole alloca/load/store dance every other field type
+                // gets below. The placeholder `"0"` is never actually
+                // dereferenced as a pointer — `Expr::Ident`'s own
+                // `Ty::Unit` short-circuit returns it directly instead
+                // of loading through it, the same "its own value is
+                // unit; never [meaningfully] read" convention every
+                // other unit-shaped result in this file already uses.
+                // Found by actually compiling `Ok(u) => true` against a
+                // real `Result(unit, str)`, not designed in advance.
+                if field_ty == Ty::Unit {
+                    scopes.define(name, Ty::Unit, "0".to_string());
+                    word_off += conservative_word_count(&field_ty, &self.registry);
+                    continue;
+                }
                 let field_ptr = self.fresh_reg("armfield.addr");
                 writeln!(self.out, "  {field_ptr} = getelementptr inbounds i64, ptr {payload}, i64 {word_off}").unwrap();
                 // Every binding gets its own stack slot — the same
@@ -6294,7 +8384,20 @@ impl Codegen<'_> {
                 word_off += conservative_word_count(&field_ty, &self.registry);
             }
             let fell_through = if result_ty.is_aggregate() {
-                let src = self.expr_ptr(&arm.body, scopes)?;
+                // `expr_ptr_expected`, not plain `expr_ptr` — this arm's
+                // body already has a real, concrete expected type in
+                // hand (`result_ty`, already resolved from `arms[0]`
+                // above), so a bare `Err(SomeVariant(...))`-shaped body
+                // (which `ctor_ty`'s own no-context inference can't
+                // disambiguate — which `Result(T, E)` instantiation does
+                // this `Err` belong to?) resolves correctly instead of
+                // hitting that ambiguity error. Found by actually
+                // compiling a `workflow`-generated `Err(NoSuchTransition())`
+                // arm, not designed in advance — the same "found by
+                // testing" precedent this file's own `Ty::Unit`-payload
+                // fix (just above, in this same per-arm loop) already
+                // set.
+                let src = self.expr_ptr_expected(&arm.body, result_ty, scopes)?;
                 if let Some((ptr, _)) = slot {
                     let bytes = agg_byte_size_operand(result_ty, &self.registry);
                     writeln!(
@@ -6366,7 +8469,10 @@ impl Codegen<'_> {
                              scopes: &mut Scopes|
          -> Result<bool, CodegenError> {
             if result_ty.is_aggregate() {
-                let src = cg.expr_ptr(body, scopes)?;
+                // `expr_ptr_expected`, not plain `expr_ptr` — same fix,
+                // same reason, as `match_enum`'s own per-arm body
+                // evaluation just above.
+                let src = cg.expr_ptr_expected(body, result_ty, scopes)?;
                 if !cg.terminated {
                     if let Some((ptr, _)) = slot {
                         let bytes = agg_byte_size_operand(result_ty, &cg.registry);

--- a/crates/compiler/src/ownership.rs
+++ b/crates/compiler/src/ownership.rs
@@ -589,9 +589,25 @@ impl<'a> Checker<'a> {
                     // than once — a real connection is meant to run many
                     // queries, the same way a `tcp`/`file` handle is
                     // meant to `send`/`recv` many times before its one
-                    // `stop` (`Ty::Db`'s doc comment).
-                    let consume =
-                        !(i == 0 && matches!(name.as_str(), "db_query" | "db_execute" | "mq_publish" | "mq_consume"));
+                    // `stop` (`Ty::Db`'s doc comment). `send_email`/
+                    // `send_sms`/`send_push`/`notify` (`docs/WORKFLOW.md`)
+                    // take the exact same `conn: Db` leading argument
+                    // shape (a workflow's `on_entry` typically fires
+                    // several notifications off one connection) — same
+                    // exemption, same reason. `notify` alone also takes a
+                    // second connection-shaped argument, `mq: Mq`
+                    // (`docs/WORKFLOW.md`'s presence bridge) -- it's just
+                    // as reusable as `conn` (a workflow's `on_entry` may
+                    // call `notify` more than once off the same `mq`
+                    // connection before its own one `stop`), so it gets
+                    // the same read-not-consumed treatment at its own
+                    // fixed position instead of the generic `i == 0`.
+                    let consume = !((i == 0
+                        && matches!(
+                            name.as_str(),
+                            "db_query" | "db_execute" | "mq_publish" | "mq_consume" | "send_email" | "send_sms" | "send_push" | "notify"
+                        ))
+                        || (i == 1 && name.as_str() == "notify"));
                     self.touch_expr(a, consume);
                 }
             }

--- a/crates/compiler/src/plugin.rs
+++ b/crates/compiler/src/plugin.rs
@@ -25,11 +25,40 @@ use crate::ast::Ty;
 ///
 /// Deliberately **not** a field on `PluginBuiltin` (which stays exactly
 /// as it was): a native-callable builtin is a *stricter* subset (no
-/// `str`/aggregate/`Db`/`Handle` — anything `codegen.rs::llvm_ty`
-/// doesn't already emit a scalar LLVM type for, checked by
-/// [`NativePluginBuiltin::validate`]), and keeping it a separate,
-/// explicit opt-in avoids ever silently expecting a `str`-taking plugin
-/// builtin to somehow compile.
+/// `Vector`/`Matrix`/`Db`/`Mq`/`Json`/`Ty::Named` — anything
+/// `codegen.rs::llvm_ty` doesn't already emit a plain-value LLVM type
+/// for, checked by [`NativePluginBuiltin::validate`]), and keeping it a
+/// separate, explicit opt-in avoids ever silently expecting an
+/// aggregate-taking plugin builtin to somehow compile.
+///
+/// rfcs/0008-native-plugin-abi-widening.md Phase 1: `str` and `handle`
+/// are *not* in that stricter subset — both already have a plain-value
+/// LLVM representation `codegen.rs::llvm_ty` emits for every ordinary
+/// `.nir` function today (`Ty::Str => "{ptr, i64}"`, passed/returned by
+/// value in registers exactly like `f64`/`Dec128Bits`, never through
+/// the `Vector`/`Matrix` sret/pointer convention; `Ty::Handle(_)` is a
+/// plain opaque `i64`, its only safety coming from `ownership.rs`'s
+/// affine tracking at the *type* level, same as `Ty::Thread`/
+/// `Ty::Channel`/`Ty::File`). `Codegen::call`'s generic `sigs`-driven
+/// dispatch (`codegen.rs:3952`) already handles both shapes correctly
+/// for a `declare`d native symbol with zero special-casing — the only
+/// thing that stopped a `str`/`handle`-typed native plugin from
+/// compiling was this validator's own scalar-only restriction, not a
+/// missing codegen capability.
+///
+/// `&handle(Kind)` (`Ty::Ref(Box::new(Ty::Handle(_)))`) is also accepted
+/// — deliberately narrower than "any `Ty::Ref`" — for the same reason
+/// the deleted interpreter-path `widget_query` test case needed it: a
+/// *read* of a stateful resource must **borrow**, not consume, or a
+/// handle could only ever be used once before its own `close` (rfcs/
+/// 0005 §1's affine guarantee would make every real "connect, query N
+/// times, close" plugin uncallable). `codegen.rs::llvm_ty` already
+/// renders any `Ty::Ref(_)` as a plain one-word `ptr` — the *address* of
+/// the underlying `i64` handle slot, not the handle value itself — so a
+/// native plugin function taking `&handle(Kind)` must dereference that
+/// pointer once to read the `i64` id (see `crates/plugin-example-
+/// native-kv`'s `kv_get`/`kv_set` for a real, working example of both
+/// the `.nir`-side `&h` call and the Rust-side `*const i64` deref).
 pub struct NativePluginBuiltin {
     /// Must equal the corresponding `PluginBuiltin.name` this native
     /// form backs, and must also be the exact `#[no_mangle] extern "C"`
@@ -51,34 +80,64 @@ pub struct NativePluginBuiltin {
 
 impl NativePluginBuiltin {
     /// Every param and the return type must be a type `codegen.rs`
-    /// already emits as a plain LLVM scalar (or `void`) — `str`,
-    /// `Vector`/`Matrix`, `Json`, `Db`/`Mq`/`Handle`, any `Ty::Named`
-    /// struct/enum, are all real ABI questions (multi-word values,
-    /// pointers with real ownership) this narrow mechanism doesn't
-    /// attempt to answer; see rfcs/0005 §3's own "harder, still-open
-    /// question" for why that's a separate, bigger design, not an
-    /// oversight here.
+    /// already emits as a plain *value* (passed/returned in registers,
+    /// never through the `sret`/by-pointer convention `Vector`/`Matrix`/
+    /// `Ty::Named` need) — scalars, `str` (a `{ptr, i64}` two-word
+    /// value), and `handle(Kind)` (a plain `i64`) all qualify.
+    /// `Vector`/`Matrix`/`Json`/`Db`/`Mq`/any `Ty::Named` struct/enum do
+    /// not: those are real ABI questions (variable-size aggregates,
+    /// pointers with real ownership beyond a single opaque word) this
+    /// narrow mechanism doesn't attempt to answer — see rfcs/0005 §3's
+    /// own "harder, still-open question" for why that's separate,
+    /// bigger design, not an oversight here.
+    ///
+    /// A `str` parameter crosses as the plugin author's own
+    /// `#[repr(C)]` struct of `(ptr: *const u8, len: i64)` passed by
+    /// value (matching `runtime-kernels/src/lib.rs`'s `Dec128Bits`
+    /// pattern for its own two-word `{i64, i64}` values) — **not**
+    /// NUL-terminated, `len` is load-bearing. A `str` return works the
+    /// same way in reverse: the plugin allocates its own buffer (e.g.
+    /// via `Box::leak`) and returns `(ptr, len)` by value; nothing on
+    /// the Nirdosha side ever frees a plugin-returned string, the same
+    /// permanent-leak posture `codegen.rs`'s own `sha256_hex` builtin
+    /// already has for the identical reason (`Ty::Str` isn't affine, so
+    /// there's no scope-closing point to hook a free onto) — see
+    /// `crates/plugin-example-native-shout` for a real, working example
+    /// of both directions.
     pub fn validate(&self) -> Result<(), String> {
-        fn is_native_scalar(ty: &Ty) -> bool {
+        fn is_native_value(ty: &Ty) -> bool {
             matches!(
                 ty,
-                Ty::I8 | Ty::I16 | Ty::I32 | Ty::I64 | Ty::U8 | Ty::U16 | Ty::U32 | Ty::U64 | Ty::Usize | Ty::F64 | Ty::Bool | Ty::Unit
-            )
+                Ty::I8
+                    | Ty::I16
+                    | Ty::I32
+                    | Ty::I64
+                    | Ty::U8
+                    | Ty::U16
+                    | Ty::U32
+                    | Ty::U64
+                    | Ty::Usize
+                    | Ty::F64
+                    | Ty::Bool
+                    | Ty::Unit
+                    | Ty::Str
+                    | Ty::Handle(_)
+            ) || matches!(ty, Ty::Ref(inner) if matches!(inner.as_ref(), Ty::Handle(_)))
         }
         for p in &self.params {
-            if !is_native_scalar(p) {
+            if !is_native_value(p) {
                 return Err(format!(
                     "native plugin builtin `{}`: parameter type `{}` isn't a supported native-ABI \
-                     scalar (only i8..usize/f64/bool are) -- str/aggregate/Db/Mq/Handle types can't \
-                     cross this boundary yet (rfcs/0005 §3)",
+                     value (i8..usize/f64/bool/str/handle(..)/&handle(..) are) -- Vector/Matrix/Json/Db/Mq/struct \
+                     types can't cross this boundary yet (rfcs/0005 §3, rfcs/0008 §Phase 1)",
                     self.name,
                     p.name()
                 ));
             }
         }
-        if !is_native_scalar(&self.ret) {
+        if !is_native_value(&self.ret) {
             return Err(format!(
-                "native plugin builtin `{}`: return type `{}` isn't a supported native-ABI scalar",
+                "native plugin builtin `{}`: return type `{}` isn't a supported native-ABI value",
                 self.name,
                 self.ret.name()
             ));

--- a/crates/compiler/src/typeck.rs
+++ b/crates/compiler/src/typeck.rs
@@ -2385,6 +2385,18 @@ impl<'a> Checker<'a> {
                             self.error(TypeErrorKind::InvalidFieldValidationExpr { key: key.to_string() }, value.span());
                         }
                     }
+                    // `state Name { sla_seconds: N ... }` — `docs/ROADMAP.md`
+                    // A15's SLA/escalation design. Must be a non-negative
+                    // integer literal — `codegen::emit_workflow_start`/
+                    // `emit_workflow_advance` read this directly off the
+                    // AST at compile time (building the SLA config a real
+                    // `.nir` value could never legally construct
+                    // dynamically), the same "state ownership"/`label`
+                    // treatment above already gives `owner`/`label`.
+                    "sla_seconds" => match value {
+                        Expr::Int(n, _) if *n >= 0 => {}
+                        _ => self.error(TypeErrorKind::InvalidFieldValidationExpr { key: key.to_string() }, value.span()),
+                    },
                     _ => {}
                 }
             }
@@ -3811,7 +3823,8 @@ impl<'a> Checker<'a> {
             },
             ("len", 1) => match self.infer(&args[0], expected_ret, scopes) {
                 Ty::Vector(_, _) => Ty::I64,
-                found => self.wrong_arg(name, "a Vector", found, span),
+                Ty::Str => Ty::I64,
+                found => self.wrong_arg(name, "a Vector or str", found, span),
             },
             ("norm", 1) | ("norm1", 1) | ("norm_inf", 1) => {
                 match self.expect_f64_vector(&args[0], name, expected_ret, scopes, span) {
@@ -4148,6 +4161,22 @@ impl<'a> Checker<'a> {
                 self.check(&args[1], &Ty::Str, expected_ret, scopes);
                 Ty::Bool
             }
+            // Minimal compiled string-parsing primitives (`BUILTIN_NAMES`'
+            // own doc comment has the full scope). Both infallible --
+            // `str_slice`'s bounds are checked at runtime by a trap, not a
+            // `Result`; `str_index_of` returns `-1` rather than an `Err`
+            // for "not found", matching `nir_str_index_of`'s own contract.
+            ("str_slice", 3) => {
+                self.check(&args[0], &Ty::Str, expected_ret, scopes);
+                self.check(&args[1], &Ty::I64, expected_ret, scopes);
+                self.check(&args[2], &Ty::I64, expected_ret, scopes);
+                Ty::Str
+            }
+            ("str_index_of", 2) => {
+                self.check(&args[0], &Ty::Str, expected_ret, scopes);
+                self.check(&args[1], &Ty::Str, expected_ret, scopes);
+                Ty::I64
+            }
             // DB, layer 1 + layer 2 (`Ty::Db`'s doc comment) -- `path` is
             // really "connection string": a bare file path or `:memory:`
             // still means SQLite, `postgres://`/`postgresql://` selects
@@ -4354,6 +4383,13 @@ impl<'a> Checker<'a> {
                 self.check(&args[1], &Ty::I64, expected_ret, scopes); // instance_id
                 workflow_result_of(Ty::Json)
             }
+            // `docs/ROADMAP.md` A15's SLA/escalation design — backs
+            // every SLA-declaring workflow's synthesized
+            // `list_<workflow>_overdue()`.
+            ("__workflow_overdue", 1) => {
+                self.check(&args[0], &Ty::Str, expected_ret, scopes); // workflow_name
+                workflow_result_of(Ty::Json)
+            }
             ("__workflow_link_advance", 5) => {
                 self.check(&args[0], &Ty::Str, expected_ret, scopes); // workflow_name
                 self.check(&args[1], &Ty::I64, expected_ret, scopes); // instance_id
@@ -4401,8 +4437,9 @@ impl<'a> Checker<'a> {
             "dot" | "cross" | "solve" | "json_get" | "json_get_str" | "json_get_i64" | "json_get_f64"
             | "json_get_bool" | "json_array_get" | "check_role" | "extract_claim" | "extract_claim_path"
             | "db_query" | "db_execute" | "validate_api_key" | "mq_connect" | "constant_time_str_eq"
-            | "dec_from_i64" | "dec_round" => 2,
-            "http_get" | "https_get" | "exchange_refresh_token" | "mq_publish" | "mq_consume" | "check_role_path" => 3,
+            | "dec_from_i64" | "dec_round" | "str_index_of" => 2,
+            "http_get" | "https_get" | "exchange_refresh_token" | "mq_publish" | "mq_consume" | "check_role_path"
+            | "str_slice" => 3,
             "http_post" | "https_post" | "oidc_validate_token" | "send_email" | "send_sms" | "send_push" => 4,
             "mock_issue_token" => 7,
             "notify" | "__workflow_link_advance" | "__workflow_advance" => 5,

--- a/crates/compiler/src/workflow_lower.rs
+++ b/crates/compiler/src/workflow_lower.rs
@@ -322,6 +322,30 @@ fn lower_one(w: &WorkflowDecl, program: &mut Program) -> Result<(), ParseError> 
         exported: true,
     });
 
+    // 4c. `list_<workflow_snake>_overdue() -> Result(json,
+    // WorkflowActionError)` — `docs/ROADMAP.md` A15's SLA/escalation
+    // design, only synthesized if at least one `state` declares
+    // `sla_seconds` (an unused feature costs nothing, same convention
+    // `link_token_name` above already follows for `LinkToken`). No
+    // `identity` param — this is an operational/admin query, not scoped
+    // to "my own" anything, unlike `pending_for_me`/`submitted_by_me`.
+    if w.states.iter().any(|s| s.entries.iter().any(|(k, _)| k == "sla_seconds")) {
+        program.fns.push(FnDecl {
+            name: format!("list_{}_overdue", to_snake_case(&w.name)),
+            params: vec![],
+            ret: result_ty(Ty::Json),
+            body: one_return(Expr::Call("__workflow_overdue".to_string(), vec![Expr::Str(w.name.clone(), span)], span)),
+            span,
+            declared_effects: None,
+            requires: None,
+            explicit_public: false,
+            nfr: None,
+            module: None,
+            ns: None,
+            exported: true,
+        });
+    }
+
     // 5. `<event>_via_link(instance_id: i64, token: <Workflow>LinkToken,
     // payload: json) -> Result(bool, WorkflowActionError)` — one per
     // distinct `link`-marked event, unauthenticated (no `requires`, no

--- a/crates/compiler/tests/codegen.rs
+++ b/crates/compiler/tests/codegen.rs
@@ -2175,3 +2175,88 @@ fn nfr_error_rate_tracks_real_result_tag_on_both_arms() {
     assert_eq!(code, 0);
     assert_eq!(stdout, "42\n-1\n");
 }
+
+/// Ordinary (ungated) first-class functions, compiled for real
+/// (2026-09): a bare top-level fn name used as a value (`apply(double,
+/// 21)`) evaluates to its own address (`Expr::Ident`'s fallback when
+/// `name` isn't a local variable), and calling a `fn(..)->..`-typed
+/// local (`apply`'s own `f` parameter) emits a real indirect call
+/// (`Codegen::call_indirect`) — no proof, no `acquire`, just a plain
+/// value like any other.
+#[test]
+fn ordinary_first_class_function_value_compiles_and_calls_indirectly() {
+    let src = r#"
+        fn double(x: i64) -> i64 {
+            return x * 2
+        }
+        fn apply(f: fn(i64) -> i64, x: i64) -> i64 {
+            return f(x)
+        }
+        fn main() {
+            print(apply(double, 21))
+        }
+    "#;
+    let (stdout, code) = compile_and_run(src);
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "42\n");
+}
+
+/// `acquire name(proof)` compiled for real (2026-09, LANGUAGE.md §6a):
+/// a `requires`-gated fn's value is obtained only through a real
+/// `check_role`-produced `RoleView` matching its declared role —
+/// `Ok(f)` then calls the acquired function like any other `Ty::Fn`
+/// value (`call_indirect`), `Err(reason)` when the given identity's own
+/// real `RoleView` doesn't prove the required role. This is the
+/// function-level counterpart to
+/// `check_role_produces_real_role_view_that_drives_field_masking`'s
+/// field-level masking — both driven by the same compiled `check_role`,
+/// neither involving the interpreter in any way.
+///
+/// The inner `match`'s arms are deliberately `Err` before `Ok`:
+/// `Codegen::match_expr` infers the match's own result type from its
+/// *first* arm's body, evaluated before that arm's own bindings exist
+/// — `Ok(f) => f(...)` can't be first here, since `f` isn't in scope
+/// yet at that point. A real, disclosed ordering constraint, not a bug
+/// in this test.
+#[test]
+fn acquire_produces_real_callable_fn_value_gated_by_check_role() {
+    let src = r#"
+        struct Text { value: str }
+        struct Employee {
+            name: str,
+            department: str,
+            salary: f64,
+        }
+        fn get_employee(caller: RoleView, name: Text, department: Text, salary: f64) -> Employee
+            effect(pure)
+            requires(role: "admin")
+        {
+            return Employee(name.value, department.value, salary)
+        }
+        fn main() {
+            let admin_identity: VerifiedIdentity = VerifiedIdentity("alice", "https://idp", "app", 0, 0, "admin")
+            let admin_view: Employee = match check_role(admin_identity, "admin") {
+                Err(e) => Employee("", "", -1.0),
+                Ok(role) => match acquire get_employee(role) {
+                    Err(msg) => Employee("denied", "", -2.0),
+                    Ok(f) => f(role, Text("Ada"), Text("Eng"), 150000.0),
+                },
+            }
+            print(admin_view.salary)
+
+            let guest_identity: VerifiedIdentity = VerifiedIdentity("bob", "https://idp", "app", 0, 0, "guest")
+            let guest_view: Employee = match check_role(guest_identity, "guest") {
+                Err(e) => Employee("", "", -1.0),
+                Ok(role) => match acquire get_employee(role) {
+                    Err(msg) => Employee("denied", "", -2.0),
+                    Ok(f) => f(role, Text("Ada"), Text("Eng"), 150000.0),
+                },
+            }
+            print(guest_view.salary)
+            print(guest_view.name)
+        }
+    "#;
+    let (stdout, code) = compile_and_run(src);
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "150000.000000\n-2.000000\ndenied\n");
+}

--- a/crates/compiler/tests/codegen.rs
+++ b/crates/compiler/tests/codegen.rs
@@ -1890,6 +1890,140 @@ fn compiled_listen_accept_serves_a_real_client() {
     assert_eq!(String::from_utf8_lossy(&output.stdout).trim_end(), "client hello");
 }
 
+/// Phase 0 (compiled `serve`): a real curl-shaped request over a real
+/// socket, twice, against the *same* running compiled process, routed by
+/// path to two different compiled `fn`s -- `str_index_of`/`str_slice`/
+/// `len(str)` doing the request-line parsing, plain `if`/`else if` + `==`
+/// doing the routing. Same "spawn the compiled binary since `accept`
+/// blocks, connect a real client from the test" shape as
+/// `compiled_listen_accept_serves_a_real_client`, except this server's
+/// own `while true` loop never exits on its own, so the test kills the
+/// child at the end instead of waiting on it.
+#[test]
+fn compiled_serve_routes_by_path_to_two_compiled_functions() {
+    let port = free_port();
+    let src = format!(
+        r#"
+        struct Text {{
+            value: str,
+        }}
+
+        fn handle_hello() -> Text {{
+            return Text("hello from /api/hello")
+        }}
+
+        fn handle_echo() -> Text {{
+            return Text("hello from /api/echo")
+        }}
+
+        fn main() {{
+            let l: tcp_listener = listen({port})
+            while true {{
+                let conn: tcp = accept(l)
+                let req: str = recv(conn)
+
+                let line_end: i64 = str_index_of(req, "\r\n")
+                let line: str = str_slice(req, 0, line_end)
+                let sp1: i64 = str_index_of(line, " ")
+                let after_method: str = str_slice(line, sp1 + 1, len(line))
+                let sp2: i64 = str_index_of(after_method, " ")
+                let path: str = str_slice(after_method, 0, sp2)
+
+                if path == "/api/hello" {{
+                    let body: Text = handle_hello()
+                    send(conn, "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n")
+                    send(conn, body.value)
+                }} else if path == "/api/echo" {{
+                    let body: Text = handle_echo()
+                    send(conn, "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n")
+                    send(conn, body.value)
+                }} else {{
+                    send(conn, "HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n")
+                }}
+                stop conn
+            }}
+        }}
+    "#
+    );
+
+    let program = parse_checked(&src);
+    let report = nirdosha::smt::analyze(&program);
+    let mut out_path = std::env::temp_dir();
+    out_path.push(format!("nirdosha_test_{}_{}", std::process::id(), unique_suffix()));
+    codegen::build(&program, &report, &out_path, codegen::OptLevel::O2).expect("codegen::build should succeed");
+    let mut child = Command::new(&out_path).spawn().expect("compiled binary should start");
+
+    use std::io::{Read, Write};
+    let request = |path: &str| -> Vec<u8> {
+        let mut attempt = 0;
+        let mut conn = loop {
+            match std::net::TcpStream::connect(("127.0.0.1", port)) {
+                Ok(s) => break s,
+                Err(_) if attempt < 50 => {
+                    attempt += 1;
+                    std::thread::sleep(std::time::Duration::from_millis(20));
+                }
+                Err(e) => panic!("could not connect to the compiled listener: {e}"),
+            }
+        };
+        conn.write_all(format!("GET {path} HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n").as_bytes()).unwrap();
+        let mut buf = Vec::new();
+        conn.read_to_end(&mut buf).unwrap();
+        buf
+    };
+
+    let hello_response = String::from_utf8_lossy(&request("/api/hello")).into_owned();
+    let echo_response = String::from_utf8_lossy(&request("/api/echo")).into_owned();
+    let missing_response = String::from_utf8_lossy(&request("/api/unknown")).into_owned();
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = std::fs::remove_file(&out_path);
+
+    assert!(hello_response.starts_with("HTTP/1.1 200 OK"), "unexpected response: {hello_response:?}");
+    assert!(hello_response.ends_with("hello from /api/hello"), "unexpected response: {hello_response:?}");
+    assert!(echo_response.starts_with("HTTP/1.1 200 OK"), "unexpected response: {echo_response:?}");
+    assert!(echo_response.ends_with("hello from /api/echo"), "unexpected response: {echo_response:?}");
+    assert!(missing_response.starts_with("HTTP/1.1 404 Not Found"), "unexpected response: {missing_response:?}");
+    assert_ne!(hello_response, echo_response, "two different routes must produce two different bodies");
+}
+
+#[test]
+fn str_slice_and_str_index_of_parse_a_request_line() {
+    let src = r#"
+        fn main() {
+            let s: str = "GET /api/hello HTTP/1.1"
+            print(len(s))
+            let sp1: i64 = str_index_of(s, " ")
+            print(sp1)
+            let method: str = str_slice(s, 0, sp1)
+            print(method)
+            let rest: str = str_slice(s, sp1 + 1, len(s))
+            let sp2: i64 = str_index_of(rest, " ")
+            let path: str = str_slice(rest, 0, sp2)
+            print(path)
+            print(str_index_of(s, "xyz"))
+            print(path == "/api/hello")
+        }
+    "#;
+    let (stdout, code) = compile_and_run(src);
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "23\n3\nGET\n/api/hello\n-1\n1\n");
+}
+
+#[test]
+fn str_slice_traps_on_out_of_bounds_end() {
+    let src = r#"
+        fn main() {
+            let s: str = "hello"
+            let bad: str = str_slice(s, 2, 10)
+            print(bad)
+        }
+    "#;
+    let (_, code) = compile_and_run(src);
+    assert_ne!(code, 0, "an out-of-bounds str_slice should trap, not succeed");
+}
+
 #[test]
 fn connecting_to_a_closed_port_traps_at_runtime() {
     let port = free_port(); // bound then immediately dropped -- nothing listens on it
@@ -2259,4 +2393,843 @@ fn acquire_produces_real_callable_fn_value_gated_by_check_role() {
     let (stdout, code) = compile_and_run(src);
     assert_eq!(code, 0);
     assert_eq!(stdout, "150000.000000\n-2.000000\ndenied\n");
+}
+
+/// Phase 1 (identity crypto): a genuine HMAC-SHA256 JWT, verified end to
+/// end in a compiled binary via real `jsonwebtoken` signature verification
+/// against a static JWKS -- same fixture as `examples/features/
+/// 30_identity_oidc.nir`/`31_mock_identity_provider.nir` (`kid:"key1"`,
+/// `kty:"oct"`, `k:"bXktc2VjcmV0LWtleQ"` = `"my-secret-key"`). Arms are
+/// `Err(...)`-first throughout -- the documented, pre-existing
+/// `match_expr` workaround (`docs/PHASE0.md`'s "Twenty-first update":
+/// `local_ty_of` infers a match's result type from its *first* arm's
+/// body, evaluated before that arm's own bindings exist in scope, so an
+/// `Ok(id) => id`-shaped first arm doesn't resolve; reordering is the
+/// complete, correct fix, not something this phase needed to touch).
+#[test]
+fn oidc_validate_token_verifies_a_real_jwt_and_drives_check_role_and_extract_claim() {
+    let src = r#"
+        struct Text {
+            value: str,
+        }
+
+        fn main() {
+            let token: str = "eyJhbGciOiAiSFMyNTYiLCAia2lkIjogImtleTEifQ.eyJzdWIiOiAiYWxpY2UiLCAiaXNzIjogImh0dHBzOi8vZXhhbXBsZS5jb20iLCAiYXVkIjogIm15LWFwcCIsICJleHAiOiAyMDAwMDAwMDAwLCAiaWF0IjogMTcwMDAwMDAwMCwgInJvbGVzIjogWyJwaHlzaWNpYW4iXSwgImRlcGFydG1lbnQiOiAiY2FyZGlvbG9neSJ9.nrFdeqNDwXWLeGzud6X9Q4ITzCXULzZBBK8y51LGYXs"
+            let jwks: str = "{\"keys\":[{\"kid\":\"key1\",\"kty\":\"oct\",\"k\":\"bXktc2VjcmV0LWtleQ\"}]}"
+
+            let identity: VerifiedIdentity = match oidc_validate_token(token, "https://example.com", "my-app", jwks) {
+                Err(e) => VerifiedIdentity("", "", "", 0, 0, "{}"),
+                Ok(id) => id,
+            }
+            print(identity.subject)
+            print(identity.issuer)
+            print(identity.audience)
+
+            let has_physician: bool = match check_role(identity, "physician") {
+                Err(e) => false,
+                Ok(proof) => true,
+            }
+            print(has_physician)
+
+            let has_admin: bool = match check_role(identity, "admin") {
+                Err(e) => false,
+                Ok(proof) => true,
+            }
+            print(has_admin)
+
+            let department: Text = match extract_claim(identity, "department") {
+                Err(e) => Text(e),
+                Ok(claim) => Text(claim.value),
+            }
+            print(department.value)
+
+            print(identity_expired(identity, 999999999999))
+            print(identity_expired(identity, 1700000001))
+
+            let wrong_issuer_rejected: bool = match oidc_validate_token(token, "https://wrong-issuer.example", "my-app", jwks) {
+                Err(e) => true,
+                Ok(id) => false,
+            }
+            print(wrong_issuer_rejected)
+
+            // A tampered signature (last character of the token flipped)
+            // is a real `Err`, never a trap.
+            let tampered: str = "eyJhbGciOiAiSFMyNTYiLCAia2lkIjogImtleTEifQ.eyJzdWIiOiAiYWxpY2UiLCAiaXNzIjogImh0dHBzOi8vZXhhbXBsZS5jb20iLCAiYXVkIjogIm15LWFwcCIsICJleHAiOiAyMDAwMDAwMDAwLCAiaWF0IjogMTcwMDAwMDAwMCwgInJvbGVzIjogWyJwaHlzaWNpYW4iXSwgImRlcGFydG1lbnQiOiAiY2FyZGlvbG9neSJ9.nrFdeqNDwXWLeGzud6X9Q4ITzCXULzZBBK8y51LGYXt"
+            let tampered_rejected: bool = match oidc_validate_token(tampered, "https://example.com", "my-app", jwks) {
+                Err(e) => true,
+                Ok(id) => false,
+            }
+            print(tampered_rejected)
+        }
+    "#;
+    let (stdout, code) = compile_and_run(src);
+    assert_eq!(code, 0);
+    assert_eq!(
+        stdout,
+        "alice\nhttps://example.com\nmy-app\n1\n0\ncardiology\n1\n0\n1\n1\n"
+    );
+}
+
+/// Phase 2 (`db`, SQLite via `rusqlite`): a real, unmodified copy of
+/// `examples/features/27_database.nir` — `db_connect`/`db_execute`/
+/// `db_query`/`json_array_get`/`json_get_str`/`stop`, compiled and run
+/// against a real in-memory SQLite database. A schema is created, two
+/// rows inserted, a filtered `SELECT` round-tripped through the new
+/// `Ty::Json`-as-text representation, a row updated, and a connection
+/// failure (a real `Err`, never a trap) all exercised end to end.
+#[test]
+fn db_connect_execute_query_round_trips_real_sqlite_rows() {
+    let src = include_str!("../../../examples/features/27_database.nir");
+    let (stdout, code) = compile_and_run(src);
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "ada\n1\n");
+}
+
+/// The rest of the `json_*` accessor surface `27_database.nir` doesn't
+/// happen to exercise — `json_get_i64`/`json_get_f64`/`json_get_bool`/
+/// `json_array_len` read out of a real `db_query` row (SQLite has no
+/// native boolean column, so `active` round-trips as `0`/`1`, matching
+/// `NirBindValue`'s own documented bool-as-integer convention), plus
+/// `json_parse`/`json_get`/`json_set_str` against plain literals. `Json`
+/// and `Str` are distinct types even though they share one compiled
+/// representation (`Ty::Json`'s `llvm_ty` arm) — `typeck.rs` enforces
+/// the distinction like any other nominal type, so every `json_get_*`
+/// call here reads directly from the live `Ty::Json` value in scope
+/// (`row`, `parsed`), never through a `Text`-wrapped detour; only the
+/// final *scalar* extractions (`str`/`i64`/`f64`/`bool`) cross
+/// `build_row`'s own function boundary, carried in one `Row` struct
+/// (struct *fields* aren't inspected by the `str`-at-boundary ban —
+/// `contains_str` only walks a generic type's own type arguments, not a
+/// plain struct's field list — the same reason the ban's own suggested
+/// `struct Text { value: str }` fix works at all). Arms are
+/// `Err(...)`-first throughout — the same documented, pre-existing
+/// `match_expr` ordering workaround the identity test above already
+/// uses (a bare bound identifier as an arm's body, e.g. `Ok(f) => f`,
+/// needs its real type already known when `match_expr` infers the whole
+/// match's result type from its *first* arm; putting `Err` first
+/// sidesteps that inference order entirely).
+#[test]
+fn json_accessors_read_every_scalar_type_out_of_a_real_db_query_result() {
+    let src = r#"
+        struct Row {
+            name: str,
+            id: i64,
+            score: f64,
+            active: bool,
+            len_is_err: bool,
+        }
+
+        // `json` is a plain parameter type here (like `db` already is for
+        // `conn` below) -- not banned, since `contains_str` only walks a
+        // generic type's own type arguments, and bare `Ty::Json` isn't
+        // one. Kept as its own function so `build_row` below never needs
+        // a multi-statement match-arm body (this grammar's `=>` takes one
+        // expression, not a `{ }` block) to combine several `json_get_*`
+        // reads into one `Row`.
+        fn row_from_json(row: json) -> Row {
+            let name: str = match json_get_str(row, "name") {
+                Err(e) => "",
+                Ok(s) => s,
+            }
+            let id: i64 = match json_get_i64(row, "id") {
+                Err(e) => -1,
+                Ok(n) => n,
+            }
+            let score: f64 = match json_get_f64(row, "score") {
+                Err(e) => -1.0,
+                Ok(f) => f,
+            }
+            let active: bool = match json_get_bool(row, "active") {
+                Err(e) => false,
+                Ok(b) => b,
+            }
+            let len_is_err: bool = match json_array_len(row) {
+                Err(e) => true, // `row` is one object, not an array
+                Ok(n) => false,
+            }
+            return Row(name, id, score, active, len_is_err)
+        }
+
+        fn build_row(conn: db) -> Row {
+            let created: i64 = match db_execute(conn, "CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT, score REAL, active INTEGER)") {
+                Err(e) => -1,
+                Ok(n) => n,
+            }
+            let inserted: i64 = match db_execute(conn, "INSERT INTO t (name, score, active) VALUES (?, ?, ?)", "ada", 4.5, true) {
+                Err(e) => -1,
+                Ok(n) => n,
+            }
+            let result: Row = match db_query(conn, "SELECT * FROM t") {
+                Err(e) => Row("", -1, -1.0, false, false),
+                Ok(rows) => match json_array_get(rows, 0) {
+                    Err(e) => Row("", -1, -1.0, false, false),
+                    Ok(row) => row_from_json(row),
+                },
+            }
+            stop conn
+            return result
+        }
+
+        fn main() {
+            let row: Row = match db_connect(":memory:") {
+                Err(e) => Row("", -1, -1.0, false, false),
+                Ok(conn) => build_row(conn),
+            }
+            print(row.name)        // ada
+            print(row.id)          // 1
+            print(row.score)       // 4.5
+            print(row.active)      // true -- bound as SQLite integer 1; `nir_json_get_bool` accepts a real JSON boolean or a 0/1 integer
+            print(row.len_is_err)  // true
+
+            let parsed: bool = match json_parse("{\"a\": 1}") {
+                Err(e) => false,
+                Ok(j) => match json_get_i64(j, "a") {
+                    Err(e) => false,
+                    Ok(n) => n == 1,
+                },
+            }
+            print(parsed) // 1 (bool prints as 1/0, not "true"/"false")
+
+            // Every match's first-listed arm here is a literal, not a
+            // bare bound identifier -- `Ok(s) => s`-shaped passthroughs
+            // (like the innermost arm below) are fine in *second*
+            // position (`match_expr` only infers the whole match's
+            // result type from `arms[0]`'s body, `docs/PHASE0.md`'s
+            // "Twenty-first update"), but a bare identifier *first*
+            // (`Err(e) => e` would have been, here) hits that same
+            // inference-order gap regardless of whether the payload is
+            // an aggregate or, as here, a plain `str`/`json` value.
+            let nested: str = match json_parse("{\"outer\": {\"inner\": \"value\"}}") {
+                Err(e) => "parse-error",
+                Ok(doc) => match json_get(doc, "outer") {
+                    Err(e) => "get-error",
+                    Ok(inner) => match json_get_str(inner, "inner") {
+                        Err(e) => "get-str-error",
+                        Ok(s) => s,
+                    },
+                },
+            }
+            print(nested) // value
+
+            let set_ok: bool = match json_parse("null") {
+                Err(e) => false,
+                Ok(null_doc) => match json_set_str(null_doc, "extra", "value") {
+                    Err(e) => false,
+                    Ok(j) => match json_get_str(j, "extra") {
+                        Err(e) => false,
+                        Ok(s) => s == "value",
+                    },
+                },
+            }
+            print(set_ok) // 1
+        }
+    "#;
+    let (stdout, code) = compile_and_run(src);
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "ada\n1\n4.500000\n1\n1\n1\nvalue\n1\n");
+}
+
+/// Phase 3 (`transact`, Layer 1 only — `docs/TRANSACT.md`,
+/// `codegen::emit_transact`'s own doc comment has the full scope): a
+/// real, unmodified copy of `examples/features/36_transact.nir` —
+/// `precheck`/`network`/`verify`/`commit`/`compensate`/`log`, the
+/// implicit `network`/`verify`/`txn_id` bindings, and a `transact { ... }`
+/// expression's own real `bool` value, all compiled and run for real.
+/// `checkout(10)` commits, `checkout(-5)` compensates, `minimal(1)`
+/// (no `precheck`/`compensate`/`log`) commits.
+#[test]
+fn transact_commits_and_compensates_for_real_matching_the_checked_in_example() {
+    let src = include_str!("../../../examples/features/36_transact.nir");
+    let (stdout, code) = compile_and_run(src);
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "committing\n10\nlogged\n10\n1\n1\ncompensating\n-5\nlogged\n-5\n0\n0\ncommitting\n1\n1\n");
+}
+
+/// `precheck == false` aborts the whole block immediately — nothing
+/// durable would ever be written (moot today, no durability log exists
+/// yet), but concretely: `network`/`verify`/`commit`/`compensate`/`log`
+/// must never run at all, and the block's own value is `false`. Not
+/// exercised by `36_transact.nir` itself (both its `checkout` calls have
+/// `db_reachable()` return `true`), so a dedicated test.
+#[test]
+fn transact_precheck_false_skips_every_other_slot() {
+    let src = r#"
+        fn never_reachable() -> bool {
+            print("db down")
+            return false
+        }
+        fn call_api(txn_id: str, amount: i64) -> i64 {
+            print("network ran") // must never print
+            return amount
+        }
+        fn check(resp: i64) -> bool {
+            print("verify ran") // must never print
+            return resp > 0
+        }
+        fn update_db(amount: i64) -> i64 {
+            print("commit ran") // must never print
+            return amount
+        }
+
+        fn main() {
+            let result: bool = transact {
+                precheck: never_reachable()
+                network:  call_api(txn_id, 5)
+                verify:   check(network)
+                commit:   update_db(5)
+            }
+            print(result)
+        }
+    "#;
+    let (stdout, code) = compile_and_run(src);
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "db down\n0\n");
+}
+
+/// `verify == false` with no `compensate` slot at all is still
+/// immediately terminal (`docs/TRANSACT.md`'s own explicit note) — the
+/// block yields `false`, nothing else runs.
+#[test]
+fn transact_verify_false_with_no_compensate_slot_yields_false() {
+    let src = r#"
+        fn call_api(txn_id: str, amount: i64) -> i64 {
+            return amount
+        }
+        fn check(resp: i64) -> bool {
+            return resp > 0
+        }
+        fn update_db(amount: i64) -> i64 {
+            print("commit ran") // must never print
+            return amount
+        }
+
+        fn main() {
+            let result: bool = transact {
+                network: call_api(txn_id, -5)
+                verify:  check(network)
+                commit:  update_db(-5)
+            }
+            print(result)
+        }
+    "#;
+    let (stdout, code) = compile_and_run(src);
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "0\n");
+}
+
+/// `network`'s `retry`/`timeout` modifiers are a real, architectural
+/// rejection (`check_expr`'s pre-pass), not a generic "unsupported"
+/// fallthrough — confirms the specific error path, not just that *some*
+/// error occurs.
+#[test]
+fn transact_network_retry_is_explicitly_rejected_not_silently_ignored() {
+    let src = r#"
+        fn call_api(txn_id: str, amount: i64) -> i64 { return amount }
+        fn check(resp: i64) -> bool { return resp > 0 }
+        fn update_db(amount: i64) -> i64 { return amount }
+
+        fn main() {
+            let result: bool = transact {
+                network: call_api(txn_id, 5) retry 3
+                verify:  check(network)
+                commit:  update_db(5)
+            }
+            print(result)
+        }
+    "#;
+    let program = parse_checked(src);
+    let report = nirdosha::smt::analyze(&program);
+    let mut out_path = std::env::temp_dir();
+    out_path.push(format!("nirdosha_test_{}_{}", std::process::id(), unique_suffix()));
+    let err = codegen::build(&program, &report, &out_path, codegen::OptLevel::O2).expect_err("retry should be rejected");
+    assert!(err.contains("retry"), "unexpected error message: {err}");
+}
+
+/// Phase 4 (`mq`, Redis): a real, compiled `mq_connect`/`mq_publish`/
+/// `mq_consume` round trip against the real local Redis instance this
+/// environment already has running at `127.0.0.1:6379` (same host/port
+/// `examples/features/28_message_queue.nir` itself uses) — not a mock.
+/// `Ok(m) => m` (a bare bound identifier as `mq_consume`'s Ok arm) is
+/// deliberately *not* written first here — the same documented
+/// `match_expr` ordering workaround the `transact`/`db` tests above
+/// already use.
+#[test]
+fn mq_publish_and_consume_round_trip_a_real_message() {
+    let src = r#"
+        struct Text { value: str }
+
+        fn round_trip(conn: mq) -> Text {
+            let published: bool = match mq_publish(conn, "nirdosha_codegen_test_queue", "hello from a compiled binary") {
+                Err(e) => false,
+                Ok(u) => true,
+            }
+            print(published)
+
+            let consumed: Text = match mq_consume(conn, "nirdosha_codegen_test_queue", 2) {
+                Err(e) => Text(e),
+                Ok(m) => Text(m),
+            }
+            stop conn
+            return consumed
+        }
+
+        fn main() {
+            let result: Text = match mq_connect("127.0.0.1", 6379) {
+                Err(e) => Text(e),
+                Ok(conn) => round_trip(conn),
+            }
+            print(result.value)
+        }
+    "#;
+    let (stdout, code) = compile_and_run(src);
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "1\nhello from a compiled binary\n");
+}
+
+/// Phase 4 (`http`/`https`): a real, compiled `http_get`/`http_post`
+/// round trip against a real local TCP server the same test spawns
+/// (self-contained, no external network dependency, same shape
+/// `compiled_listen_accept_serves_a_real_client` already uses) — proves
+/// the full compiled pipeline (`codegen::emit_http_call` -> `nir_http_get`/
+/// `nir_http_post` -> a real socket), not just the kernel in isolation
+/// (already covered by `runtime-kernels`' own `http_kernel_tests`).
+/// `https_get`/`https_post` (vendored-OpenSSL-linked, chunked-transfer-
+/// encoding-decoding) are exercised directly against a real production
+/// server (`example.com`) as a manual verification step instead of an
+/// automated test here, to keep this suite free of an external-network
+/// dependency — the shared `parse_http_response`/`decode_chunked_body`
+/// logic underneath both is already covered by `runtime-kernels`' own
+/// unit tests either way.
+#[test]
+fn http_get_and_post_round_trip_against_a_real_local_server() {
+    let get_port = free_port();
+    let src = format!(
+        r#"
+        struct HttpResult {{
+            status: i64,
+            body: str,
+        }}
+
+        fn server(l: tcp_listener) -> unit {{
+            let conn: tcp = accept(l)
+            let req: str = recv(conn)
+            send(conn, "HTTP/1.1 201 Created\r\nConnection: close\r\n\r\ncreated ok")
+            stop conn
+            stop l
+            return
+        }}
+
+        fn main() {{
+            let l: tcp_listener = listen({get_port})
+            let h: thread unit = spawn server(l)
+
+            let result: HttpResult = match http_get("127.0.0.1", {get_port}, "/api/thing") {{
+                Err(e) => HttpResult(-1, e),
+                Ok(resp) => HttpResult(resp.status, resp.body),
+            }}
+            print(result.status)
+            print(result.body)
+            join h
+        }}
+    "#
+    );
+    let (stdout, code) = compile_and_run(&src);
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "201\ncreated ok\n");
+
+    let post_port = free_port();
+    let src2 = format!(
+        r#"
+        struct HttpResult {{
+            status: i64,
+            body: str,
+        }}
+
+        // `thread`/`spawn`/`join` compile word-sized payloads only
+        // (`docs/LANGUAGE.md` §10) -- `str`/struct results don't cross
+        // that boundary yet, so the server prints the request it
+        // received itself, from inside the spawned thread, rather than
+        // returning it through `join`.
+        fn server(l: tcp_listener) -> unit {{
+            let conn: tcp = accept(l)
+            let req: str = recv(conn)
+            print(req) // the real request the server received, proving Content-Length + body were sent
+            send(conn, "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nack")
+            stop conn
+            stop l
+            return
+        }}
+
+        fn main() {{
+            let l: tcp_listener = listen({post_port})
+            let h: thread unit = spawn server(l)
+
+            let result: HttpResult = match http_post("127.0.0.1", {post_port}, "/submit", "payload=42") {{
+                Err(e) => HttpResult(-1, e),
+                Ok(resp) => HttpResult(resp.status, resp.body),
+            }}
+            print(result.status)
+            print(result.body)
+            join h
+        }}
+    "#
+    );
+    let (stdout2, code2) = compile_and_run(&src2);
+    assert_eq!(code2, 0);
+    // The server's own `print(req)` runs (in real wall-clock order)
+    // before `main`'s `http_post` can possibly finish reading a
+    // response — the server must `recv`, print, and `send` before
+    // `main`'s blocking read returns at all — so `req`'s print always
+    // lands first in `stdout`, found by running this, not assumed.
+    let request_line = stdout2.lines().next().unwrap();
+    assert!(request_line.starts_with("POST /submit HTTP/1.1"), "unexpected request: {request_line}");
+    assert!(stdout2.contains("Content-Length: 10"), "unexpected request: {stdout2}");
+    assert!(stdout2.trim_end().ends_with("200\nack"), "unexpected tail: {stdout2}");
+}
+
+/// Phase 5 (`workflow` Layer 1, `docs/WORKFLOW.md`): a real, compiled
+/// `start_<workflow>`/`advance_<workflow>` round trip — an empty-`data`
+/// workflow (`Codegen::resolve_workflow_layer1`'s own disclosed
+/// restriction; `38_workflow.nir`'s own non-empty `data` block is why
+/// that example still isn't compiled-runnable this round, see
+/// `examples/features/README.md`), `on_entry`/`on_exit` actions that
+/// both read the implicit `instance_id` binding, an ordinary transition,
+/// and a `terminal` state reached for real. Also proves
+/// `Err(NoSuchTransition)`/`Err(InstanceNotFound)` are real `Err`s, never
+/// traps, for a bad event and a nonexistent instance id respectively.
+#[test]
+fn workflow_start_advance_runs_on_entry_on_exit_and_reaches_a_terminal_state() {
+    let src = r#"
+        fn log_open(instance_id: i64) -> unit {
+            print("opened", instance_id)
+        }
+        fn log_close(instance_id: i64) -> unit {
+            print("closed", instance_id)
+        }
+        fn log_exit_open(instance_id: i64) -> unit {
+            print("exiting open", instance_id)
+        }
+
+        workflow Ticket {
+            state Open {
+                on_entry {
+                    log_open(instance_id)
+                }
+                on_exit {
+                    log_exit_open(instance_id)
+                }
+                on Close -> Closed
+            }
+            state Closed terminal {
+                on_entry {
+                    log_close(instance_id)
+                }
+            }
+        }
+
+        // `advance_ticket`'s trailing `payload: json` argument needs a
+        // real `json` value, not a `Result(json, str)` — this mirrors
+        // `38_workflow.nir`'s own `decide_approval` wrapper exactly,
+        // *including* its arm order: `Ok(payload) => advance_ticket(...)`
+        // (a plain call with a fully known return type) must come first.
+        // Swapping the order — `Err(...) => Err(NoSuchTransition())`
+        // first — hits a different, also pre-existing `local_ty_of`/
+        // `ctor_ty` gap: with no expected-type context, a generic
+        // `Err(...)`-wrapping arm can't resolve which `Result`
+        // instantiation it belongs to when it's `arms[0]`.
+        fn advance_now(identity: VerifiedIdentity, instance_id: i64, event: TicketEvent) -> Result(bool, WorkflowActionError) {
+            return match json_parse("{}") {
+                Ok(payload) => advance_ticket(identity, instance_id, event, payload),
+                Err(e) => Err(NoSuchTransition()),
+            }
+        }
+
+        fn main() {
+            let identity: VerifiedIdentity = VerifiedIdentity("u1", "iss", "aud", 9999999999, 0, "{}")
+
+            let instance_id: i64 = match start_ticket(None(), TicketData()) {
+                Err(e) => -1,
+                Ok(id) => id,
+            }
+            print(instance_id)
+
+            let closed: bool = match advance_now(identity, instance_id, Close()) {
+                Err(e) => false,
+                Ok(v) => v,
+            }
+            print(closed)
+
+            // `Closed` has no outgoing transitions -- firing `Close()`
+            // again is a real `Err` (`NoSuchTransition`), never a trap.
+            let bad_event: bool = match advance_now(identity, instance_id, Close()) {
+                Err(e) => true,
+                Ok(v) => false,
+            }
+            print(bad_event)
+
+            // A nonexistent instance id is a real `Err` (`InstanceNotFound`),
+            // never a trap either.
+            let missing: bool = match advance_now(identity, 999999, Close()) {
+                Err(e) => true,
+                Ok(v) => false,
+            }
+            print(missing)
+        }
+    "#;
+    let (stdout, code) = compile_and_run(src);
+    assert_eq!(code, 0, "stdout: {stdout}");
+    // `print(a, b)` prints each argument on its own line (`Codegen::call`'s
+    // `"print"` arm), and `Open`'s `on_entry` runs *inside* `start_ticket`
+    // itself, before it returns the new instance id — so "opened"/"1"
+    // land before `main`'s own `print(instance_id)` line. `true`/`false`
+    // print as `1`/`0` (`Codegen::call`'s own disclosed cosmetic
+    // difference from the deleted interpreter's `"true"`/`"false"`).
+    assert_eq!(
+        stdout,
+        "opened\n1\n1\nexiting open\n1\nclosed\n1\n1\n1\n1\n",
+        "unexpected stdout: {stdout}"
+    );
+}
+
+/// Phase 5 (`send_email`, `docs/WORKFLOW.md`): a workflow's `on_entry`
+/// action really does post an authenticated HTTPS-shaped request to a
+/// real local server, driven by a real, admin-editable provider row in a
+/// real SQLite table — not a mock. Also proves the not-configured path
+/// (no provider row at all) is a real `Err`, never a trap.
+#[test]
+fn workflow_on_entry_send_email_posts_to_a_real_configured_provider() {
+    let port = free_port();
+    let src = format!(
+        r#"
+        fn server(l: tcp_listener) -> unit {{
+            let conn: tcp = accept(l)
+            let req: str = recv(conn)
+            print(req)
+            send(conn, "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nsent")
+            stop conn
+            stop l
+        }}
+
+        // Neither `db` nor `json` has a literal an `Err` arm could fall
+        // back to (there's no syntax for an opaque handle, and
+        // `27_database.nir`'s own idiom never binds a bare `json` out of
+        // a match either) -- so, like that file, every `Result`-typed
+        // value here is consumed inside a nested match, never unwrapped
+        // into a bare `let x: db/json = match {{ ... }}` with a made-up
+        // fallback.
+        fn notify_with_conn(conn: db, instance_id: i64) -> unit {{
+            let created: i64 = match db_execute(conn, "CREATE TABLE email_provider_config (id INTEGER PRIMARY KEY, active INTEGER, host TEXT, port INTEGER, path TEXT, api_key TEXT, from_address TEXT)") {{
+                Err(e) => -1,
+                Ok(n) => n,
+            }}
+            let inserted: i64 = match db_execute(conn, "INSERT INTO email_provider_config (active, host, port, path, api_key, from_address) VALUES (1, ?, ?, ?, ?, ?)", "127.0.0.1", {port}, "/send", "secret-key-123", "noreply@example.com") {{
+                Err(e) => -1,
+                Ok(n) => n,
+            }}
+            match json_parse("{{}}") {{
+                Ok(vars) => match send_email(conn, ByRole("reviewer"), "ticket_opened", vars) {{
+                    Ok(v) => print(v),
+                    Err(e) => print(false),
+                }},
+                Err(e) => print(e),
+            }}
+            stop conn
+        }}
+
+        fn notify_open(instance_id: i64) -> unit {{
+            match db_connect(":memory:") {{
+                Ok(conn) => notify_with_conn(conn, instance_id),
+                Err(e) => print(e),
+            }}
+        }}
+
+        workflow Ticket {{
+            state Open {{
+                on_entry {{
+                    notify_open(instance_id)
+                }}
+                on Close -> Closed
+            }}
+            state Closed terminal {{
+            }}
+        }}
+
+        // No provider row at all this time -- a real `Err`, never a trap.
+        fn check_not_configured(conn: db) -> bool {{
+            let not_configured: bool = match json_parse("{{}}") {{
+                Ok(vars) => match send_email(conn, ByRole("reviewer"), "ticket_opened", vars) {{
+                    Ok(v) => false,
+                    Err(e) => true,
+                }},
+                Err(e) => false,
+            }}
+            stop conn
+            return not_configured
+        }}
+
+        fn main() {{
+            let l: tcp_listener = listen({port})
+            let h: thread unit = spawn server(l)
+
+            let instance_id: i64 = match start_ticket(None(), TicketData()) {{
+                Err(e) => -1,
+                Ok(id) => id,
+            }}
+            print(instance_id)
+            join h
+
+            match db_connect(":memory:") {{
+                Ok(conn) => print(check_not_configured(conn)),
+                Err(e) => print(false),
+            }}
+        }}
+    "#
+    );
+    let (stdout, code) = compile_and_run(&src);
+    assert_eq!(code, 0, "stdout: {stdout}");
+    let lines: Vec<&str> = stdout.lines().collect();
+    // The server's own `print(req)` (real happens-before: `send_email`'s
+    // blocking POST must complete before `start_ticket`/`main` can move
+    // on) lands before `main`'s own prints -- same real, verified-by-
+    // running ordering `http_get_and_post_round_trip_against_a_real_local_server`
+    // already established. Real, authenticated, JSON-bodied POST: the
+    // provider's own `api_key` shows up as a real `Authorization: Bearer`
+    // header, and the body is `{"to","from","template","vars"}` built
+    // straight from the real, admin-editable provider row and the
+    // `send_email` call's own arguments (`send_via_provider`'s own doc
+    // comment) -- not a hand-typed test fixture.
+    assert!(lines[0].starts_with("POST /send HTTP/1.1"), "unexpected request line: {}", lines[0]);
+    assert!(stdout.contains("Authorization: Bearer secret-key-123"), "missing auth header: {stdout}");
+    assert!(
+        stdout.contains(r#""from":"noreply@example.com""#) && stdout.contains(r#""template":"ticket_opened""#) && stdout.contains(r#""to":"reviewer""#),
+        "unexpected body: {stdout}"
+    );
+    // Tail, in real observed order: the on_entry action's own
+    // `print(v)` (the successful `send_email` -> `true`), `main`'s
+    // `print(instance_id)`, then `print(check_not_configured(conn))`
+    // (no provider row the second time -- a real `Err`, never a trap,
+    // reported as `true`).
+    assert_eq!(&lines[lines.len() - 3..], ["1", "1", "1"], "unexpected tail: {stdout}");
+}
+
+/// Phase 5 (`__workflow_overdue`, `docs/ROADMAP.md` A15): `state {
+/// sla_seconds: N }` plus the synthesized `list_<workflow>_overdue()`
+/// really do detect a stale instance — no scheduling/cron primitive
+/// exists in this language (`docs/WORKFLOW.md`'s own "Deliberate non-
+/// goals" section), so this is the disclosed, queryable fallback an
+/// external scheduler would poll. Also proves a state with *no*
+/// `sla_seconds` entry is never reported overdue, and that a
+/// non-terminal `state` with no matching `sla_seconds` key still moves
+/// on normally.
+#[test]
+fn workflow_list_overdue_reports_a_real_stale_instance_and_ignores_states_with_no_sla() {
+    let src = r#"
+        workflow Ticket {
+            state Open {
+                sla_seconds: 1
+                on Close -> Closed
+            }
+            state Closed terminal {
+            }
+        }
+
+        fn main() {
+            let instance_id: i64 = match start_ticket(None(), TicketData()) {
+                Err(e) => -1,
+                Ok(id) => id,
+            }
+            print(instance_id)
+
+            // Not overdue yet -- `entered_at` is "now". `print` doesn't
+            // support an aggregate (`WorkflowActionError`) argument yet,
+            // so the (real, but here-unreachable) `Err` arm prints a
+            // fixed literal instead of the error value itself.
+            match list_ticket_overdue() {
+                Ok(j) => print(j), // []
+                Err(e) => print("overdue query failed"),
+            }
+
+            sleep_ms(1100)
+
+            match list_ticket_overdue() {
+                Ok(j) => print(j), // [{"instance_id":1,"state":"Open","age_seconds":...}]
+                Err(e) => print("overdue query failed"),
+            }
+        }
+    "#;
+    let (stdout, code) = compile_and_run(src);
+    assert_eq!(code, 0, "stdout: {stdout}");
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines[0], "1");
+    assert_eq!(lines[1], "[]", "a brand-new instance shouldn't be overdue yet: {stdout}");
+    assert!(
+        lines[2].contains(r#""instance_id":1"#) && lines[2].contains(r#""state":"Open""#),
+        "expected the stale instance to be reported overdue: {stdout}"
+    );
+}
+
+/// A `workflow` with a non-empty `data {{ ... }}` block is explicitly
+/// rejected, not silently miscompiled — `Codegen::resolve_workflow_layer1`'s
+/// own doc comment: this Layer 1 runtime has nowhere durable to persist
+/// a `data` value past the initial `start_*` call.
+#[test]
+fn workflow_with_a_data_block_is_explicitly_rejected_not_silently_dropped() {
+    let src = r#"
+        workflow Approval {
+            data {
+                amount: i64,
+            }
+            state Pending {
+                on Approve -> Approved
+            }
+            state Approved terminal {
+            }
+        }
+
+        fn main() {
+            let instance_id: i64 = match start_approval(None(), ApprovalData(100)) {
+                Err(e) => -1,
+                Ok(id) => id,
+            }
+            print(instance_id)
+        }
+    "#;
+    let program = parse_checked(src);
+    let report = nirdosha::smt::analyze(&program);
+    let mut out_path = std::env::temp_dir();
+    out_path.push(format!("nirdosha_test_{}_{}", std::process::id(), unique_suffix()));
+    let err = codegen::build(&program, &report, &out_path, codegen::OptLevel::O2).expect_err("a non-empty `data` block should be rejected");
+    assert!(err.contains("data"), "unexpected error message: {err}");
+}
+
+/// `__workflow_link_advance` (a magic-link `*_via_link` fn, only
+/// synthesized for a workflow that declares a `link`-marked transition)
+/// is explicitly rejected too — same real durable-storage gap, but
+/// scoped only to programs that actually declare one, unlike the
+/// `data`-block restriction above which applies to the whole workflow.
+#[test]
+fn workflow_link_marked_transitions_are_explicitly_rejected_not_silently_dropped() {
+    let src = r#"
+        workflow Approval {
+            state Pending {
+                on link Approve -> Approved
+            }
+            state Approved terminal {
+            }
+        }
+
+        fn main() {
+            let instance_id: i64 = match start_approval(None(), ApprovalData()) {
+                Err(e) => -1,
+                Ok(id) => id,
+            }
+            print(instance_id)
+        }
+    "#;
+    let program = parse_checked(src);
+    let report = nirdosha::smt::analyze(&program);
+    let mut out_path = std::env::temp_dir();
+    out_path.push(format!("nirdosha_test_{}_{}", std::process::id(), unique_suffix()));
+    let err = codegen::build(&program, &report, &out_path, codegen::OptLevel::O2).expect_err("a `link`-marked transition's `*_via_link` fn should be rejected");
+    assert!(err.contains("magic-link") || err.contains("__workflow_link_advance"), "unexpected error message: {err}");
 }

--- a/crates/compiler/tests/native_plugin_codegen.rs
+++ b/crates/compiler/tests/native_plugin_codegen.rs
@@ -118,13 +118,250 @@ fn a_native_plugin_call_compiles_and_the_native_binary_runs_correctly() {
     let _ = std::fs::remove_dir_all(out_dir);
 }
 
-/// A native plugin declaring a non-scalar type (`str`) is rejected at
-/// `validate()` time with a named, actionable reason -- not a confusing
-/// LLVM/clang failure surfacing from deep inside a malformed `declare`.
+/// A native plugin declaring a type this narrow ABI genuinely doesn't
+/// reach yet (`Ty::Json`, still a real aggregate/interpreter-only
+/// question -- unlike `str`/`handle` below, which rfcs/0008 widens this
+/// to accept) is rejected at `validate()` time with a named, actionable
+/// reason -- not a confusing LLVM/clang failure surfacing from deep
+/// inside a malformed `declare`.
 #[test]
-fn a_str_typed_native_plugin_is_rejected_by_validate_not_left_to_fail_in_clang() {
-    let native_plugin = NativePluginBuiltin { name: "bad_plugin".to_string(), params: vec![Ty::Str], ret: Ty::I64, static_lib: &[] };
-    let err = native_plugin.validate().expect_err("a str parameter must be rejected");
-    assert!(err.contains("bad_plugin") && err.contains("scalar"), "expected a named, actionable reason, got: {err}");
+fn a_json_typed_native_plugin_is_rejected_by_validate_not_left_to_fail_in_clang() {
+    let native_plugin = NativePluginBuiltin { name: "bad_plugin".to_string(), params: vec![Ty::Json], ret: Ty::I64, static_lib: &[] };
+    let err = native_plugin.validate().expect_err("a json parameter must be rejected");
+    assert!(err.contains("bad_plugin") && err.contains("value"), "expected a named, actionable reason, got: {err}");
+}
+
+/// rfcs/0008-native-plugin-abi-widening.md Phase 1's actual claim: a
+/// `str` value crosses the native boundary in both directions, using
+/// the exact `#[repr(C)]` two-word-struct-by-value convention
+/// `runtime-kernels/src/lib.rs`'s own `Dec128Bits` already establishes
+/// for `str`'s `{ptr, i64}` LLVM shape -- not a new ABI invented for
+/// this test, the same one `crates/plugin-example-native-shout`'s real,
+/// shipped source uses.
+#[test]
+fn a_str_typed_native_plugin_crosses_the_boundary_in_both_directions() {
+    let lib_bytes = compile_native_plugin_staticlib(
+        "plugin_str_roundtrip",
+        r#"
+            #[repr(C)]
+            pub struct NirStr { pub ptr: *const u8, pub len: i64 }
+
+            #[no_mangle]
+            pub extern "C" fn plugin_shout(s: NirStr) -> NirStr {
+                let bytes = unsafe { std::slice::from_raw_parts(s.ptr, s.len as usize) };
+                let mut v: Vec<u8> = bytes.iter().map(|b| b.to_ascii_uppercase()).collect();
+                v.push(b'!');
+                let leaked: &'static mut [u8] = Box::leak(v.into_boxed_slice());
+                NirStr { ptr: leaked.as_ptr(), len: leaked.len() as i64 }
+            }
+
+            #[no_mangle]
+            pub extern "C" fn plugin_str_first_byte(s: NirStr) -> i64 {
+                if s.len == 0 { return -1; }
+                let bytes = unsafe { std::slice::from_raw_parts(s.ptr, s.len as usize) };
+                bytes[0] as i64
+            }
+        "#,
+    );
+    let lib_bytes: &'static [u8] = Box::leak(lib_bytes.into_boxed_slice());
+
+    let src = r#"
+        fn main() -> i64 {
+            let shouted: str = plugin_shout("hi")
+            return plugin_str_first_byte(shouted)
+        }
+    "#;
+
+    let shout = NativePluginBuiltin { name: "plugin_shout".to_string(), params: vec![Ty::Str], ret: Ty::Str, static_lib: lib_bytes };
+    let first_byte =
+        NativePluginBuiltin { name: "plugin_str_first_byte".to_string(), params: vec![Ty::Str], ret: Ty::I64, static_lib: lib_bytes };
+    shout.validate().expect("a str->str signature must validate now");
+    first_byte.validate().expect("a str->i64 signature must validate");
+
+    let plugins = [shout, first_byte];
+    let program = typecheck_and_own_with_plugins(src, &plugins);
+    let report = analyze(&program);
+
+    let out_dir = std::env::temp_dir().join(format!("nirdosha_native_str_plugin_test_bin_{}", std::process::id()));
+    std::fs::create_dir_all(&out_dir).unwrap();
+    let out_path = out_dir.join("native_str_plugin_test_bin");
+
+    codegen::build_with_native_plugins(&program, &report, &out_path, codegen::OptLevel::O2, &plugins, &Default::default())
+        .expect("build_with_native_plugins should compile and link cleanly");
+
+    let output = Command::new(&out_path).output().expect("running the compiled binary should succeed");
+    // "hi" -> plugin_shout -> "HI!" -> plugin_str_first_byte -> b'H' == 72,
+    // computed entirely by the real, separately-compiled Rust functions
+    // above, both string value and byte crossing the same LLVM-generated
+    // `call` boundary twice in one program.
+    assert_eq!(output.status.code(), Some(72), "compiled binary's exit code: {output:?}");
+
+    let _ = std::fs::remove_dir_all(out_dir);
+}
+
+/// rfcs/0008 Phase 1's other half: `handle(Kind)` crosses the native
+/// boundary as a plain `i64`, exactly like `Ty::Thread`/`Ty::Channel`/
+/// `Ty::File` already do -- proven here by a value minted on one side of
+/// the boundary and read back correctly on the other, through generated
+/// LLVM IR, no interpreter involved.
+#[test]
+fn a_handle_typed_native_plugin_crosses_the_boundary_as_a_plain_i64() {
+    let lib_bytes = compile_native_plugin_staticlib(
+        "plugin_handle_roundtrip",
+        r#"
+            #[no_mangle]
+            pub extern "C" fn plugin_counter_open() -> i64 { 42 }
+
+            #[no_mangle]
+            pub extern "C" fn plugin_counter_close(h: i64) -> i64 { h }
+        "#,
+    );
+    let lib_bytes: &'static [u8] = Box::leak(lib_bytes.into_boxed_slice());
+
+    let src = r#"
+        fn main() -> i64 {
+            let h: handle(Counter) = plugin_counter_open()
+            return plugin_counter_close(h)
+        }
+    "#;
+
+    let open = NativePluginBuiltin {
+        name: "plugin_counter_open".to_string(),
+        params: vec![],
+        ret: Ty::Handle("Counter".to_string()),
+        static_lib: lib_bytes,
+    };
+    let close = NativePluginBuiltin {
+        name: "plugin_counter_close".to_string(),
+        params: vec![Ty::Handle("Counter".to_string())],
+        ret: Ty::I64,
+        static_lib: lib_bytes,
+    };
+    open.validate().expect("a ()->handle signature must validate now");
+    close.validate().expect("a handle->i64 signature must validate");
+
+    let plugins = [open, close];
+    let program = typecheck_and_own_with_plugins(src, &plugins);
+    let report = analyze(&program);
+
+    let out_dir = std::env::temp_dir().join(format!("nirdosha_native_handle_plugin_test_bin_{}", std::process::id()));
+    std::fs::create_dir_all(&out_dir).unwrap();
+    let out_path = out_dir.join("native_handle_plugin_test_bin");
+
+    codegen::build_with_native_plugins(&program, &report, &out_path, codegen::OptLevel::O2, &plugins, &Default::default())
+        .expect("build_with_native_plugins should compile and link cleanly");
+
+    let output = Command::new(&out_path).output().expect("running the compiled binary should succeed");
+    assert_eq!(output.status.code(), Some(42), "compiled binary's exit code: {output:?}");
+
+    let _ = std::fs::remove_dir_all(out_dir);
+}
+
+/// The other real-world requirement rfcs/0008 §Phase 1 adds: a *read*
+/// of a handle must borrow (`&handle(Kind)`, crossing as a plain `ptr`
+/// to the caller's `i64` slot -- `codegen.rs::llvm_ty`'s existing
+/// `Ty::Ref(_) => "ptr"` case, no new codegen needed), not consume it,
+/// so the same handle can be used any number of times before the one
+/// real, final, consuming `close`. Without this, `Ty::Handle`'s affine
+/// guarantee (rfcs/0005 §1) would make a real "connect, query N times,
+/// close" plugin -- e.g. `crates/plugin-example-native-kv`'s `kv_set`/
+/// `kv_get` -- impossible to call more than once.
+#[test]
+fn a_borrowed_native_plugin_handle_can_be_read_any_number_of_times_before_one_final_close() {
+    let lib_bytes = compile_native_plugin_staticlib(
+        "plugin_handle_borrow",
+        r#"
+            #[no_mangle]
+            pub extern "C" fn plugin_counter_open() -> i64 { 10 }
+
+            #[no_mangle]
+            pub extern "C" fn plugin_counter_peek(h: *const i64) -> i64 {
+                unsafe { *h }
+            }
+
+            #[no_mangle]
+            pub extern "C" fn plugin_counter_close(h: i64) -> i64 { h }
+        "#,
+    );
+    let lib_bytes: &'static [u8] = Box::leak(lib_bytes.into_boxed_slice());
+
+    let src = r#"
+        fn main() -> i64 {
+            let h: handle(Counter) = plugin_counter_open()
+            let a: i64 = plugin_counter_peek(&h)
+            let b: i64 = plugin_counter_peek(&h)
+            let c: i64 = plugin_counter_close(h)
+            return a + b + c
+        }
+    "#;
+
+    let counter_kind = || Ty::Handle("Counter".to_string());
+    let open = NativePluginBuiltin { name: "plugin_counter_open".to_string(), params: vec![], ret: counter_kind(), static_lib: lib_bytes };
+    let peek = NativePluginBuiltin {
+        name: "plugin_counter_peek".to_string(),
+        params: vec![Ty::Ref(Box::new(counter_kind()))],
+        ret: Ty::I64,
+        static_lib: lib_bytes,
+    };
+    let close = NativePluginBuiltin { name: "plugin_counter_close".to_string(), params: vec![counter_kind()], ret: Ty::I64, static_lib: lib_bytes };
+    open.validate().expect("a ()->handle signature must validate");
+    peek.validate().expect("a &handle->i64 signature must validate now");
+    close.validate().expect("a handle->i64 signature must validate");
+
+    let plugins = [open, peek, close];
+    let program = typecheck_and_own_with_plugins(src, &plugins);
+    let report = analyze(&program);
+
+    let out_dir = std::env::temp_dir().join(format!("nirdosha_native_handle_borrow_test_bin_{}", std::process::id()));
+    std::fs::create_dir_all(&out_dir).unwrap();
+    let out_path = out_dir.join("native_handle_borrow_test_bin");
+
+    codegen::build_with_native_plugins(&program, &report, &out_path, codegen::OptLevel::O2, &plugins, &Default::default())
+        .expect("build_with_native_plugins should compile and link cleanly");
+
+    let output = Command::new(&out_path).output().expect("running the compiled binary should succeed");
+    // 10 (peek) + 10 (peek again -- the same handle, still valid because
+    // both reads borrowed it) + 10 (close, the one consuming use) == 30.
+    assert_eq!(output.status.code(), Some(30), "compiled binary's exit code: {output:?}");
+
+    let _ = std::fs::remove_dir_all(out_dir);
+}
+
+/// The affine half of the handle claim: `ownership.rs` already lists
+/// `Ty::Handle(_)` in `is_affine()` (rfcs/0005 §1) -- this proves that
+/// still holds for a *native*-plugin-sourced handle now that codegen
+/// accepts the type, not just for the interpreter path. Using a handle
+/// twice must be a compile-time ownership error, before codegen (let
+/// alone `clang`) ever runs.
+#[test]
+fn a_native_plugin_handle_used_twice_is_a_compile_time_ownership_error() {
+    let src = r#"
+        fn main() -> i64 {
+            let h: handle(Counter) = plugin_counter_open()
+            let a: i64 = plugin_counter_close(h)
+            let b: i64 = plugin_counter_close(h)
+            return a + b
+        }
+    "#;
+    let open = NativePluginBuiltin {
+        name: "plugin_counter_open".to_string(),
+        params: vec![],
+        ret: Ty::Handle("Counter".to_string()),
+        static_lib: &[],
+    };
+    let close = NativePluginBuiltin {
+        name: "plugin_counter_close".to_string(),
+        params: vec![Ty::Handle("Counter".to_string())],
+        ret: Ty::I64,
+        static_lib: &[],
+    };
+    let plugins = [open, close];
+
+    let toks = Lexer::new(src).tokenize().expect("lex should succeed");
+    let program = Parser::new(toks).parse_program().expect("parse should succeed");
+    typecheck_with_native_plugins(&program, &plugins).expect("typecheck_with_native_plugins should accept this program");
+    let err = check_ownership(&program).expect_err("using a handle twice must be rejected");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("h") || msg.to_lowercase().contains("moved"), "expected a use-after-move ownership error, got: {msg}");
 }
 

--- a/crates/compiler/tests/native_plugin_examples.rs
+++ b/crates/compiler/tests/native_plugin_examples.rs
@@ -1,0 +1,135 @@
+//! Proves that the two real, shipped example crates —
+//! `crates/plugin-example-native-shout` and `crates/plugin-example-
+//! native-kv` — actually work as their own READMEs claim: build them
+//! exactly the way a plugin *consumer* would (`cargo build --release
+//! -p <crate>`), link the resulting real `.a` files into a real
+//! `nirdosha build` output via `NativePluginBuiltin`/
+//! `build_with_native_plugins`, and run the resulting native binary.
+//! No interpreter anywhere in this path, and no inline/duplicated
+//! plugin source the way `native_plugin_codegen.rs`'s own tests use for
+//! speed — this test exercises the identical bytes a real user would
+//! get from these crates.
+
+use nirdosha::ast::Ty;
+use nirdosha::codegen;
+use nirdosha::ownership::check_ownership;
+use nirdosha::parser::Parser;
+use nirdosha::plugin::NativePluginBuiltin;
+use nirdosha::smt::analyze;
+use nirdosha::token::Lexer;
+use nirdosha::typeck::typecheck_with_native_plugins;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn workspace_root() -> PathBuf {
+    // `crates/compiler` -> up two levels -> the repo root, where the
+    // root `Cargo.toml` (and its shared `target/`) lives.
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+/// `cargo build --release -p <crate>` against the *root* workspace —
+/// the same command this test's own module doc, and each example
+/// crate's own README, tells a consumer to run. Building here (rather
+/// than assuming a prior `cargo build --release --workspace` already
+/// ran) makes this test self-contained; it costs a few seconds the
+/// first time and is a cache hit on every run after.
+fn build_release(crate_name: &str) {
+    let root = workspace_root();
+    let status = Command::new(std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string()))
+        .arg("build")
+        .arg("--release")
+        .arg("--manifest-path")
+        .arg(root.join("Cargo.toml"))
+        .arg("-p")
+        .arg(crate_name)
+        .status()
+        .unwrap_or_else(|e| panic!("failed to invoke cargo to build {crate_name}: {e}"));
+    assert!(status.success(), "cargo build --release -p {crate_name} failed");
+}
+
+/// `lib<crate_name-with-underscores>.a` in the shared workspace
+/// `target/release/` — Cargo's own, platform-default staticlib naming
+/// convention (this test only runs on Unix CI/dev machines today, same
+/// as the rest of this native-plugin test suite; a `windows-msvc` build
+/// would need the `.lib`/no-`lib`-prefix naming
+/// `crates/compiler/build.rs` already handles for `runtime-kernels`).
+fn read_staticlib(crate_name: &str) -> &'static [u8] {
+    let lib_name = format!("lib{}.a", crate_name.replace('-', "_"));
+    let path = workspace_root().join("target/release").join(&lib_name);
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("reading {}: {e}", path.display()));
+    Box::leak(bytes.into_boxed_slice())
+}
+
+fn typecheck_and_own_with_plugins(src: &str, plugins: &[NativePluginBuiltin]) -> nirdosha::ast::Program {
+    let toks = Lexer::new(src).tokenize().expect("lex should succeed");
+    let program = Parser::new(toks).parse_program().expect("parse should succeed");
+    typecheck_with_native_plugins(&program, plugins).expect("typecheck_with_native_plugins should accept this program");
+    check_ownership(&program).expect("ownership check should accept this program");
+    program
+}
+
+/// The real claim: install both example crates the way their READMEs
+/// describe, call every one of their six builtins from one `.nir`
+/// program (`plugin_shout`'s `str` round trip, `kv_open`/`kv_set`/
+/// `kv_get`/`kv_close`'s `handle`+`str` round trip), compile it to a
+/// real native binary, and run it.
+#[test]
+fn the_shipped_example_plugin_crates_compile_and_run_correctly() {
+    build_release("nirdosha-plugin-native-shout");
+    build_release("nirdosha-plugin-native-kv");
+    let shout_lib = read_staticlib("nirdosha-plugin-native-shout");
+    let kv_lib = read_staticlib("nirdosha-plugin-native-kv");
+
+    let kv_store_kind = || Ty::Handle("KvStore".to_string());
+    let kv_store_ref = || Ty::Ref(Box::new(kv_store_kind()));
+    let plugins = vec![
+        NativePluginBuiltin { name: "plugin_shout".to_string(), params: vec![Ty::Str], ret: Ty::Str, static_lib: shout_lib },
+        NativePluginBuiltin { name: "kv_open".to_string(), params: vec![], ret: kv_store_kind(), static_lib: kv_lib },
+        NativePluginBuiltin {
+            name: "kv_set".to_string(),
+            params: vec![kv_store_ref(), Ty::Str, Ty::Str],
+            ret: Ty::I64,
+            static_lib: kv_lib,
+        },
+        NativePluginBuiltin { name: "kv_get".to_string(), params: vec![kv_store_ref(), Ty::Str], ret: Ty::Str, static_lib: kv_lib },
+        NativePluginBuiltin { name: "kv_close".to_string(), params: vec![kv_store_kind()], ret: Ty::I64, static_lib: kv_lib },
+    ];
+    for p in &plugins {
+        p.validate().unwrap_or_else(|e| panic!("{e}"));
+    }
+
+    let src = r#"
+        fn main() -> i64 {
+            let shouted: str = plugin_shout("hello")
+            let h: handle(KvStore) = kv_open()
+            let ok1: i64 = kv_set(&h, "greeting", shouted)
+            let got: str = kv_get(&h, "greeting")
+            let ok2: i64 = kv_close(h)
+            if got == "HELLO!" {
+                return ok1 * 10 + ok2
+            }
+            return -1
+        }
+    "#;
+
+    let program = typecheck_and_own_with_plugins(src, &plugins);
+    let report = analyze(&program);
+
+    let out_dir = std::env::temp_dir().join(format!("nirdosha_native_plugin_examples_bin_{}", std::process::id()));
+    std::fs::create_dir_all(&out_dir).unwrap();
+    let out_path = out_dir.join("native_plugin_examples_bin");
+
+    codegen::build_with_native_plugins(&program, &report, &out_path, codegen::OptLevel::O2, &plugins, &Default::default())
+        .expect("build_with_native_plugins should compile and link cleanly");
+
+    let output = Command::new(&out_path).output().expect("running the compiled binary should succeed");
+    // "hello" -> plugin_shout -> "HELLO!" -> stored under "greeting" via
+    // kv_set (real, separately-compiled Rust code, both times) -> kv_get
+    // reads the identical string back -> the `==` comparison is real
+    // proof the round trip preserved the bytes exactly, not just that
+    // something non-empty came back -> kv_set/kv_close both report
+    // success (1) -> 1*10 + 1 == 11.
+    assert_eq!(output.status.code(), Some(11), "compiled binary's exit code: {output:?}");
+
+    let _ = std::fs::remove_dir_all(out_dir);
+}

--- a/crates/plugin-example-native-kv/Cargo.toml
+++ b/crates/plugin-example-native-kv/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "nirdosha-plugin-native-kv"
+version = "0.1.0"
+edition = "2024"
+description = "Reference native (compiled-path) Nirdosha plugin (rfcs/0008-native-plugin-abi-widening.md): a stateful, handle(Kind)-based builtin gallery -- kv_open/kv_set/kv_get/kv_close -- the shape every real I/O plugin (a DB/MQ connection) needs, without requiring a live external service to try."
+
+[package.metadata.nirdosha]
+kind = "native-compiled"
+builtins = [
+    { name = "kv_open", params = [], ret = "handle(KvStore)" },
+    # `&handle(KvStore)`, not a bare `handle(KvStore)` -- these two
+    # *borrow* the store (read/write through the reference) rather than
+    # consuming it, so the same handle can back any number of
+    # `kv_set`/`kv_get` calls before the one, final, consuming
+    # `kv_close(h)` -- see `src/lib.rs`'s own doc comments on both.
+    { name = "kv_set", params = ["&handle(KvStore)", "str", "str"], ret = "i64" },
+    { name = "kv_get", params = ["&handle(KvStore)", "str"], ret = "str" },
+    { name = "kv_close", params = ["handle(KvStore)"], ret = "i64" },
+]
+
+# Same "zero dependency on the `nirdosha` crate" story as
+# `plugin-example-native-shout` -- see that crate's own Cargo.toml
+# comment.
+[dependencies]
+
+[lib]
+crate-type = ["staticlib"]
+
+# See `plugin-example-native-shout/Cargo.toml`'s identical comment: no
+# `[profile.release]` here, a member crate's own copy would be silently
+# ignored by Cargo (only the workspace-root manifest's is honored).

--- a/crates/plugin-example-native-kv/README.md
+++ b/crates/plugin-example-native-kv/README.md
@@ -1,0 +1,97 @@
+# nirdosha-plugin-native-kv
+
+The stateful reference for rfcs/0008-native-plugin-abi-widening.md
+Phase 1's `handle(Kind)` crossing, combined with `str` (see
+`../plugin-example-native-shout` for `str` on its own): `kv_open`/
+`kv_set`/`kv_get`/`kv_close`, an in-memory key-value store. This is the
+*shape* every real stateful I/O plugin needs — `connect`, use the
+connection any number of times, `close` it — the same pattern the
+(deleted, interpreter-only) `mysql`/`cassandra`/`activemq` reference
+plugins had. It's in-memory only so this example needs no Docker
+container to try; porting one of those onto this same ABI is rfcs/0008
+Phase 4's real remaining proof.
+
+## Try it
+
+```sh
+cargo build --release -p nirdosha-plugin-native-kv
+# produces target/release/libnirdosha_plugin_native_kv.a
+```
+
+`crates/compiler/tests/native_plugin_examples.rs` builds this exact
+crate, links it into a real `nirdosha build` output alongside
+`plugin-example-native-shout`, and runs the resulting binary —
+`cargo test -p nirdosha --test native_plugin_examples`.
+
+## The one rule this crate exists to demonstrate: borrow to read, move to close
+
+```nir
+fn main() -> i64 {
+    let h: handle(KvStore) = kv_open()
+    let ok: i64 = kv_set(&h, "greeting", "hello")   // &h -- borrows
+    let v: str = kv_get(&h, "greeting")              // &h -- borrows
+    return kv_close(h)                               // h  -- consumes
+}
+```
+
+`Ty::Handle` is affine (`ownership.rs`, rfcs/0005 §1): a bare
+`handle(KvStore)` value can be used **exactly once** before it's
+"moved." If `kv_set`/`kv_get` took a bare `handle(KvStore)` instead of
+`&handle(KvStore)`, the first call would consume `h` and every
+following call would be a compile-time `UseAfterMove` error — a real
+plugin could never be queried more than once. Passing `&h` instead
+(`Ty::Ref(Box::new(Ty::Handle(...)))`) **borrows** it: `codegen.rs`
+already renders any `Ty::Ref(_)` as a plain one-word `ptr` (the address
+of the caller's own `i64` handle slot), so the underlying value is read
+through the pointer, never moved. `kv_close(h)` — no `&` — is the one
+real, final, consuming use.
+
+On the Rust side, that means `kv_set`/`kv_get` take `*const i64` and
+dereference it once ([`src/lib.rs`](./src/lib.rs)); `kv_open`/
+`kv_close` take/return a plain `i64`, exactly like
+`plugin-example-native-shout`'s scalars.
+
+```toml
+[package.metadata.nirdosha]
+kind = "native-compiled"
+builtins = [
+    { name = "kv_open", params = [], ret = "handle(KvStore)" },
+    { name = "kv_set", params = ["&handle(KvStore)", "str", "str"], ret = "i64" },
+    { name = "kv_get", params = ["&handle(KvStore)", "str"], ret = "str" },
+    { name = "kv_close", params = ["handle(KvStore)"], ret = "i64" },
+]
+```
+
+`crates/compiler/tests/native_plugin_codegen.rs`'s
+`a_native_plugin_handle_used_twice_is_a_compile_time_ownership_error`
+and `a_borrowed_native_plugin_handle_can_be_read_any_number_of_times_
+before_one_final_close` are the two proofs of this rule, using a
+smaller inline plugin than this crate.
+
+## The one thing a plugin author has to hand-roll today
+
+The deleted, interpreter-only `nirdosha-plugin-support::HandleRegistry<T>`
+gave every stateful plugin a shared, generic `Mutex<HashMap<u64, T>>`
+for free. No compiled-path equivalent exists yet — this crate's
+`stores()`/`next_handle()` (~15 lines) are what a plugin author writes
+by hand until rfcs/0008 Phase 2's authoring-convention crate exists.
+`ownership.rs`'s affine tracking is what actually prevents a `.nir`
+program from double-closing or leaking a handle — this crate's own Rust
+code does not, and does not need to, defend against that itself (see
+`kv_close`'s doc comment).
+
+## What's honestly not covered
+
+- **No `Result`/error-detail crossing.** `kv_set`/`kv_close` return a
+  plain `1`/`0` sentinel; `kv_get` returns an empty string on a miss —
+  a real richer error story is rfcs/0005 §3's "harder, still-open
+  question" (no aggregate/`Result` crossing yet).
+- **No Cargo-driven auto-discovery.** Consuming this crate still means
+  hand-constructing `NativePluginBuiltin`s and calling
+  `codegen::build_with_native_plugins` — see
+  `plugin-example-native-shout/README.md`'s "app-author side" section,
+  identical here.
+
+## Full design
+
+rfcs/0008-native-plugin-abi-widening.md.

--- a/crates/plugin-example-native-kv/src/lib.rs
+++ b/crates/plugin-example-native-kv/src/lib.rs
@@ -1,0 +1,132 @@
+//! `kv_open`/`kv_set`/`kv_get`/`kv_close` — the reference example for
+//! rfcs/0008-native-plugin-abi-widening.md Phase 1's `handle(Kind)`
+//! crossing, combined with `str` crossing (`plugin-example-native-shout`
+//! covers `str` alone). This is the *shape* every real I/O plugin the
+//! deleted interpreter-era gallery had (`mysql_connect`/`cassandra_
+//! connect`/`activemq_connect`, all `connect -> handle`, `... -> ...`,
+//! `close(handle)`) actually needs — an in-memory store instead of a
+//! real network service only so this example needs no Docker container
+//! to try, not because the pattern is different for a real one.
+//!
+//! ## The one thing a plugin author has to hand-roll here
+//!
+//! The deleted `nirdosha-plugin-support::HandleRegistry<T>` (interpreter
+//! path) gave every stateful plugin a shared, generic `Mutex<HashMap<
+//! u64, T>>` for free. No compiled-path equivalent exists yet — a real
+//! follow-up (rfcs/0008 Phase 2's authoring-convention crate would be
+//! the natural home for one). Until then, the ~15 lines below
+//! (`STORES`, `next_handle`) are what a plugin author writes by hand;
+//! `ownership.rs`'s affine tracking (`Ty::Handle`'s own safety story,
+//! rfcs/0005 §1) is what actually prevents a `.nir` program from
+//! double-closing or leaking one of these, entirely on the *compiler*
+//! side — this crate does not, and does not need to, defend against
+//! that itself.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+fn stores() -> &'static Mutex<HashMap<i64, HashMap<String, String>>> {
+    static STORES: OnceLock<Mutex<HashMap<i64, HashMap<String, String>>>> = OnceLock::new();
+    STORES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn next_handle() -> i64 {
+    static NEXT: AtomicI64 = AtomicI64::new(1);
+    NEXT.fetch_add(1, Ordering::Relaxed)
+}
+
+/// Must match `plugin-example-native-shout::NirStr` field-for-field —
+/// each plugin crate declares its own copy rather than sharing one
+/// (rfcs/0008 Phase 2's future authoring-convention crate is the real
+/// fix for that duplication; see this crate's own module doc).
+#[repr(C)]
+pub struct NirStr {
+    pub ptr: *const u8,
+    pub len: i64,
+}
+
+unsafe fn nir_str_to_string(s: &NirStr) -> String {
+    let bytes = unsafe { std::slice::from_raw_parts(s.ptr, s.len as usize) };
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+fn string_to_nir_str(s: String) -> NirStr {
+    let leaked: &'static mut [u8] = Box::leak(s.into_bytes().into_boxed_slice());
+    NirStr { ptr: leaked.as_ptr(), len: leaked.len() as i64 }
+}
+
+/// Mints a fresh, empty store and returns its `handle(KvStore)` id.
+/// `ownership.rs` requires every `.nir` binding of this type to be
+/// consumed exactly once (moved into exactly one later call) — this
+/// function's own Rust code has no matching enforcement of its own, by
+/// design; that's the whole point of `Ty::Handle` doing this at the
+/// type level instead of every plugin reimplementing it at runtime.
+#[unsafe(no_mangle)]
+pub extern "C" fn kv_open() -> i64 {
+    let h = next_handle();
+    stores().lock().unwrap().insert(h, HashMap::new());
+    h
+}
+
+/// Takes `&handle(KvStore)`, not a bare `handle(KvStore)` — a *read*
+/// (well, a write-through-a-reference, but not a resource-closing
+/// operation either) must **borrow** the handle, not consume it, or
+/// `ownership.rs`'s affine tracking would only ever allow one `kv_set`/
+/// `kv_get` before `kv_close` per store (rfcs/0005 §1's own guarantee).
+/// A `Ty::Ref(_)` crosses as a plain one-word `ptr` — the address of the
+/// caller's `i64` handle slot — so this dereferences it once to read
+/// the id back out; `codegen.rs` never inspects a `Ty::Handle` value
+/// itself, only ever passes the word through, so a plain, unsynchronized
+/// read here is exactly as safe as reading any other `&i64` would be.
+///
+/// Returns `1` on success, `0` if `handle` names no open store (e.g.
+/// already closed) — a plain sentinel return, not a panic, matching
+/// this narrow ABI's "no `Result`/aggregate crossing yet" limit
+/// (rfcs/0008 Phase 1's own disclosed scope).
+#[unsafe(no_mangle)]
+pub extern "C" fn kv_set(handle: *const i64, key: NirStr, val: NirStr) -> i64 {
+    let handle = unsafe { *handle };
+    let key = unsafe { nir_str_to_string(&key) };
+    let val = unsafe { nir_str_to_string(&val) };
+    match stores().lock().unwrap().get_mut(&handle) {
+        Some(store) => {
+            store.insert(key, val);
+            1
+        }
+        None => 0,
+    }
+}
+
+/// Same `&handle(KvStore)`-borrows story as `kv_set` above.
+///
+/// Returns the stored value, or an empty `str` if `key`/`handle` isn't
+/// found — not a sentinel error code, since the return type here is
+/// `str`, not `i64`; a real plugin with a richer error story is exactly
+/// the "harder, still-open question" rfcs/0005 §3 and rfcs/0008's
+/// Rejected Alternatives section both name (no `Result`/`Option`
+/// crossing yet).
+#[unsafe(no_mangle)]
+pub extern "C" fn kv_get(handle: *const i64, key: NirStr) -> NirStr {
+    let handle = unsafe { *handle };
+    let key = unsafe { nir_str_to_string(&key) };
+    let found = stores().lock().unwrap().get(&handle).and_then(|store| store.get(&key).cloned());
+    string_to_nir_str(found.unwrap_or_default())
+}
+
+/// Returns `1` on success, `0` if `handle` was already closed (or never
+/// opened) — the double-close case `ownership.rs` already rejects at
+/// **compile time** for any well-typed `.nir` program (see
+/// `crates/compiler/tests/native_plugin_codegen.rs`'s
+/// `a_native_plugin_handle_used_twice_is_a_compile_time_ownership_error`),
+/// so this runtime check only ever fires for a handle value that
+/// reached this function some other way (a future FFI caller not going
+/// through Nirdosha's own ownership checker) — defense in depth, not
+/// something a real `.nir` program can trigger.
+#[unsafe(no_mangle)]
+pub extern "C" fn kv_close(handle: i64) -> i64 {
+    match stores().lock().unwrap().remove(&handle) {
+        Some(_) => 1,
+        None => 0,
+    }
+}

--- a/crates/plugin-example-native-shout/Cargo.toml
+++ b/crates/plugin-example-native-shout/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "nirdosha-plugin-native-shout"
+version = "0.1.0"
+edition = "2024"
+description = "Reference native (compiled-path) Nirdosha plugin (rfcs/0008-native-plugin-abi-widening.md): a pure str-in/str-out builtin, shout(s: str) -> str, called directly from generated LLVM IR -- no interpreter."
+
+# The same statically-greppable convention `docs/ECOSYSTEM.md` #G1
+# proposed for the (deleted, interpreter-only) Kind-A plugins, updated
+# for the compiled path: `kind = "native-compiled"` distinguishes this
+# from a `kind = "native"` (interpreter `PluginBuiltin`) crate, which no
+# longer exists in this repo but could in principle exist again -- a
+# future `nirdosha build` auto-discovery pass (rfcs/0008 Phase 3, not
+# built yet) would need this distinction to know it can call straight
+# into a linked symbol here, not into `Interpreter::plugins`.
+[package.metadata.nirdosha]
+kind = "native-compiled"
+builtins = [
+    { name = "plugin_shout", params = ["str"], ret = "str" },
+]
+
+# Deliberately zero dependency on the `nirdosha` crate itself, unlike
+# the old interpreter-era plugin crates (which had to implement
+# `NirdoshaPlugin`, a Rust trait living in `nirdosha`). A native plugin
+# is a plain `#[no_mangle] extern "C"` symbol -- the compiler links
+# against the *symbol*, never the Rust type system on this side of the
+# boundary, so this crate needs nothing beyond `std`.
+[dependencies]
+
+[lib]
+crate-type = ["staticlib"]
+
+# No `[profile.release]` here (unlike `crates/runtime-kernels/Cargo.toml`,
+# which is its own separate workspace and can): this crate is a member
+# of the repo's root workspace, and Cargo only honors `[profile.*]` from
+# a workspace *root* manifest, silently ignoring it in a member crate's
+# own `Cargo.toml` (the same trap the root `Cargo.toml`'s own
+# `overflow-checks` comment documents). `panic = "unwind"` is already
+# the default release-profile behavior, so there's nothing to override.

--- a/crates/plugin-example-native-shout/README.md
+++ b/crates/plugin-example-native-shout/README.md
@@ -1,0 +1,104 @@
+# nirdosha-plugin-native-shout
+
+The simplest possible reference for rfcs/0008-native-plugin-abi-widening.md
+Phase 1's `str` crossing: one builtin, `plugin_shout(s: str) -> str`,
+called directly from a compiled `.nir` binary's generated LLVM IR — no
+interpreter anywhere in the path. If you want the stateful/`handle(Kind)`
+half of the story instead, see `../plugin-example-native-kv`.
+
+## Try it
+
+```sh
+cargo build --release -p nirdosha-plugin-native-shout
+# produces target/release/libnirdosha_plugin_native_shout.a
+```
+
+`crates/compiler/tests/native_plugin_examples.rs` is the automated,
+run-the-real-binary proof that this exact crate's compiled output,
+linked into a real `nirdosha build`, produces the right answer —
+`cargo test -p nirdosha --test native_plugin_examples`.
+
+## How this crate is built (the plugin-author side)
+
+One function, in [`src/lib.rs`](./src/lib.rs):
+
+```rust
+#[repr(C)]
+pub struct NirStr { pub ptr: *const u8, pub len: i64 }
+
+#[unsafe(no_mangle)]
+pub extern "C" fn plugin_shout(s: NirStr) -> NirStr { /* ... */ }
+```
+
+Three rules this ABI actually enforces, not just documents:
+
+1. **`NirStr`'s field order and widths must match `Ty::Str`'s own LLVM
+   shape exactly** — `{ptr, i64}`, first the pointer, then the length,
+   passed **by value** (not a pointer to the struct) — the same
+   `#[repr(C)]`-struct-by-value convention `runtime-kernels/src/lib.rs`'s
+   `Dec128Bits` already uses for a different two-word value. Get the
+   field order wrong and you get silently wrong data, not a compile
+   error — there's no cross-language shape-check here yet.
+2. **Not NUL-terminated.** `len` is the only thing saying how many bytes
+   are valid; a `.nir` `str` can contain an embedded `\0`.
+3. **A returned string's memory is never freed by Nirdosha.** `Ty::Str`
+   isn't affine (no scope-closing point to hook a free onto — the same
+   reason `codegen.rs`'s own `sha256_hex` builtin leaks its output),
+   so `plugin_shout` allocates via `Box::leak` and that memory is gone
+   for the life of the process. A plugin returning many short-lived
+   strings in a hot loop should design around this, not fight it.
+
+`Cargo.toml`'s `[package.metadata.nirdosha]` block declares the same
+signature in a statically-greppable form:
+
+```toml
+[package.metadata.nirdosha]
+kind = "native-compiled"
+builtins = [
+    { name = "plugin_shout", params = ["str"], ret = "str" },
+]
+```
+
+## How a project consumes it (the app-author side)
+
+There's no `nirdosha build` CLI flag that finds this crate on its own
+yet (rfcs/0008 Phase 3 — Cargo-driven auto-discovery — isn't built).
+Today, consuming a native plugin means constructing a
+`NativePluginBuiltin` by hand and calling
+`codegen::build_with_native_plugins` instead of the plain `nirdosha`
+CLI:
+
+```rust
+use nirdosha::ast::Ty;
+use nirdosha::plugin::NativePluginBuiltin;
+
+let lib_bytes: &'static [u8] = /* read target/release/libnirdosha_plugin_native_shout.a */;
+let shout = NativePluginBuiltin {
+    name: "plugin_shout".to_string(),
+    params: vec![Ty::Str],
+    ret: Ty::Str,
+    static_lib: lib_bytes,
+};
+shout.validate().expect("signature must be a supported native-ABI value");
+// typecheck_with_native_plugins / check_ownership / codegen::build_with_native_plugins
+// -- see crates/compiler/tests/native_plugin_examples.rs for the real,
+// working, end-to-end version of this.
+```
+
+## What you get for free once it's linked in
+
+- **Static type checking.** `plugin_shout(42)` or wrong arity are real
+  *type errors*, caught before `clang` ever runs — `typecheck_with_
+  native_plugins` slots this signature into the exact same table an
+  ordinary `fn` uses.
+- **A named, actionable rejection**, not a confusing LLVM/clang
+  failure, for a signature this ABI doesn't support yet (`validate()`).
+- **Real native speed.** This is a direct `call` in generated LLVM IR
+  into a statically-linked symbol — no interpreter, no dispatch table.
+
+## Full design
+
+rfcs/0008-native-plugin-abi-widening.md — what's built (this crate is
+part of the Phase 1/4 evidence), what's still open (Phase 2's authoring
+macro, Phase 3's Cargo-driven discovery), and why str/handle crossing
+works the way it does.

--- a/crates/plugin-example-native-shout/src/lib.rs
+++ b/crates/plugin-example-native-shout/src/lib.rs
@@ -1,0 +1,43 @@
+//! `plugin_shout(s: str) -> str` — the reference example for
+//! rfcs/0008-native-plugin-abi-widening.md Phase 1's `str` crossing: a
+//! plugin author's own `#[repr(C)]` two-word struct, `(ptr, len)`,
+//! passed and returned *by value*, matching the exact LLVM shape
+//! `codegen.rs::llvm_ty` already emits for every `.nir` `str` value
+//! (`Ty::Str => "{ptr, i64}"`) — the same convention
+//! `runtime-kernels/src/lib.rs`'s own `Dec128Bits` already establishes
+//! for a different two-word value. Nothing here is Nirdosha-specific
+//! beyond that struct's shape: this crate has zero dependency on the
+//! `nirdosha` crate itself.
+//!
+//! See this crate's `README.md` for how to build it and wire it into a
+//! real `nirdosha build`, and `crates/compiler/tests/
+//! native_plugin_examples.rs` for the automated, run-the-real-binary
+//! proof that this exact source does what it claims.
+
+/// Must match `Ty::Str`'s own `{ptr, i64}` field order and widths
+/// exactly — this is the ABI, not an internal convenience type. Not
+/// NUL-terminated: `len` is the only thing saying how many bytes are
+/// valid, the same as every other `str` value in this compiler.
+#[repr(C)]
+pub struct NirStr {
+    pub ptr: *const u8,
+    pub len: i64,
+}
+
+/// Upper-cases the input and appends `!`. Allocates its own buffer and
+/// leaks it (`Box::leak`) — nothing on the Nirdosha side ever frees a
+/// plugin-returned string, the same permanent-leak posture
+/// `codegen.rs`'s own `sha256_hex` builtin already has for the
+/// identical reason: `Ty::Str` isn't affine, so there is no
+/// scope-closing point to hook a free onto. A plugin returning a *lot*
+/// of short-lived strings in a loop should keep this in mind — it's a
+/// real, disclosed limit of the current `str`-return convention, not an
+/// oversight in this one example.
+#[unsafe(no_mangle)]
+pub extern "C" fn plugin_shout(s: NirStr) -> NirStr {
+    let bytes = unsafe { std::slice::from_raw_parts(s.ptr, s.len as usize) };
+    let mut v: Vec<u8> = bytes.iter().map(|b| b.to_ascii_uppercase()).collect();
+    v.push(b'!');
+    let leaked: &'static mut [u8] = Box::leak(v.into_boxed_slice());
+    NirStr { ptr: leaked.as_ptr(), len: leaked.len() as i64 }
+}

--- a/crates/presence-gateway/src/jwt.rs
+++ b/crates/presence-gateway/src/jwt.rs
@@ -44,8 +44,12 @@ struct RawJwk {
     // oct (`kty: "oct"`, symmetric — HS256 only). Real IdPs never publish
     // one of these in a public JWKS (it would leak the shared secret) —
     // this exists so a locally-mocked JWKS (`mock_issue_token`, this
-    // crate's own integration tests, `tests/serve.rs`'s own `JWKS` const)
-    // verifies exactly the same way a real RSA/EC IdP's would.
+    // crate's own integration tests, and the identical fixture ported into
+    // `crates/runtime-kernels/src/lib.rs`'s `nir_oidc_validate_token` for
+    // the compiled-path side of this same job) verifies exactly the same
+    // way a real RSA/EC IdP's would. (`tests/serve.rs`, this comment's
+    // original citation, no longer exists — deleted along with the
+    // interpreter and `nirdosha serve`.)
     k: Option<String>,
 }
 
@@ -55,9 +59,11 @@ struct VerifiableKey {
 }
 
 /// A parsed, ready-to-verify-against JWKS — loaded once at startup from
-/// `--jwks-file`, the same "static file, no live rotation" posture
-/// `nirdosha serve`'s own `--jwks-file`/`--issuer`/`--audience` trio
-/// already takes (`main.rs`'s `cmd_serve` doc comment); disclosed, not
+/// `--jwks-file`, the same "static file, no live rotation" posture the
+/// old interpreter-era `nirdosha serve --jwks-file` used to take (that
+/// command is gone along with the interpreter; `nir_oidc_validate_token`,
+/// `crates/runtime-kernels/src/lib.rs`, is this same posture's compiled-
+/// path successor); disclosed, not
 /// hidden, the same way that limitation already is there.
 pub struct KeySet {
     keys: HashMap<String, VerifiableKey>,

--- a/crates/runtime-kernels/Cargo.lock
+++ b/crates/runtime-kernels/Cargo.lock
@@ -9,6 +9,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,6 +40,12 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -63,6 +90,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "cc"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +110,32 @@ name = "cfg_aliases"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "combine"
+version = "4.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crc32fast"
@@ -99,10 +162,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
+
+[[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "flate2"
@@ -116,14 +236,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -140,9 +310,131 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -151,7 +443,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -161,10 +462,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -198,13 +548,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nirdosha-runtime-kernels"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "crossbeam-channel",
  "flate2",
+ "jsonwebtoken",
+ "native-tls",
+ "openssl",
  "r2d2",
+ "redis",
+ "rusqlite",
  "rust_decimal",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -221,6 +621,59 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking_lot"
@@ -244,6 +697,49 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -358,12 +854,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis"
+version = "0.27.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d8f99a4090c89cc489a94833c901ead69bfbf3877b4867d5482e321ee875bc"
+dependencies = [
+ "arc-swap",
+ "combine",
+ "itertools",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "ryu",
+ "sha1_smol",
+ "socket2",
+ "url",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -384,10 +926,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "scheduled-thread-pool"
@@ -405,12 +975,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -447,16 +1041,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"
@@ -478,6 +1118,90 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
+
+[[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -515,6 +1239,42 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -584,6 +1344,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
 name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +1439,35 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -616,6 +1487,60 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
 ]
 
 [[package]]

--- a/crates/runtime-kernels/Cargo.toml
+++ b/crates/runtime-kernels/Cargo.toml
@@ -58,6 +58,60 @@ flate2 = "1"
 # channel is itself sync-only, mature, and widely used well outside
 # this project.
 crossbeam-channel = "0.5"
+# `nir_oidc_validate_token`/`nir_extract_claim`/`nir_check_role`'s real
+# JWT/JWKS crypto and JSON claims parsing (Row 12 identity). Not a new
+# provenance story this time either: `crates/presence-gateway/src/jwt.rs`
+# already depends on this exact set (`jsonwebtoken`/`serde`/`serde_json`/
+# `base64`) for the identical job -- real signature verification against a
+# JWKS, keyed by `kid`, with the JWK's own `kty` locking which `alg` it may
+# verify under (never trusting the token's own `alg` header -- closes the
+# classic algorithm-confusion attack). Same dependency set, same guard,
+# ported here so the compiled path can link it too.
+jsonwebtoken = "9"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+base64 = "0.22"
+# `nir_db_connect`/`nir_db_query`/`nir_db_execute`'s real SQLite backend
+# (Row: `db`). Same crate + feature the root workspace's own
+# `crates/compiler/Cargo.toml` already pins (`rusqlite = { version =
+# "0.31", features = ["bundled"] }`, used by `migrate.rs`/`rqlite.rs`) --
+# `bundled` statically links SQLite's own C source into this crate, no
+# system `libsqlite3` dependency, so a compiled `.nir` binary using `db`
+# stays exactly as self-contained a deployment artifact as one that
+# doesn't. `rusqlite::types::Value` (an owned, already-`ToSql` enum) is
+# the marshaling type every bind value below converts into -- no
+# hand-rolled parameter-binding trait needed.
+rusqlite = { version = "0.31", features = ["bundled"] }
+# `nir_mq_connect`/`nir_mq_publish`/`nir_mq_consume`'s real Redis backend
+# (Row: `mq`, `Ty::Mq`'s doc comment). Same crate + version the root
+# workspace's own `crates/compiler/Cargo.toml` already pins
+# (`redis = "0.27"`) -- no new provenance story. `LPUSH`/`BLPOP` back
+# `mq_publish`/`mq_consume`, same as the original interpreter-era design;
+# no static-linking concern (a real network client, not an embedded C
+# library) the way SQLite's `bundled` feature was a decision to make.
+redis = "0.27"
+# `nir_http_get`/`nir_http_post`/`nir_https_get`/`nir_https_post`'s real
+# HTTP(S) client. Same crate the root workspace's own
+# `crates/compiler/Cargo.toml` already pins (`native-tls = "0.2"`) for the
+# identical job -- but a real, deliberate departure from that crate's own
+# choice on the one point `docs/ROADMAP.md` already flagged as needing a
+# conscious decision, not a silent default: **vendored**, not system-
+# linked. Found by actually linking a compiled binary, not decided in
+# advance -- this machine's system OpenSSL doesn't export the symbols
+# (`SSL_ctrl`/`SSL_CTX_ctrl`/`X509_LOOKUP_ctrl`) the `openssl-sys` version
+# this dependency tree resolves to expects (an ABI mismatch real enough to
+# fail the link step outright, not a hypothetical portability concern).
+# Pulling in `openssl` directly with its own `vendored` feature forces
+# Cargo's feature unification to statically compile and link OpenSSL from
+# source into this crate instead of trusting whatever `libssl` happens to
+# be on the host -- the exact same "no system dependency" posture
+# `rusqlite`'s own `bundled` feature already gives SQLite, now given to
+# TLS too, for the same self-contained-deployment reason. Needs a C
+# compiler + `perl`/`make` at *build* time only (already present on any
+# machine that can build this workspace at all — `rusqlite`'s own
+# `bundled` SQLite already requires the same); nothing extra at runtime.
+native-tls = "0.2"
+openssl = { version = "0.10", features = ["vendored"] }
 
 [profile.release]
 # `unwind` (the default -- kept explicit here as a record of a real

--- a/crates/runtime-kernels/src/kernel/mod.rs
+++ b/crates/runtime-kernels/src/kernel/mod.rs
@@ -148,6 +148,19 @@ pub enum Domain {
     /// pair; a total-ever-created cap would be a different, not-yet-
     /// asked-for kind of limit.
     Thread,
+    /// One outstanding `db` connection (between `db_connect` and its
+    /// matching `stop`) — same ceiling-on-concurrently-held-affine-
+    /// handles shape as `Tcp`/`File` above, now that a real SQLite
+    /// backend exists (`nir_db_connect`, `lib.rs`'s "db kernels"
+    /// section). Appended after `Thread`, not inserted earlier, so
+    /// every existing `Domain as u8` discriminant this module's own
+    /// flight-recorder encoding (`kernel::recorder::domain_name`)
+    /// depends on stays stable.
+    Db,
+    /// One outstanding `mq` (Redis) connection — same shape as `Db`
+    /// just above, appended after it for the same "existing `Domain as
+    /// u8` discriminants stay stable" reason.
+    Mq,
 }
 
 impl Domain {
@@ -161,6 +174,8 @@ impl Domain {
             Domain::Tcp => "NIRDOSHA_KERNEL_MAX_TCP",
             Domain::File => "NIRDOSHA_KERNEL_MAX_FILE",
             Domain::Thread => "NIRDOSHA_KERNEL_MAX_THREAD",
+            Domain::Db => "NIRDOSHA_KERNEL_MAX_DB",
+            Domain::Mq => "NIRDOSHA_KERNEL_MAX_MQ",
         }
     }
 
@@ -190,12 +205,16 @@ impl DomainCounters {
 static TCP: DomainCounters = DomainCounters::new();
 static FILE: DomainCounters = DomainCounters::new();
 static THREAD: DomainCounters = DomainCounters::new();
+static DB: DomainCounters = DomainCounters::new();
+static MQ: DomainCounters = DomainCounters::new();
 
 fn counters_for(domain: Domain) -> &'static DomainCounters {
     match domain {
         Domain::Tcp => &TCP,
         Domain::File => &FILE,
         Domain::Thread => &THREAD,
+        Domain::Db => &DB,
+        Domain::Mq => &MQ,
     }
 }
 
@@ -274,7 +293,7 @@ pub fn stats(domain: Domain) -> (i64, u64, u64) {
 /// it's ever seen, not just a diagnostic curiosity.
 pub fn dump_report() -> String {
     let mut out = String::from("nirdosha kernel flight recorder:\n");
-    for (name, domain) in [("tcp", Domain::Tcp), ("file", Domain::File), ("thread", Domain::Thread)] {
+    for (name, domain) in [("tcp", Domain::Tcp), ("file", Domain::File), ("thread", Domain::Thread), ("db", Domain::Db), ("mq", Domain::Mq)] {
         let (held, grants, denials) = stats(domain);
         out.push_str(&format!("  {name}: held={held} grants={grants} denials={denials}\n"));
     }

--- a/crates/runtime-kernels/src/kernel/recorder.rs
+++ b/crates/runtime-kernels/src/kernel/recorder.rs
@@ -136,6 +136,8 @@ fn domain_name(d: u8) -> &'static str {
         0 => "tcp",
         1 => "file",
         2 => "thread",
+        3 => "db",
+        4 => "mq",
         _ => "unknown",
     }
 }

--- a/crates/runtime-kernels/src/lib.rs
+++ b/crates/runtime-kernels/src/lib.rs
@@ -613,6 +613,79 @@ pub unsafe extern "C" fn nir_str_eq(a: *const u8, a_len: i64, b: *const u8, b_le
     (a == b) as i32
 }
 
+/// Backs the `str_index_of(haystack, needle)` builtin — the one string
+/// primitive that's a genuine byte-scan (`str_slice`/`len(str)` are pure
+/// pointer-arithmetic in `codegen.rs`, no kernel call at all). Returns the
+/// byte offset of the first occurrence of `needle` in `haystack`, or `-1`
+/// if it's not found. An empty `needle` always matches at offset `0`
+/// (mirrors `str::find`'s own convention for an empty pattern).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_str_index_of(
+    hay_ptr: *const u8,
+    hay_len: i64,
+    needle_ptr: *const u8,
+    needle_len: i64,
+) -> i64 {
+    if needle_len == 0 {
+        return 0;
+    }
+    if needle_len > hay_len {
+        return -1;
+    }
+    let hay = unsafe { std::slice::from_raw_parts(hay_ptr, hay_len as usize) };
+    let needle = unsafe { std::slice::from_raw_parts(needle_ptr, needle_len as usize) };
+    match hay.windows(needle.len()).position(|w| w == needle) {
+        Some(i) => i as i64,
+        None => -1,
+    }
+}
+
+#[cfg(test)]
+mod str_index_of_tests {
+    use super::nir_str_index_of;
+
+    fn index_of(hay: &str, needle: &str) -> i64 {
+        unsafe {
+            nir_str_index_of(
+                hay.as_ptr(),
+                hay.len() as i64,
+                needle.as_ptr(),
+                needle.len() as i64,
+            )
+        }
+    }
+
+    #[test]
+    fn finds_a_substring_in_the_middle() {
+        assert_eq!(index_of("GET /api/hello HTTP/1.1", " "), 3);
+    }
+
+    #[test]
+    fn returns_negative_one_when_not_found() {
+        assert_eq!(index_of("hello", "xyz"), -1);
+    }
+
+    #[test]
+    fn empty_needle_matches_at_offset_zero() {
+        assert_eq!(index_of("hello", ""), 0);
+    }
+
+    #[test]
+    fn needle_at_offset_zero() {
+        assert_eq!(index_of("hello world", "hello"), 0);
+    }
+
+    #[test]
+    fn needle_at_the_end() {
+        assert_eq!(index_of("hello world", "world"), 6);
+    }
+
+    #[test]
+    fn needle_longer_than_haystack_is_not_found() {
+        assert_eq!(index_of("hi", "hello"), -1);
+    }
+}
+
 // ---- tcp/tcp_listener kernels --------------------------------------------
 //
 // A `tcp`/`tcp_listener` handle is a raw OS socket handle, not a Rust
@@ -1440,22 +1513,210 @@ pub extern "C" fn nir_nfr_call_end(id: i64, start_ns: i64, was_err: i32) {
     kernel::nfr::call_end(id, start_ns, was_err != 0)
 }
 
-// ---- check_role kernel (identity/RBAC, real authorization pipeline) ------
+// ---- check_role / oidc_validate_token / extract_claim kernels -----------
+// (identity/RBAC, real authorization pipeline)
 //
 // `codegen.rs`'s `IDENTITY_BUILTINS`/`emit_check_role` doc comments have
-// the full scope: this is `check_role`'s real, compiled implementation,
-// deliberately narrower than the interpreter's own JSON-based one —
-// `claims` here is read as a plain comma-separated role list, not
-// parsed as JSON (no JSON parser is linked into this crate). Exact
-// per-entry matching, not a substring search — `"adm"` must never match
-// a claims list containing `"admin"`.
+// the full scope. `check_role` was previously a plain comma-separated
+// role list, deliberately narrower than the interpreter's own JSON-based
+// one, disclosed as such — "no JSON parser is linked into this crate".
+// 2026-09: that's no longer true (`Cargo.toml`'s new `serde_json`
+// dependency, added for `oidc_validate_token`'s own claims below), so
+// `check_role` is upgraded here to real JSON-array parsing too, **with a
+// fallback to the original comma-separated matching** so a
+// `VerifiedIdentity` built directly in `.nir` source with a plain
+// `claims_json = "admin,editor"` string (not real JSON — the existing
+// `check_role_produces_real_role_view_that_drives_field_masking` test
+// fixture does exactly this) still works unchanged.
+//
+// `oidc_validate_token`/`extract_claim` port
+// `crates/presence-gateway/src/jwt.rs`'s exact JWKS-verification shape
+// (same dependency set, same doc comment's own reasoning) — including its
+// one load-bearing security detail: a JWK's `kty` *locks* which `alg` it
+// may verify under (RSA→RS256, EC/P-256→ES256, oct→HS256), never derived
+// from the token's own `alg` header, closing the classic algorithm-
+// confusion attack (an RSA public key replayed as an HMAC secret).
+// Deliberately **not** validating `exp` against the real wall clock here,
+// unlike `jwt.rs::verify` — that module is a live network boundary and
+// checking real-time expiry there is the right split for its job; this
+// compiled builtin stays a pure function of its inputs
+// (`docs/LANGUAGE.md` §9's determinism story), leaving expiry to
+// `identity_expired(identity, now)`'s own explicit `now` instead of an
+// ambient clock read.
 
-/// `1` if `role` (as UTF-8 bytes) exactly equals one comma-separated
-/// entry of `claims` (each entry's surrounding whitespace trimmed, so
-/// `"admin, editor"` and `"admin,editor"` behave identically), `0`
+#[derive(serde::Deserialize)]
+struct RawJwks {
+    keys: Vec<RawJwk>,
+}
+
+#[derive(serde::Deserialize)]
+struct RawJwk {
+    kid: String,
+    kty: String,
+    // RSA (`kty: "RSA"`)
+    n: Option<String>,
+    e: Option<String>,
+    // EC (`kty: "EC"`, `crv: "P-256"` only — ES256)
+    crv: Option<String>,
+    x: Option<String>,
+    y: Option<String>,
+    // oct (`kty: "oct"`, symmetric — HS256 only).
+    k: Option<String>,
+}
+
+fn decoding_key_for(jwk: &RawJwk) -> Result<(jsonwebtoken::DecodingKey, jsonwebtoken::Algorithm), String> {
+    use base64::Engine as _;
+    match jwk.kty.as_str() {
+        "RSA" => {
+            let n = jwk.n.as_deref().ok_or("JWK is missing required field `n`")?;
+            let e = jwk.e.as_deref().ok_or("JWK is missing required field `e`")?;
+            let decoding_key = jsonwebtoken::DecodingKey::from_rsa_components(n, e).map_err(|err| format!("invalid RSA key material: {err}"))?;
+            Ok((decoding_key, jsonwebtoken::Algorithm::RS256))
+        }
+        "EC" => {
+            let crv = jwk.crv.clone().unwrap_or_default();
+            if crv != "P-256" {
+                return Err(format!("unsupported EC curve `{crv}` (only P-256/ES256 is supported)"));
+            }
+            let x = jwk.x.as_deref().ok_or("JWK is missing required field `x`")?;
+            let y = jwk.y.as_deref().ok_or("JWK is missing required field `y`")?;
+            let decoding_key = jsonwebtoken::DecodingKey::from_ec_components(x, y).map_err(|err| format!("invalid EC key material: {err}"))?;
+            Ok((decoding_key, jsonwebtoken::Algorithm::ES256))
+        }
+        "oct" => {
+            let k = jwk.k.as_deref().ok_or("JWK is missing required field `k`")?;
+            let raw_secret = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(k).map_err(|_| "JWK field `k` is not valid base64url".to_string())?;
+            Ok((jsonwebtoken::DecodingKey::from_secret(&raw_secret), jsonwebtoken::Algorithm::HS256))
+        }
+        other => Err(format!("unsupported JWK `kty`: `{other}` (only RSA, EC/P-256, and oct are supported)")),
+    }
+}
+
+struct VerifiedClaims {
+    subject: String,
+    issuer: String,
+    audience: String,
+    expires_at: i64,
+    issued_at: i64,
+    claims_json: String,
+}
+
+fn validate_oidc_token_inner(token: &str, expected_issuer: &str, expected_audience: &str, jwks_json: &str) -> Result<VerifiedClaims, String> {
+    let jwks: RawJwks = serde_json::from_str(jwks_json).map_err(|e| format!("malformed JWKS: {e}"))?;
+    let header = jsonwebtoken::decode_header(token).map_err(|e| format!("malformed token: {e}"))?;
+    let kid = header.kid.ok_or_else(|| "token header has no `kid`".to_string())?;
+    let jwk = jwks.keys.iter().find(|k| k.kid == kid).ok_or_else(|| format!("token references unknown key id `{kid}`"))?;
+    let (decoding_key, algorithm) = decoding_key_for(jwk)?;
+
+    // Locked to exactly the one algorithm this `kid`'s key material is
+    // valid for (never the token's own `alg` header) — the actual
+    // algorithm-confusion guard, decided entirely by `decoding_key_for`'s
+    // `kty` match above, same as `jwt.rs::verify`.
+    let mut validation = jsonwebtoken::Validation::new(algorithm);
+    validation.set_issuer(&[expected_issuer]);
+    validation.set_audience(&[expected_audience]);
+    validation.validate_exp = false; // see this section's own doc comment
+
+    let data = jsonwebtoken::decode::<serde_json::Value>(token, &decoding_key, &validation).map_err(|e| format!("token verification failed: {e}"))?;
+    let claims = data.claims;
+
+    let subject = claims.get("sub").and_then(|v| v.as_str()).unwrap_or("").to_string();
+    let issuer = claims.get("iss").and_then(|v| v.as_str()).unwrap_or("").to_string();
+    let audience = claims.get("aud").and_then(|v| v.as_str()).unwrap_or("").to_string();
+    let expires_at = claims.get("exp").and_then(|v| v.as_i64()).unwrap_or(0);
+    let issued_at = claims.get("iat").and_then(|v| v.as_i64()).unwrap_or(0);
+    // The full decoded claims, re-serialized — this is what `check_role`/
+    // `extract_claim` read back out of `VerifiedIdentity.claims_json`.
+    let claims_json = serde_json::to_string(&claims).unwrap_or_else(|_| "{}".to_string());
+
+    Ok(VerifiedClaims { subject, issuer, audience, expires_at, issued_at, claims_json })
+}
+
+/// `{ptr, i64}` — matches `Ty::Str`'s own codegen layout exactly (same
+/// idea as the RFC 0008 native-plugin ABI's `NirStr`), so `codegen.rs`
+/// can load one of these straight into a `str` value with a plain
+/// `insertvalue` pair, no marshaling. Every `NirStrOut` this file
+/// produces is heap-allocated via `nir_alloc` and never freed — the same
+/// disclosed, permanent-leak convention `nir_sha256_hex` already uses
+/// (`Ty::Str` isn't affine, so there's no scope-closing point to hook a
+/// matching `nir_free` onto).
+#[repr(C)]
+pub struct NirStrOut {
+    pub ptr: *const u8,
+    pub len: i64,
+}
+
+unsafe fn write_str_out(out: *mut NirStrOut, s: String) {
+    let leaked: &'static [u8] = Box::leak(s.into_boxed_str().into_boxed_bytes());
+    unsafe {
+        *out = NirStrOut { ptr: leaked.as_ptr(), len: leaked.len() as i64 };
+    }
+}
+
+unsafe fn str_from_raw<'a>(ptr: *const u8, len: i64) -> Option<&'a str> {
+    let bytes = unsafe { std::slice::from_raw_parts(ptr, len as usize) };
+    std::str::from_utf8(bytes).ok()
+}
+
+/// `oidc_validate_token`'s real, compiled implementation. `1` (with every
+/// `out_*` param populated) if `token`'s signature verifies against
+/// `jwks_json` and its `iss`/`aud` match, `0` (with `out_err` populated,
+/// everything else untouched) otherwise — a malformed token/JWKS is a
+/// real `Err`, never a trap, same as every other identity check in this
+/// codebase.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_oidc_validate_token(
+    token_ptr: *const u8,
+    token_len: i64,
+    issuer_ptr: *const u8,
+    issuer_len: i64,
+    audience_ptr: *const u8,
+    audience_len: i64,
+    jwks_ptr: *const u8,
+    jwks_len: i64,
+    out_subject: *mut NirStrOut,
+    out_issuer: *mut NirStrOut,
+    out_audience: *mut NirStrOut,
+    out_expires_at: *mut i64,
+    out_issued_at: *mut i64,
+    out_claims_json: *mut NirStrOut,
+    out_err: *mut NirStrOut,
+) -> i32 {
+    let (Some(token), Some(expected_issuer), Some(expected_audience), Some(jwks_json)) = (
+        unsafe { str_from_raw(token_ptr, token_len) },
+        unsafe { str_from_raw(issuer_ptr, issuer_len) },
+        unsafe { str_from_raw(audience_ptr, audience_len) },
+        unsafe { str_from_raw(jwks_ptr, jwks_len) },
+    ) else {
+        unsafe { write_str_out(out_err, "token/issuer/audience/jwks is not valid UTF-8".to_string()) };
+        return 0;
+    };
+    match validate_oidc_token_inner(token, expected_issuer, expected_audience, jwks_json) {
+        Ok(claims) => unsafe {
+            write_str_out(out_subject, claims.subject);
+            write_str_out(out_issuer, claims.issuer);
+            write_str_out(out_audience, claims.audience);
+            *out_expires_at = claims.expires_at;
+            *out_issued_at = claims.issued_at;
+            write_str_out(out_claims_json, claims.claims_json);
+            1
+        },
+        Err(msg) => unsafe {
+            write_str_out(out_err, msg);
+            0
+        },
+    }
+}
+
+/// `1` if `role` (as UTF-8 bytes) is present in `claims`'s roles, `0`
 /// otherwise — including if either buffer isn't valid UTF-8, the same
 /// "fail closed on malformed input" posture every other identity check
-/// in this codebase already has.
+/// in this codebase already has. Tries `claims` as real JSON first (a
+/// top-level `"roles"` array of strings — `nir_oidc_validate_token`'s own
+/// `claims_json` output shape); on JSON-parse failure, falls back to the
+/// original plain comma-separated-list matching (each entry's
+/// surrounding whitespace trimmed) — exact per-entry matching either way,
+/// never a substring search (`"adm"` must never match `"admin"`).
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn nir_check_role(claims_ptr: *const u8, claims_len: i64, role_ptr: *const u8, role_len: i64) -> i32 {
     let claims = unsafe { std::slice::from_raw_parts(claims_ptr, claims_len as usize) };
@@ -1463,7 +1724,1849 @@ pub unsafe extern "C" fn nir_check_role(claims_ptr: *const u8, claims_len: i64, 
     let (Ok(claims), Ok(role)) = (std::str::from_utf8(claims), std::str::from_utf8(role)) else {
         return 0;
     };
+    if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(claims) {
+        if let Some(roles) = parsed.get("roles").and_then(|v| v.as_array()) {
+            return roles.iter().any(|r| r.as_str() == Some(role)) as i32;
+        }
+    }
     claims.split(',').any(|entry| entry.trim() == role) as i32
+}
+
+/// `extract_claim`'s real, compiled implementation. `1` (with `out_value`
+/// populated) if `claims_json` parses as JSON and has a top-level
+/// string-valued claim named `name`, `0` otherwise. Array/object-valued
+/// claims (e.g. `"roles"`) are out of scope here — that's `check_role`'s
+/// job, not `extract_claim`'s, per this exact split in
+/// `examples/features/30_identity_oidc.nir`'s own fixture.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_extract_claim(claims_json_ptr: *const u8, claims_json_len: i64, name_ptr: *const u8, name_len: i64, out_value: *mut NirStrOut) -> i32 {
+    let (Some(claims_json), Some(name)) = (unsafe { str_from_raw(claims_json_ptr, claims_json_len) }, unsafe { str_from_raw(name_ptr, name_len) }) else {
+        return 0;
+    };
+    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(claims_json) else {
+        return 0;
+    };
+    match parsed.get(name).and_then(|v| v.as_str()) {
+        Some(s) => unsafe {
+            write_str_out(out_value, s.to_string());
+            1
+        },
+        None => 0,
+    }
+}
+
+#[cfg(test)]
+mod identity_kernel_tests {
+    use super::*;
+
+    // Same fixture as `examples/features/30_identity_oidc.nir`/
+    // `31_mock_identity_provider.nir`: header `{"alg":"HS256","kid":"key1"}`,
+    // payload `{"sub":"alice","iss":"https://example.com","aud":"my-app",
+    // "exp":2000000000,"iat":1700000000,"roles":["physician"],
+    // "department":"cardiology"}`, secret `"my-secret-key"` (JWKS `k` is
+    // that string's base64url encoding).
+    const FIXTURE_TOKEN: &str = "eyJhbGciOiAiSFMyNTYiLCAia2lkIjogImtleTEifQ.eyJzdWIiOiAiYWxpY2UiLCAiaXNzIjogImh0dHBzOi8vZXhhbXBsZS5jb20iLCAiYXVkIjogIm15LWFwcCIsICJleHAiOiAyMDAwMDAwMDAwLCAiaWF0IjogMTcwMDAwMDAwMCwgInJvbGVzIjogWyJwaHlzaWNpYW4iXSwgImRlcGFydG1lbnQiOiAiY2FyZGlvbG9neSJ9.nrFdeqNDwXWLeGzud6X9Q4ITzCXULzZBBK8y51LGYXs";
+    const FIXTURE_JWKS: &str = r#"{"keys":[{"kid":"key1","kty":"oct","k":"bXktc2VjcmV0LWtleQ"}]}"#;
+
+    #[test]
+    fn valid_token_verifies_and_extracts_real_claims() {
+        let claims = validate_oidc_token_inner(FIXTURE_TOKEN, "https://example.com", "my-app", FIXTURE_JWKS).expect("fixture token should verify");
+        assert_eq!(claims.subject, "alice");
+        assert_eq!(claims.issuer, "https://example.com");
+        assert_eq!(claims.audience, "my-app");
+        assert_eq!(claims.expires_at, 2000000000);
+        assert_eq!(claims.issued_at, 1700000000);
+        let parsed: serde_json::Value = serde_json::from_str(&claims.claims_json).unwrap();
+        assert_eq!(parsed["department"], "cardiology");
+        assert_eq!(parsed["roles"][0], "physician");
+    }
+
+    #[test]
+    fn wrong_issuer_is_rejected() {
+        assert!(validate_oidc_token_inner(FIXTURE_TOKEN, "https://wrong-issuer.example", "my-app", FIXTURE_JWKS).is_err());
+    }
+
+    #[test]
+    fn wrong_audience_is_rejected() {
+        assert!(validate_oidc_token_inner(FIXTURE_TOKEN, "https://example.com", "wrong-app", FIXTURE_JWKS).is_err());
+    }
+
+    #[test]
+    fn tampered_signature_is_rejected() {
+        // Flip the last character of the signature segment.
+        let mut tampered = FIXTURE_TOKEN.to_string();
+        tampered.pop();
+        tampered.push('x');
+        assert!(validate_oidc_token_inner(&tampered, "https://example.com", "my-app", FIXTURE_JWKS).is_err());
+    }
+
+    #[test]
+    fn unknown_kid_is_rejected() {
+        let jwks = r#"{"keys":[{"kid":"some-other-key","kty":"oct","k":"bXktc2VjcmV0LWtleQ"}]}"#;
+        assert!(validate_oidc_token_inner(FIXTURE_TOKEN, "https://example.com", "my-app", jwks).is_err());
+    }
+
+    #[test]
+    fn malformed_jwks_is_rejected_not_a_panic() {
+        assert!(validate_oidc_token_inner(FIXTURE_TOKEN, "https://example.com", "my-app", "not json").is_err());
+    }
+
+    fn check_role(claims_json: &str, role: &str) -> i32 {
+        unsafe { nir_check_role(claims_json.as_ptr(), claims_json.len() as i64, role.as_ptr(), role.len() as i64) }
+    }
+
+    #[test]
+    fn check_role_finds_a_role_in_a_real_json_roles_array() {
+        let claims = r#"{"roles":["physician","nurse"]}"#;
+        assert_eq!(check_role(claims, "physician"), 1);
+        assert_eq!(check_role(claims, "admin"), 0);
+    }
+
+    #[test]
+    fn check_role_falls_back_to_comma_separated_for_non_json_claims() {
+        // The existing `check_role_produces_real_role_view_that_drives_
+        // field_masking` test's own fixture shape -- must keep working.
+        assert_eq!(check_role("admin,editor", "admin"), 1);
+        assert_eq!(check_role("admin,editor", "adm"), 0); // exact match, not substring
+    }
+
+    #[test]
+    fn extract_claim_reads_a_string_claim_from_real_json() {
+        let claims_json = r#"{"department":"cardiology","roles":["physician"]}"#;
+        let name = "department";
+        let mut out = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let found = unsafe { nir_extract_claim(claims_json.as_ptr(), claims_json.len() as i64, name.as_ptr(), name.len() as i64, &mut out) };
+        assert_eq!(found, 1);
+        let value = unsafe { std::str::from_utf8(std::slice::from_raw_parts(out.ptr, out.len as usize)).unwrap() };
+        assert_eq!(value, "cardiology");
+    }
+
+    #[test]
+    fn extract_claim_not_found_returns_zero() {
+        let claims_json = r#"{"department":"cardiology"}"#;
+        let name = "missing";
+        let mut out = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let found = unsafe { nir_extract_claim(claims_json.as_ptr(), claims_json.len() as i64, name.as_ptr(), name.len() as i64, &mut out) };
+        assert_eq!(found, 0);
+    }
+}
+
+// ---- db kernels (`db_connect`/`db_query`/`db_execute`/`stop`) -----------
+//
+// `Ty::Db`'s own doc comment (`ast.rs`) has the full design: layer 1
+// targets SQLite specifically, via `rusqlite`'s `bundled` feature
+// (statically linked, no system `libsqlite3`, same reason this crate's
+// own `Cargo.toml` gives). Postgres (`postgres://`/`postgresql://`) is a
+// real, separate, deferred follow-up (dynamic TLS linking) — not
+// silently dropped, `docs/ROADMAP.md`'s own B2 note already says so.
+//
+// A `db` handle rides through `kernel::HandleTable<rusqlite::Connection>`
+// (`kernel/mod.rs`'s own "not wired to any `nir_*` kernel yet" table,
+// built exactly for this), not a raw OS fd like `tcp`/`file` — a
+// `rusqlite::Connection` isn't `Copy`/reconstructable from a bare
+// integer the way a fd is, so the table (not `Box::into_raw`/`from_raw`
+// pointer arithmetic) is the right fit here, same as `channel_table`/
+// `thread_table` above already use it for their own non-fd resources.
+
+fn db_table() -> &'static HandleTable<rusqlite::Connection> {
+    static TABLE: OnceLock<HandleTable<rusqlite::Connection>> = OnceLock::new();
+    TABLE.get_or_init(HandleTable::new)
+}
+
+/// One bind value for `db_execute`/`db_query`'s trailing `?`-placeholder
+/// arguments — `codegen.rs`'s `emit_db_binds` builds an array of these
+/// (one per trailing arg, tag chosen by that arg's own static type),
+/// passed as a plain `(ptr, i64 len)` pair like any other buffer here.
+/// `#[repr(C)]`, field order/types matched exactly by the anonymous LLVM
+/// struct type `codegen.rs` GEPs into (`{ i32, i64, double, ptr, i64 }`)
+/// — non-packed, so ordinary C/LLVM natural-alignment layout applies on
+/// both sides, the same "trust the target's own layout rules, don't
+/// hand-replicate them" stance `agg_byte_size_operand`'s sizeof trick
+/// already takes.
+#[repr(C)]
+pub struct NirBindValue {
+    pub tag: i32, // 0 = i64, 1 = f64, 2 = str, 3 = bool
+    pub i: i64,
+    pub f: f64,
+    pub s_ptr: *const u8,
+    pub s_len: i64,
+}
+
+unsafe fn bind_values_from_raw(ptr: *const NirBindValue, len: i64) -> Vec<rusqlite::types::Value> {
+    if len == 0 {
+        return Vec::new();
+    }
+    let raw = unsafe { std::slice::from_raw_parts(ptr, len as usize) };
+    raw.iter()
+        .map(|b| match b.tag {
+            0 => rusqlite::types::Value::Integer(b.i),
+            1 => rusqlite::types::Value::Real(b.f),
+            2 => {
+                let s = unsafe { str_from_raw(b.s_ptr, b.s_len) }.unwrap_or("").to_string();
+                rusqlite::types::Value::Text(s)
+            }
+            // SQLite has no native boolean column type — bound as 0/1,
+            // same convention every `i32`-as-bool return in this file
+            // already uses on the way back out.
+            3 => rusqlite::types::Value::Integer(b.i),
+            _ => rusqlite::types::Value::Null,
+        })
+        .collect()
+}
+
+fn sqlite_row_to_json(row: &rusqlite::Row, column_names: &[String]) -> serde_json::Value {
+    let mut obj = serde_json::Map::with_capacity(column_names.len());
+    for (i, name) in column_names.iter().enumerate() {
+        let value: rusqlite::types::Value = row.get(i).unwrap_or(rusqlite::types::Value::Null);
+        let json_val = match value {
+            rusqlite::types::Value::Null => serde_json::Value::Null,
+            rusqlite::types::Value::Integer(n) => serde_json::Value::from(n),
+            rusqlite::types::Value::Real(f) => serde_json::Number::from_f64(f).map(serde_json::Value::Number).unwrap_or(serde_json::Value::Null),
+            rusqlite::types::Value::Text(s) => serde_json::Value::String(s),
+            // `BLOB` has no first-class Nirdosha type to carry it (no
+            // `bytes` type — the same gap `Ty::File`'s own doc comment
+            // already names for file I/O) — a disclosed, narrower cut,
+            // not a silent drop: every other SQLite type round-trips
+            // exactly.
+            rusqlite::types::Value::Blob(_) => serde_json::Value::Null,
+        };
+        obj.insert(name.clone(), json_val);
+    }
+    serde_json::Value::Object(obj)
+}
+
+/// `db_connect(path) -> Result(db, str)`. `path` is really "connection
+/// string" per `Ty::Db`'s own doc comment, but this kernel only ever
+/// opens SQLite — a bare path or `":memory:"`, both handled by
+/// `rusqlite::Connection::open` itself, no special-casing needed here.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_db_connect(path_ptr: *const u8, path_len: i64, out_handle: *mut i64, out_err: *mut NirStrOut) -> i32 {
+    let Some(path) = (unsafe { str_from_raw(path_ptr, path_len) }) else {
+        unsafe { write_str_out(out_err, "connection string is not valid UTF-8".to_string()) };
+        return 0;
+    };
+    if !kernel::acquire(kernel::Domain::Db) {
+        unsafe { write_str_out(out_err, "too many open db connections".to_string()) };
+        return 0;
+    }
+    match rusqlite::Connection::open(path) {
+        Ok(conn) => {
+            let id = db_table().insert(conn);
+            unsafe { *out_handle = id };
+            1
+        }
+        Err(e) => {
+            kernel::release(kernel::Domain::Db);
+            unsafe { write_str_out(out_err, e.to_string()) };
+            0
+        }
+    }
+}
+
+/// Closes `handle` — `ownership.rs`'s affine typing already proves this
+/// runs at most once per handle in a well-typed program, same "the
+/// checker is the real gate" convention `nir_tcp_stop`/`nir_file_stop`
+/// already document.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_db_stop(handle: i64) -> i32 {
+    if db_table().remove(handle).is_some() {
+        kernel::release(kernel::Domain::Db);
+    }
+    0
+}
+
+/// `db_execute(conn, sql, ...binds) -> Result(i64, str)` — everything
+/// except `SELECT` (`INSERT`/`UPDATE`/`DELETE`/DDL); returns the
+/// affected-row count.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_db_execute(
+    handle: i64,
+    sql_ptr: *const u8,
+    sql_len: i64,
+    binds_ptr: *const NirBindValue,
+    binds_len: i64,
+    out_affected: *mut i64,
+    out_err: *mut NirStrOut,
+) -> i32 {
+    let Some(sql) = (unsafe { str_from_raw(sql_ptr, sql_len) }) else {
+        unsafe { write_str_out(out_err, "sql is not valid UTF-8".to_string()) };
+        return 0;
+    };
+    let binds = unsafe { bind_values_from_raw(binds_ptr, binds_len) };
+    let result = db_table().with(handle, |conn| conn.execute(sql, rusqlite::params_from_iter(binds.iter())));
+    match result {
+        Some(Ok(n)) => {
+            unsafe { *out_affected = n as i64 };
+            1
+        }
+        Some(Err(e)) => {
+            unsafe { write_str_out(out_err, e.to_string()) };
+            0
+        }
+        None => {
+            unsafe { write_str_out(out_err, "db handle is not open".to_string()) };
+            0
+        }
+    }
+}
+
+/// `db_query(conn, sql, ...binds) -> Result(json, str)` — `SELECT`
+/// statements. Every row comes back as one JSON object (column name ->
+/// value); the whole result set is a JSON array (`Ty::Json`'s own doc
+/// comment). This compiled path represents `Ty::Json` as the raw text
+/// itself (see `codegen.rs`'s `Ty::Json` `llvm_ty` arm), re-parsed by
+/// each `json_get_*` accessor below rather than a persisted parsed-tree
+/// handle — the simplest thing that reuses `str`'s existing
+/// `{ptr, i64}` representation with zero new runtime value type,
+/// matching this crate's own established "ship the real, narrower
+/// slice, disclose the gap" pattern (`nir_check_role`'s own doc comment
+/// is the precedent for this exact discipline).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_db_query(
+    handle: i64,
+    sql_ptr: *const u8,
+    sql_len: i64,
+    binds_ptr: *const NirBindValue,
+    binds_len: i64,
+    out_json: *mut NirStrOut,
+    out_err: *mut NirStrOut,
+) -> i32 {
+    let Some(sql) = (unsafe { str_from_raw(sql_ptr, sql_len) }) else {
+        unsafe { write_str_out(out_err, "sql is not valid UTF-8".to_string()) };
+        return 0;
+    };
+    let binds = unsafe { bind_values_from_raw(binds_ptr, binds_len) };
+    let result: Option<Result<String, rusqlite::Error>> = db_table().with(handle, |conn| {
+        let mut stmt = conn.prepare(sql)?;
+        let column_names: Vec<String> = stmt.column_names().iter().map(|s| s.to_string()).collect();
+        let mut rows = stmt.query(rusqlite::params_from_iter(binds.iter()))?;
+        let mut out_rows = Vec::new();
+        while let Some(row) = rows.next()? {
+            out_rows.push(sqlite_row_to_json(row, &column_names));
+        }
+        Ok(serde_json::to_string(&serde_json::Value::Array(out_rows)).unwrap_or_else(|_| "[]".to_string()))
+    });
+    match result {
+        Some(Ok(json)) => {
+            unsafe { write_str_out(out_json, json) };
+            1
+        }
+        Some(Err(e)) => {
+            unsafe { write_str_out(out_err, e.to_string()) };
+            0
+        }
+        None => {
+            unsafe { write_str_out(out_err, "db handle is not open".to_string()) };
+            0
+        }
+    }
+}
+
+#[cfg(test)]
+mod db_kernel_tests {
+    use super::*;
+
+    unsafe fn connect(path: &str) -> Result<i64, String> {
+        let mut handle = 0i64;
+        let mut err = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let ok = unsafe { nir_db_connect(path.as_ptr(), path.len() as i64, &mut handle, &mut err) };
+        if ok != 0 {
+            Ok(handle)
+        } else {
+            Err(unsafe { std::str::from_utf8(std::slice::from_raw_parts(err.ptr, err.len as usize)).unwrap().to_string() })
+        }
+    }
+
+    unsafe fn execute(handle: i64, sql: &str, binds: &[NirBindValue]) -> Result<i64, String> {
+        let mut affected = 0i64;
+        let mut err = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let ok = unsafe { nir_db_execute(handle, sql.as_ptr(), sql.len() as i64, binds.as_ptr(), binds.len() as i64, &mut affected, &mut err) };
+        if ok != 0 {
+            Ok(affected)
+        } else {
+            Err(unsafe { std::str::from_utf8(std::slice::from_raw_parts(err.ptr, err.len as usize)).unwrap().to_string() })
+        }
+    }
+
+    unsafe fn query(handle: i64, sql: &str, binds: &[NirBindValue]) -> Result<String, String> {
+        let mut out = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let mut err = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let ok = unsafe { nir_db_query(handle, sql.as_ptr(), sql.len() as i64, binds.as_ptr(), binds.len() as i64, &mut out, &mut err) };
+        if ok != 0 {
+            Ok(unsafe { std::str::from_utf8(std::slice::from_raw_parts(out.ptr, out.len as usize)).unwrap().to_string() })
+        } else {
+            Err(unsafe { std::str::from_utf8(std::slice::from_raw_parts(err.ptr, err.len as usize)).unwrap().to_string() })
+        }
+    }
+
+    fn str_bind(s: &'static str) -> NirBindValue {
+        NirBindValue { tag: 2, i: 0, f: 0.0, s_ptr: s.as_ptr(), s_len: s.len() as i64 }
+    }
+    fn i64_bind(n: i64) -> NirBindValue {
+        NirBindValue { tag: 0, i: n, f: 0.0, s_ptr: std::ptr::null(), s_len: 0 }
+    }
+
+    #[test]
+    fn connect_execute_query_round_trips_real_rows_in_memory() {
+        unsafe {
+            let conn = connect(":memory:").expect("in-memory sqlite should always open");
+            execute(conn, "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, rating INTEGER)", &[]).expect("DDL should succeed");
+            let inserted = execute(conn, "INSERT INTO users (name, rating) VALUES (?, ?)", &[str_bind("ada"), i64_bind(5)]).expect("insert should succeed");
+            assert_eq!(inserted, 1);
+            execute(conn, "INSERT INTO users (name, rating) VALUES (?, ?)", &[str_bind("grace"), i64_bind(4)]).expect("insert should succeed");
+
+            let rows_json = query(conn, "SELECT name, rating FROM users WHERE rating >= ? ORDER BY id", &[i64_bind(5)]).expect("query should succeed");
+            let rows: serde_json::Value = serde_json::from_str(&rows_json).unwrap();
+            assert_eq!(rows[0]["name"], "ada");
+            assert_eq!(rows[0]["rating"], 5);
+            assert_eq!(rows.as_array().unwrap().len(), 1);
+
+            let updated = execute(conn, "UPDATE users SET rating = ? WHERE name = ?", &[i64_bind(5), str_bind("grace")]).expect("update should succeed");
+            assert_eq!(updated, 1);
+
+            assert_eq!(nir_db_stop(conn), 0);
+        }
+    }
+
+    #[test]
+    fn connect_to_an_invalid_path_is_a_real_err_not_a_panic() {
+        unsafe {
+            assert!(connect("/no/such/directory/at/all/db.sqlite").is_err());
+        }
+    }
+
+    #[test]
+    fn bad_sql_is_a_real_err_not_a_panic() {
+        unsafe {
+            let conn = connect(":memory:").unwrap();
+            assert!(execute(conn, "NOT VALID SQL AT ALL", &[]).is_err());
+            nir_db_stop(conn);
+        }
+    }
+}
+
+// ---- json kernels (`Ty::Json` as raw text, re-parsed per accessor) ------
+//
+// See `nir_db_query`'s own doc comment for the representation choice.
+// Every accessor is fallible (`Result(_, str)`, `Ty::Json`'s own doc
+// comment) — a malformed document, a missing key, or a type mismatch is
+// a real `Err`, never a trap.
+
+unsafe fn parse_json(ptr: *const u8, len: i64) -> Result<serde_json::Value, String> {
+    let s = unsafe { str_from_raw(ptr, len) }.ok_or_else(|| "json text is not valid UTF-8".to_string())?;
+    serde_json::from_str(s).map_err(|e| format!("malformed JSON: {e}"))
+}
+
+/// `json_parse(s) -> Result(json, str)` — validates `s` parses as JSON;
+/// `codegen.rs`'s `emit_json_parse` reuses `s`'s own already-computed
+/// `{ptr, i64}` value as the `Ok` payload directly (this representation
+/// makes `json_parse` an identity function on success), so this kernel
+/// only needs to report validity, not produce a value.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_json_validate(json_ptr: *const u8, json_len: i64, out_err: *mut NirStrOut) -> i32 {
+    match unsafe { parse_json(json_ptr, json_len) } {
+        Ok(_) => 1,
+        Err(e) => {
+            unsafe { write_str_out(out_err, e) };
+            0
+        }
+    }
+}
+
+/// `json_get(doc, key) -> Result(json, str)` — the sub-value at `key`,
+/// re-serialized (this representation's `Ty::Json` is text, not a
+/// persisted tree, so navigating one level means re-emitting the
+/// sub-tree as its own JSON text).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_json_get(doc_ptr: *const u8, doc_len: i64, key_ptr: *const u8, key_len: i64, out_json: *mut NirStrOut, out_err: *mut NirStrOut) -> i32 {
+    let parsed = match unsafe { parse_json(doc_ptr, doc_len) } {
+        Ok(v) => v,
+        Err(e) => {
+            unsafe { write_str_out(out_err, e) };
+            return 0;
+        }
+    };
+    let Some(key) = (unsafe { str_from_raw(key_ptr, key_len) }) else {
+        unsafe { write_str_out(out_err, "key is not valid UTF-8".to_string()) };
+        return 0;
+    };
+    match parsed.get(key) {
+        Some(v) => {
+            unsafe { write_str_out(out_json, serde_json::to_string(v).unwrap_or_else(|_| "null".to_string())) };
+            1
+        }
+        None => {
+            unsafe { write_str_out(out_err, format!("key `{key}` not found")) };
+            0
+        }
+    }
+}
+
+/// `json_array_get(doc, idx) -> Result(json, str)` — same shape as
+/// `json_get`, indexed by position instead of key.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_json_array_get(doc_ptr: *const u8, doc_len: i64, idx: i64, out_json: *mut NirStrOut, out_err: *mut NirStrOut) -> i32 {
+    let parsed = match unsafe { parse_json(doc_ptr, doc_len) } {
+        Ok(v) => v,
+        Err(e) => {
+            unsafe { write_str_out(out_err, e) };
+            return 0;
+        }
+    };
+    let found = if idx < 0 { None } else { parsed.as_array().and_then(|a| a.get(idx as usize)) };
+    match found {
+        Some(v) => {
+            unsafe { write_str_out(out_json, serde_json::to_string(v).unwrap_or_else(|_| "null".to_string())) };
+            1
+        }
+        None => {
+            unsafe { write_str_out(out_err, format!("index {idx} out of range, or not an array")) };
+            0
+        }
+    }
+}
+
+/// `json_array_len(doc) -> Result(i64, str)`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_json_array_len(doc_ptr: *const u8, doc_len: i64, out_len: *mut i64, out_err: *mut NirStrOut) -> i32 {
+    let parsed = match unsafe { parse_json(doc_ptr, doc_len) } {
+        Ok(v) => v,
+        Err(e) => {
+            unsafe { write_str_out(out_err, e) };
+            return 0;
+        }
+    };
+    match parsed.as_array() {
+        Some(a) => {
+            unsafe { *out_len = a.len() as i64 };
+            1
+        }
+        None => {
+            unsafe { write_str_out(out_err, "not a JSON array".to_string()) };
+            0
+        }
+    }
+}
+
+/// `json_get_str(doc, key) -> Result(str, str)` — a leaf accessor: the
+/// value at `key` must itself be a JSON string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_json_get_str(doc_ptr: *const u8, doc_len: i64, key_ptr: *const u8, key_len: i64, out_value: *mut NirStrOut, out_err: *mut NirStrOut) -> i32 {
+    let parsed = match unsafe { parse_json(doc_ptr, doc_len) } {
+        Ok(v) => v,
+        Err(e) => {
+            unsafe { write_str_out(out_err, e) };
+            return 0;
+        }
+    };
+    let Some(key) = (unsafe { str_from_raw(key_ptr, key_len) }) else {
+        unsafe { write_str_out(out_err, "key is not valid UTF-8".to_string()) };
+        return 0;
+    };
+    match parsed.get(key).and_then(|v| v.as_str()) {
+        Some(s) => {
+            unsafe { write_str_out(out_value, s.to_string()) };
+            1
+        }
+        None => {
+            unsafe { write_str_out(out_err, format!("key `{key}` not found, or not a string")) };
+            0
+        }
+    }
+}
+
+/// `json_get_i64(doc, key) -> Result(i64, str)`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_json_get_i64(doc_ptr: *const u8, doc_len: i64, key_ptr: *const u8, key_len: i64, out_value: *mut i64, out_err: *mut NirStrOut) -> i32 {
+    let parsed = match unsafe { parse_json(doc_ptr, doc_len) } {
+        Ok(v) => v,
+        Err(e) => {
+            unsafe { write_str_out(out_err, e) };
+            return 0;
+        }
+    };
+    let Some(key) = (unsafe { str_from_raw(key_ptr, key_len) }) else {
+        unsafe { write_str_out(out_err, "key is not valid UTF-8".to_string()) };
+        return 0;
+    };
+    match parsed.get(key).and_then(|v| v.as_i64()) {
+        Some(n) => {
+            unsafe { *out_value = n };
+            1
+        }
+        None => {
+            unsafe { write_str_out(out_err, format!("key `{key}` not found, or not an integer")) };
+            0
+        }
+    }
+}
+
+/// `json_get_f64(doc, key) -> Result(f64, str)`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_json_get_f64(doc_ptr: *const u8, doc_len: i64, key_ptr: *const u8, key_len: i64, out_value: *mut f64, out_err: *mut NirStrOut) -> i32 {
+    let parsed = match unsafe { parse_json(doc_ptr, doc_len) } {
+        Ok(v) => v,
+        Err(e) => {
+            unsafe { write_str_out(out_err, e) };
+            return 0;
+        }
+    };
+    let Some(key) = (unsafe { str_from_raw(key_ptr, key_len) }) else {
+        unsafe { write_str_out(out_err, "key is not valid UTF-8".to_string()) };
+        return 0;
+    };
+    match parsed.get(key).and_then(|v| v.as_f64()) {
+        Some(f) => {
+            unsafe { *out_value = f };
+            1
+        }
+        None => {
+            unsafe { write_str_out(out_err, format!("key `{key}` not found, or not a number")) };
+            0
+        }
+    }
+}
+
+/// `json_get_bool(doc, key) -> Result(bool, str)`. `out_value` is `i32`
+/// (`0`/`1`), the same boolean-as-int convention every other kernel here
+/// already uses.
+///
+/// Accepts a real JSON boolean (`true`/`false`) *or* the JSON integers
+/// `0`/`1` — not just the former. SQLite has no native boolean storage
+/// class (`NirBindValue`'s own doc comment: a bound `bool` is stored as
+/// SQLite `INTEGER` `0`/`1`), so `nir_db_query`'s `sqlite_row_to_json`
+/// re-serializes that column back as a plain JSON *number*, never a JSON
+/// boolean — there is no schema-level "this integer column is really a
+/// bool" signal available to make it re-serialize any other way. Without
+/// this fallback, `json_get_bool` would never succeed on any `db`-sourced
+/// boolean column, which would make the two builtins genuinely unusable
+/// together — found by testing a real `db_execute`/`db_query` round trip
+/// of a bound `bool`, not by reasoning about the representations in
+/// advance. Any other JSON number (not `0`/`1`) is still a real `Err`,
+/// not silently coerced.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_json_get_bool(doc_ptr: *const u8, doc_len: i64, key_ptr: *const u8, key_len: i64, out_value: *mut i32, out_err: *mut NirStrOut) -> i32 {
+    let parsed = match unsafe { parse_json(doc_ptr, doc_len) } {
+        Ok(v) => v,
+        Err(e) => {
+            unsafe { write_str_out(out_err, e) };
+            return 0;
+        }
+    };
+    let Some(key) = (unsafe { str_from_raw(key_ptr, key_len) }) else {
+        unsafe { write_str_out(out_err, "key is not valid UTF-8".to_string()) };
+        return 0;
+    };
+    let found = parsed.get(key).and_then(|v| match v {
+        serde_json::Value::Bool(b) => Some(*b),
+        serde_json::Value::Number(n) if n.as_i64() == Some(0) => Some(false),
+        serde_json::Value::Number(n) if n.as_i64() == Some(1) => Some(true),
+        _ => None,
+    });
+    match found {
+        Some(b) => {
+            unsafe { *out_value = b as i32 };
+            1
+        }
+        None => {
+            unsafe { write_str_out(out_err, format!("key `{key}` not found, or not a boolean (or 0/1 integer)")) };
+            0
+        }
+    }
+}
+
+/// `json_set_str(doc, key, value) -> Result(json, str)` — `json_get_str`'s
+/// inverse: sets `key` to a string value on a JSON object, or starts a
+/// fresh object if `doc` is JSON `null` (the shape `json_parse("{}")`/
+/// `json_parse("null")` both already produce). Any other JSON shape (an
+/// array, a scalar) is a real `Err`, not a type error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_json_set_str(
+    doc_ptr: *const u8,
+    doc_len: i64,
+    key_ptr: *const u8,
+    key_len: i64,
+    value_ptr: *const u8,
+    value_len: i64,
+    out_json: *mut NirStrOut,
+    out_err: *mut NirStrOut,
+) -> i32 {
+    let mut parsed = match unsafe { parse_json(doc_ptr, doc_len) } {
+        Ok(v) => v,
+        Err(e) => {
+            unsafe { write_str_out(out_err, e) };
+            return 0;
+        }
+    };
+    let (Some(key), Some(value)) = (unsafe { str_from_raw(key_ptr, key_len) }, unsafe { str_from_raw(value_ptr, value_len) }) else {
+        unsafe { write_str_out(out_err, "key/value is not valid UTF-8".to_string()) };
+        return 0;
+    };
+    if parsed.is_null() {
+        parsed = serde_json::Value::Object(serde_json::Map::new());
+    }
+    match parsed.as_object_mut() {
+        Some(map) => {
+            map.insert(key.to_string(), serde_json::Value::String(value.to_string()));
+            unsafe { write_str_out(out_json, serde_json::to_string(&parsed).unwrap_or_else(|_| "null".to_string())) };
+            1
+        }
+        None => {
+            unsafe { write_str_out(out_err, "not a JSON object (and not null)".to_string()) };
+            0
+        }
+    }
+}
+
+#[cfg(test)]
+mod json_kernel_tests {
+    use super::*;
+
+    fn to_str(out: &NirStrOut) -> String {
+        unsafe { std::str::from_utf8(std::slice::from_raw_parts(out.ptr, out.len as usize)).unwrap().to_string() }
+    }
+
+    #[test]
+    fn get_str_reads_a_string_field() {
+        let doc = r#"{"name":"ada","rating":5}"#;
+        let key = "name";
+        let mut out = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let mut err = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let ok = unsafe { nir_json_get_str(doc.as_ptr(), doc.len() as i64, key.as_ptr(), key.len() as i64, &mut out, &mut err) };
+        assert_eq!(ok, 1);
+        assert_eq!(to_str(&out), "ada");
+    }
+
+    #[test]
+    fn array_get_then_get_str_navigates_a_row() {
+        let doc = r#"[{"name":"ada","rating":5}]"#;
+        let mut row = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let mut err = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let ok = unsafe { nir_json_array_get(doc.as_ptr(), doc.len() as i64, 0, &mut row, &mut err) };
+        assert_eq!(ok, 1);
+        let row_text = to_str(&row);
+        let key = "name";
+        let mut name = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let ok2 = unsafe { nir_json_get_str(row_text.as_ptr(), row_text.len() as i64, key.as_ptr(), key.len() as i64, &mut name, &mut err) };
+        assert_eq!(ok2, 1);
+        assert_eq!(to_str(&name), "ada");
+    }
+
+    #[test]
+    fn missing_key_is_a_real_err_not_a_panic() {
+        let doc = "{}";
+        let key = "missing";
+        let mut out = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let mut err = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let ok = unsafe { nir_json_get_str(doc.as_ptr(), doc.len() as i64, key.as_ptr(), key.len() as i64, &mut out, &mut err) };
+        assert_eq!(ok, 0);
+    }
+
+    #[test]
+    fn malformed_json_is_a_real_err_not_a_panic() {
+        let doc = "not json";
+        let mut err = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        assert_eq!(unsafe { nir_json_validate(doc.as_ptr(), doc.len() as i64, &mut err) }, 0);
+    }
+
+    #[test]
+    fn set_str_on_null_starts_a_fresh_object() {
+        let doc = "null";
+        let key = "department";
+        let value = "cardiology";
+        let mut out = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let mut err = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let ok = unsafe { nir_json_set_str(doc.as_ptr(), doc.len() as i64, key.as_ptr(), key.len() as i64, value.as_ptr(), value.len() as i64, &mut out, &mut err) };
+        assert_eq!(ok, 1);
+        let parsed: serde_json::Value = serde_json::from_str(&to_str(&out)).unwrap();
+        assert_eq!(parsed["department"], "cardiology");
+    }
+
+    fn get_bool(doc: &str, key: &str) -> Option<i32> {
+        let mut out = 0i32;
+        let mut err = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let ok = unsafe { nir_json_get_bool(doc.as_ptr(), doc.len() as i64, key.as_ptr(), key.len() as i64, &mut out, &mut err) };
+        if ok != 0 { Some(out) } else { None }
+    }
+
+    #[test]
+    fn get_bool_accepts_a_real_json_boolean() {
+        assert_eq!(get_bool(r#"{"active":true}"#, "active"), Some(1));
+        assert_eq!(get_bool(r#"{"active":false}"#, "active"), Some(0));
+    }
+
+    #[test]
+    fn get_bool_also_accepts_sqlite_shaped_0_and_1_integers() {
+        // `db_query`'s own re-serialization of a bound `bool` column --
+        // SQLite has no native boolean storage class, so it comes back
+        // as a plain JSON number, not a JSON boolean.
+        assert_eq!(get_bool(r#"{"active":1}"#, "active"), Some(1));
+        assert_eq!(get_bool(r#"{"active":0}"#, "active"), Some(0));
+    }
+
+    #[test]
+    fn get_bool_rejects_any_other_integer() {
+        assert_eq!(get_bool(r#"{"active":2}"#, "active"), None);
+    }
+}
+
+// ---- transact kernels (`docs/TRANSACT.md`) --------------------------------
+//
+// Layer 1 (in-process control flow) plus retry/backoff, reinterpreted for
+// the compiled backend's own trap model: the now-deleted interpreter could
+// catch its own internal `RuntimeError` inside `transact`'s retry loop
+// before it ever unwound out of the interpreter; a compiled trap calls
+// `abort()` directly (`codegen.rs`'s `guard_io_ok` and every other guard),
+// an unrecoverable process exit, not a catchable error. So retry here
+// reacts only to a slot's own declared `Result(_, _)` return coming back
+// `Err` — the same rule `docs/TRANSACT.md`'s own §1b already uses for
+// `commit`/`compensate` (a trap *there* was always going to retry the same
+// way a trap anywhere else in this language traps: it doesn't, it aborts).
+// Durability logging and crash replay (`transact_log.rs`, deleted with the
+// interpreter) are a real, separate, disclosed follow-up, not attempted
+// here — `codegen::emit_transact`'s own doc comment names the gap.
+
+/// `txn_id`'s real, compiled implementation — an always-unique (not
+/// cryptographically unpredictable, but not guessable in any way that
+/// matters for its actual job: deduping a replayed resend) idempotency
+/// key: process id + a coarse monotonic timestamp + a process-wide atomic
+/// sequence number, hex-formatted. No crash-replay mechanism exists yet to
+/// actually need this to survive a restart (this update's own disclosed
+/// gap) — it only has to be unique *within* one process's lifetime today,
+/// same as the now-deleted interpreter's own scope note for a local
+/// SQLite-file-backed log.
+static TXN_ID_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_transact_gen_txn_id(out: *mut NirStrOut) {
+    use std::sync::atomic::Ordering;
+    let seq = TXN_ID_SEQ.fetch_add(1, Ordering::Relaxed);
+    let nanos = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).map(|d| d.as_nanos()).unwrap_or(0);
+    let pid = std::process::id();
+    let id = format!("txn-{pid:x}-{nanos:x}-{seq:x}");
+    unsafe { write_str_out(out, id) };
+}
+
+/// `sleep_ms(ms)` — a real wall-clock sleep (`docs/ROADMAP.md`'s own B9,
+/// "small, currently omitted... found this session"). `transact`'s own
+/// `commit`/`compensate` bounded-backoff retry loop
+/// (`codegen::emit_transact`) is what actually needed this to exist;
+/// `ms <= 0` is a no-op, not a panic (mirrors `std::thread::sleep`'s own
+/// "a zero duration returns immediately" behavior for negative input too,
+/// which `Duration::from_millis` can't represent directly).
+#[unsafe(no_mangle)]
+pub extern "C" fn nir_sleep_ms(ms: i64) {
+    if ms > 0 {
+        std::thread::sleep(std::time::Duration::from_millis(ms as u64));
+    }
+}
+
+#[cfg(test)]
+mod transact_kernel_tests {
+    use super::*;
+
+    #[test]
+    fn gen_txn_id_produces_distinct_ids() {
+        let mut a = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let mut b = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        unsafe {
+            nir_transact_gen_txn_id(&mut a);
+            nir_transact_gen_txn_id(&mut b);
+        }
+        let a_str = unsafe { std::str::from_utf8(std::slice::from_raw_parts(a.ptr, a.len as usize)).unwrap() };
+        let b_str = unsafe { std::str::from_utf8(std::slice::from_raw_parts(b.ptr, b.len as usize)).unwrap() };
+        assert_ne!(a_str, b_str);
+        assert!(a_str.starts_with("txn-"));
+    }
+
+    #[test]
+    fn sleep_ms_zero_or_negative_returns_immediately() {
+        let start = std::time::Instant::now();
+        nir_sleep_ms(0);
+        nir_sleep_ms(-5);
+        assert!(start.elapsed() < std::time::Duration::from_millis(50));
+    }
+}
+
+// ---- mq kernels (`mq_connect`/`mq_publish`/`mq_consume`, Redis) ---------
+//
+// `Ty::Mq`'s own doc comment has the full design: layer 1 targets Redis
+// specifically, `LPUSH`/`BLPOP` backing `mq_publish`/`mq_consume` (same
+// choice the now-deleted interpreter made). Same `HandleTable` shape
+// `db_table()` already uses — a `redis::Connection` isn't reconstructible
+// from a bare integer either.
+
+fn mq_table() -> &'static HandleTable<redis::Connection> {
+    static TABLE: OnceLock<HandleTable<redis::Connection>> = OnceLock::new();
+    TABLE.get_or_init(HandleTable::new)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_mq_connect(host_ptr: *const u8, host_len: i64, port: i64, out_handle: *mut i64, out_err: *mut NirStrOut) -> i32 {
+    let Some(host) = (unsafe { str_from_raw(host_ptr, host_len) }) else {
+        unsafe { write_str_out(out_err, "host is not valid UTF-8".to_string()) };
+        return 0;
+    };
+    if !kernel::acquire(kernel::Domain::Mq) {
+        unsafe { write_str_out(out_err, "too many open mq connections".to_string()) };
+        return 0;
+    }
+    let url = format!("redis://{host}:{port}");
+    let opened = redis::Client::open(url).and_then(|client| client.get_connection());
+    match opened {
+        Ok(conn) => {
+            let id = mq_table().insert(conn);
+            unsafe { *out_handle = id };
+            1
+        }
+        Err(e) => {
+            kernel::release(kernel::Domain::Mq);
+            unsafe { write_str_out(out_err, e.to_string()) };
+            0
+        }
+    }
+}
+
+/// Closes `handle` — same "the checker is the real gate" convention
+/// `nir_db_stop`/`nir_tcp_stop` already document.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_mq_stop(handle: i64) -> i32 {
+    if mq_table().remove(handle).is_some() {
+        kernel::release(kernel::Domain::Mq);
+    }
+    0
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_mq_publish(handle: i64, queue_ptr: *const u8, queue_len: i64, msg_ptr: *const u8, msg_len: i64, out_err: *mut NirStrOut) -> i32 {
+    let (Some(queue), Some(msg)) = (unsafe { str_from_raw(queue_ptr, queue_len) }, unsafe { str_from_raw(msg_ptr, msg_len) }) else {
+        unsafe { write_str_out(out_err, "queue/message is not valid UTF-8".to_string()) };
+        return 0;
+    };
+    let result = mq_table().with(handle, |conn| redis::cmd("LPUSH").arg(queue).arg(msg).query::<i64>(conn));
+    match result {
+        Some(Ok(_)) => 1,
+        Some(Err(e)) => {
+            unsafe { write_str_out(out_err, e.to_string()) };
+            0
+        }
+        None => {
+            unsafe { write_str_out(out_err, "mq handle is not open".to_string()) };
+            0
+        }
+    }
+}
+
+/// `mq_consume(conn, queue, timeout_secs) -> Result(str, str)` — `BLPOP`,
+/// blocking up to `timeout_secs` (`0` blocks forever, Redis's own
+/// convention, unchanged here). A timeout with nothing published is a
+/// real `Err`, not a trap — indistinguishable at this layer from any
+/// other Redis error, both just a message string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_mq_consume(handle: i64, queue_ptr: *const u8, queue_len: i64, timeout_secs: i64, out_msg: *mut NirStrOut, out_err: *mut NirStrOut) -> i32 {
+    let Some(queue) = (unsafe { str_from_raw(queue_ptr, queue_len) }) else {
+        unsafe { write_str_out(out_err, "queue is not valid UTF-8".to_string()) };
+        return 0;
+    };
+    let result = mq_table().with(handle, |conn| redis::cmd("BLPOP").arg(queue).arg(timeout_secs).query::<Option<(String, String)>>(conn));
+    match result {
+        Some(Ok(Some((_key, value)))) => {
+            unsafe { write_str_out(out_msg, value) };
+            1
+        }
+        Some(Ok(None)) => {
+            unsafe { write_str_out(out_err, "timed out waiting for a message".to_string()) };
+            0
+        }
+        Some(Err(e)) => {
+            unsafe { write_str_out(out_err, e.to_string()) };
+            0
+        }
+        None => {
+            unsafe { write_str_out(out_err, "mq handle is not open".to_string()) };
+            0
+        }
+    }
+}
+
+#[cfg(test)]
+mod mq_kernel_tests {
+    use super::*;
+
+    // Real Redis, not a mock -- `examples/features/28_message_queue.nir`'s
+    // own header comment already documents this file's tests degrade
+    // gracefully when Redis isn't reachable; these do the same, skipping
+    // (not failing) rather than asserting against an environment this
+    // crate doesn't control the availability of.
+    fn connect() -> Option<i64> {
+        let host = "127.0.0.1";
+        let mut handle = 0i64;
+        let mut err = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let ok = unsafe { nir_mq_connect(host.as_ptr(), host.len() as i64, 6379, &mut handle, &mut err) };
+        if ok != 0 { Some(handle) } else { None }
+    }
+
+    #[test]
+    fn publish_then_consume_round_trips_a_real_message() {
+        let Some(conn) = connect() else {
+            eprintln!("skipping: no Redis reachable at 127.0.0.1:6379");
+            return;
+        };
+        let queue = "nirdosha_test_queue_publish_then_consume";
+        let msg = "hello from mq_kernel_tests";
+        let mut err = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let published = unsafe { nir_mq_publish(conn, queue.as_ptr(), queue.len() as i64, msg.as_ptr(), msg.len() as i64, &mut err) };
+        assert_eq!(published, 1);
+
+        let mut out = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let consumed = unsafe { nir_mq_consume(conn, queue.as_ptr(), queue.len() as i64, 2, &mut out, &mut err) };
+        assert_eq!(consumed, 1);
+        let value = unsafe { std::str::from_utf8(std::slice::from_raw_parts(out.ptr, out.len as usize)).unwrap() };
+        assert_eq!(value, msg);
+
+        assert_eq!(unsafe { nir_mq_stop(conn) }, 0);
+    }
+
+    #[test]
+    fn consume_with_nothing_published_times_out_as_a_real_err() {
+        let Some(conn) = connect() else {
+            eprintln!("skipping: no Redis reachable at 127.0.0.1:6379");
+            return;
+        };
+        let queue = "nirdosha_test_queue_never_published_to";
+        let mut out = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let mut err = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let consumed = unsafe { nir_mq_consume(conn, queue.as_ptr(), queue.len() as i64, 1, &mut out, &mut err) };
+        assert_eq!(consumed, 0);
+        unsafe { nir_mq_stop(conn) };
+    }
+
+    #[test]
+    fn connect_to_an_unreachable_host_is_a_real_err_not_a_panic() {
+        let host = "127.0.0.1";
+        let mut handle = 0i64;
+        let mut err = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        // Port 1 is never a real Redis server.
+        let ok = unsafe { nir_mq_connect(host.as_ptr(), host.len() as i64, 1, &mut handle, &mut err) };
+        assert_eq!(ok, 0);
+    }
+}
+
+// ---- http/https kernels (`http_get`/`http_post`/`https_get`/`https_post`) --
+//
+// `ast::BUILTIN_NAMES`'s own doc comment has the full, already-locked
+// design (written before this backend existed, ported here unchanged):
+// plain HTTP over `std::net::TcpStream`, HTTPS over the identical
+// request/response handling wrapped in a `native_tls::TlsStream`.
+// **`Connection: close` + read-to-EOF, no `Content-Length`/chunked-
+// transfer-encoding parsing** — "no ... parsing needed for a first cut,
+// since the server closing the socket *is* the end-of-body signal" is
+// this design's own words, not a new cut made here. A network failure, a
+// malformed status line, or a non-UTF-8 body are all a real `Err`, never
+// a trap.
+
+struct HttpParsed {
+    status: i64,
+    body: String,
+}
+
+/// Decodes an HTTP/1.1 `Transfer-Encoding: chunked` body — each chunk is
+/// a hex size line, that many raw bytes, a trailing `\r\n`, repeated
+/// until a zero-size chunk terminates the sequence (any trailer headers
+/// after the terminating chunk are ignored, same "don't need them for a
+/// first cut" scope as the rest of this module). Found necessary by
+/// actually testing `https_get` against a real server (`example.com`
+/// chunks by default) — not designed in ahead of time, but not
+/// optional either once found: without this, a chunked response's body
+/// comes back with raw `<hex-size>\r\n...\r\n` framing still in it,
+/// which is a real, visibly wrong bug for a large fraction of real HTTP
+/// servers, not an acceptable "first cut" gap the way skipping
+/// `Content-Length`-driven partial reads is (this module's read-to-EOF
+/// strategy already makes `Content-Length` itself redundant).
+fn decode_chunked_body(body: &[u8]) -> Result<Vec<u8>, String> {
+    let mut out = Vec::with_capacity(body.len());
+    let mut pos = 0usize;
+    loop {
+        let line_end = body[pos..].windows(2).position(|w| w == b"\r\n").ok_or_else(|| "malformed chunked body: no chunk-size line".to_string())?;
+        let size_line = std::str::from_utf8(&body[pos..pos + line_end]).map_err(|_| "malformed chunked body: chunk-size line is not valid UTF-8".to_string())?;
+        // A chunk-size line may carry `;`-separated extensions -- ignored,
+        // only the leading hex digits matter.
+        let size_hex = size_line.split(';').next().unwrap_or("").trim();
+        let size = usize::from_str_radix(size_hex, 16).map_err(|_| format!("malformed chunked body: bad chunk size `{size_hex}`"))?;
+        pos += line_end + 2;
+        if size == 0 {
+            break; // terminating chunk -- any trailer headers after it are ignored
+        }
+        if pos + size > body.len() {
+            return Err("malformed chunked body: chunk size exceeds remaining data".to_string());
+        }
+        out.extend_from_slice(&body[pos..pos + size]);
+        pos += size;
+        if body.get(pos..pos + 2) != Some(b"\r\n") {
+            return Err("malformed chunked body: missing CRLF after chunk data".to_string());
+        }
+        pos += 2;
+    }
+    Ok(out)
+}
+
+fn parse_http_response(raw: &[u8]) -> Result<HttpParsed, String> {
+    let sep = raw.windows(4).position(|w| w == b"\r\n\r\n").ok_or_else(|| "malformed HTTP response: no header/body separator".to_string())?;
+    let head = &raw[..sep];
+    let body = &raw[sep + 4..];
+    let head_str = std::str::from_utf8(head).map_err(|_| "malformed HTTP response: headers are not valid UTF-8".to_string())?;
+    let status_line = head_str.lines().next().ok_or_else(|| "malformed HTTP response: empty status line".to_string())?;
+    let mut parts = status_line.splitn(3, ' ');
+    let _version = parts.next();
+    let status_str = parts.next().ok_or_else(|| "malformed HTTP response: no status code in status line".to_string())?;
+    let status: i64 = status_str.parse().map_err(|_| format!("malformed HTTP response: bad status code `{status_str}`"))?;
+    let is_chunked = head_str.lines().skip(1).any(|line| {
+        line.split_once(':').map(|(k, v)| k.trim().eq_ignore_ascii_case("transfer-encoding") && v.trim().eq_ignore_ascii_case("chunked")).unwrap_or(false)
+    });
+    let body_bytes = if is_chunked { decode_chunked_body(body)? } else { body.to_vec() };
+    let body_str = std::str::from_utf8(&body_bytes).map_err(|_| "HTTP response body is not valid UTF-8".to_string())?.to_string();
+    Ok(HttpParsed { status, body: body_str })
+}
+
+fn http_request_bytes(method: &str, host: &str, path: &str, body: Option<&str>, bearer_token: Option<&str>) -> Vec<u8> {
+    let mut req = format!("{method} {path} HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n");
+    if let Some(token) = bearer_token {
+        req.push_str(&format!("Authorization: Bearer {token}\r\n"));
+    }
+    match body {
+        Some(b) => req.push_str(&format!("Content-Type: application/json\r\nContent-Length: {}\r\n\r\n{b}", b.len())),
+        None => req.push_str("\r\n"),
+    }
+    req.into_bytes()
+}
+
+fn do_http(host: &str, port: i64, path: &str, method: &str, body: Option<&str>) -> Result<HttpParsed, String> {
+    do_http_with_auth(host, port, path, method, body, None)
+}
+
+/// `do_http`'s own generalization — `bearer_token`, when present, adds
+/// an `Authorization: Bearer <token>` header. `send_email`/`send_sms`/
+/// `send_push`'s own generic-provider POST (`send_via_provider`) is the
+/// one caller that needs this; `http_post`/`https_post` (client-facing
+/// builtins) never pass one, matching their own already-locked design
+/// (no auth header in that surface).
+fn do_http_with_auth(host: &str, port: i64, path: &str, method: &str, body: Option<&str>, bearer_token: Option<&str>) -> Result<HttpParsed, String> {
+    let mut stream = std::net::TcpStream::connect((host, port as u16)).map_err(|e| e.to_string())?;
+    stream.write_all(&http_request_bytes(method, host, path, body, bearer_token)).map_err(|e| e.to_string())?;
+    let mut raw = Vec::new();
+    stream.read_to_end(&mut raw).map_err(|e| e.to_string())?;
+    parse_http_response(&raw)
+}
+
+fn do_https(host: &str, port: i64, path: &str, method: &str, body: Option<&str>) -> Result<HttpParsed, String> {
+    let stream = std::net::TcpStream::connect((host, port as u16)).map_err(|e| e.to_string())?;
+    let connector = native_tls::TlsConnector::new().map_err(|e| e.to_string())?;
+    let mut stream = connector.connect(host, stream).map_err(|e| e.to_string())?;
+    stream.write_all(&http_request_bytes(method, host, path, body, None)).map_err(|e| e.to_string())?;
+    let mut raw = Vec::new();
+    stream.read_to_end(&mut raw).map_err(|e| e.to_string())?;
+    parse_http_response(&raw)
+}
+
+unsafe fn write_http_result(result: Result<HttpParsed, String>, out_status: *mut i64, out_body: *mut NirStrOut, out_err: *mut NirStrOut) -> i32 {
+    match result {
+        Ok(r) => {
+            unsafe {
+                *out_status = r.status;
+                write_str_out(out_body, r.body);
+            }
+            1
+        }
+        Err(e) => {
+            unsafe { write_str_out(out_err, e) };
+            0
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_http_get(
+    host_ptr: *const u8,
+    host_len: i64,
+    port: i64,
+    path_ptr: *const u8,
+    path_len: i64,
+    out_status: *mut i64,
+    out_body: *mut NirStrOut,
+    out_err: *mut NirStrOut,
+) -> i32 {
+    let (Some(host), Some(path)) = (unsafe { str_from_raw(host_ptr, host_len) }, unsafe { str_from_raw(path_ptr, path_len) }) else {
+        unsafe { write_str_out(out_err, "host/path is not valid UTF-8".to_string()) };
+        return 0;
+    };
+    let result = do_http(host, port, path, "GET", None);
+    unsafe { write_http_result(result, out_status, out_body, out_err) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_http_post(
+    host_ptr: *const u8,
+    host_len: i64,
+    port: i64,
+    path_ptr: *const u8,
+    path_len: i64,
+    body_ptr: *const u8,
+    body_len: i64,
+    out_status: *mut i64,
+    out_body: *mut NirStrOut,
+    out_err: *mut NirStrOut,
+) -> i32 {
+    let (Some(host), Some(path), Some(body)) =
+        (unsafe { str_from_raw(host_ptr, host_len) }, unsafe { str_from_raw(path_ptr, path_len) }, unsafe { str_from_raw(body_ptr, body_len) })
+    else {
+        unsafe { write_str_out(out_err, "host/path/body is not valid UTF-8".to_string()) };
+        return 0;
+    };
+    let result = do_http(host, port, path, "POST", Some(body));
+    unsafe { write_http_result(result, out_status, out_body, out_err) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_https_get(
+    host_ptr: *const u8,
+    host_len: i64,
+    port: i64,
+    path_ptr: *const u8,
+    path_len: i64,
+    out_status: *mut i64,
+    out_body: *mut NirStrOut,
+    out_err: *mut NirStrOut,
+) -> i32 {
+    let (Some(host), Some(path)) = (unsafe { str_from_raw(host_ptr, host_len) }, unsafe { str_from_raw(path_ptr, path_len) }) else {
+        unsafe { write_str_out(out_err, "host/path is not valid UTF-8".to_string()) };
+        return 0;
+    };
+    let result = do_https(host, port, path, "GET", None);
+    unsafe { write_http_result(result, out_status, out_body, out_err) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_https_post(
+    host_ptr: *const u8,
+    host_len: i64,
+    port: i64,
+    path_ptr: *const u8,
+    path_len: i64,
+    body_ptr: *const u8,
+    body_len: i64,
+    out_status: *mut i64,
+    out_body: *mut NirStrOut,
+    out_err: *mut NirStrOut,
+) -> i32 {
+    let (Some(host), Some(path), Some(body)) =
+        (unsafe { str_from_raw(host_ptr, host_len) }, unsafe { str_from_raw(path_ptr, path_len) }, unsafe { str_from_raw(body_ptr, body_len) })
+    else {
+        unsafe { write_str_out(out_err, "host/path/body is not valid UTF-8".to_string()) };
+        return 0;
+    };
+    let result = do_https(host, port, path, "POST", Some(body));
+    unsafe { write_http_result(result, out_status, out_body, out_err) }
+}
+
+#[cfg(test)]
+mod http_kernel_tests {
+    use super::*;
+
+    #[test]
+    fn parse_http_response_extracts_status_and_body() {
+        let raw = b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nhello world";
+        let parsed = parse_http_response(raw).unwrap();
+        assert_eq!(parsed.status, 200);
+        assert_eq!(parsed.body, "hello world");
+    }
+
+    #[test]
+    fn parse_http_response_handles_empty_body() {
+        let raw = b"HTTP/1.1 204 No Content\r\n\r\n";
+        let parsed = parse_http_response(raw).unwrap();
+        assert_eq!(parsed.status, 204);
+        assert_eq!(parsed.body, "");
+    }
+
+    #[test]
+    fn parse_http_response_rejects_malformed_input() {
+        assert!(parse_http_response(b"not an http response at all").is_err());
+    }
+
+    #[test]
+    fn parse_http_response_decodes_a_real_chunked_body() {
+        let raw = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n7\r\nMozilla\r\n9\r\nDeveloper\r\n0\r\n\r\n";
+        let parsed = parse_http_response(raw).unwrap();
+        assert_eq!(parsed.status, 200);
+        assert_eq!(parsed.body, "MozillaDeveloper");
+    }
+
+    #[test]
+    fn parse_http_response_leaves_a_non_chunked_body_untouched() {
+        let raw = b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello";
+        assert_eq!(parse_http_response(raw).unwrap().body, "hello");
+    }
+
+    #[test]
+    fn decode_chunked_body_rejects_truncated_input() {
+        assert!(decode_chunked_body(b"5\r\nabc").is_err());
+    }
+
+    #[test]
+    fn http_get_round_trips_against_a_real_local_server() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 1024];
+            let _ = stream.read(&mut buf).unwrap();
+            stream.write_all(b"HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nhello from server").unwrap();
+        });
+        let result = do_http("127.0.0.1", port as i64, "/", "GET", None);
+        server.join().unwrap();
+        let parsed = result.unwrap();
+        assert_eq!(parsed.status, 200);
+        assert_eq!(parsed.body, "hello from server");
+    }
+
+    #[test]
+    fn http_post_sends_a_real_body_with_content_length() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 4096];
+            let n = stream.read(&mut buf).unwrap();
+            let received = String::from_utf8_lossy(&buf[..n]).into_owned();
+            assert!(received.contains("Content-Length: 11"));
+            assert!(received.ends_with("hello world"));
+            stream.write_all(b"HTTP/1.1 201 Created\r\nConnection: close\r\n\r\ncreated").unwrap();
+        });
+        let result = do_http("127.0.0.1", port as i64, "/submit", "POST", Some("hello world"));
+        server.join().unwrap();
+        let parsed = result.unwrap();
+        assert_eq!(parsed.status, 201);
+        assert_eq!(parsed.body, "created");
+    }
+
+    #[test]
+    fn http_get_connection_refused_is_a_real_err_not_a_panic() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener); // bound then immediately dropped -- nothing listens on it
+        assert!(do_http("127.0.0.1", port as i64, "/", "GET", None).is_err());
+    }
+}
+
+// ---- workflow kernels (`docs/WORKFLOW.md`, Layer 1 only) -----------------
+//
+// The now-deleted interpreter's own `workflow_log.rs` (1294 lines) was a
+// real, file-backed-SQLite-by-default durability store, modeled on
+// `transact_log.rs` — instance state, an append-only history log, magic-
+// link tokens, an identity/presence directory for `notify()`. None of
+// that is rebuilt here. This is deliberately the *smallest* real slice,
+// the same "Layer 1: in-process, no durability" cut `transact` itself
+// shipped first (`docs/TRANSACT.md`'s own layering) — a process-wide,
+// in-memory instance table (`instance_id -> (workflow_name,
+// current_state)`), real state transitions, real `on_entry`/`on_exit`
+// action calls. Lost on process exit, same as `transact`'s own Layer 1
+// durability posture — a real, disclosed, much narrower gap than the
+// full design's cross-restart/multi-instance guarantee.
+
+struct WorkflowInstance {
+    workflow_name: String,
+    state: String,
+    /// Unix seconds this instance entered `state` — reset on every
+    /// transition (`nir_workflow_set_state`), stamped fresh on create.
+    /// The one piece of data `nir_workflow_list_overdue` needs to answer
+    /// "how long has this instance sat here" — an SLA/escalation clock,
+    /// not a general audit timestamp (no history of *previous* states'
+    /// own dwell times is kept, matching this whole track's Layer-1
+    /// "narrower, disclosed" scope).
+    entered_at: i64,
+}
+
+fn now_unix_secs() -> i64 {
+    std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).map(|d| d.as_secs() as i64).unwrap_or(0)
+}
+
+fn workflow_instances() -> &'static std::sync::Mutex<std::collections::HashMap<i64, WorkflowInstance>> {
+    static TABLE: OnceLock<std::sync::Mutex<std::collections::HashMap<i64, WorkflowInstance>>> = OnceLock::new();
+    TABLE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+static WORKFLOW_INSTANCE_SEQ: std::sync::atomic::AtomicI64 = std::sync::atomic::AtomicI64::new(1);
+
+/// Creates a new instance in `initial_state`, returns its fresh
+/// `instance_id`. Only fails on malformed UTF-8 input — in practice
+/// never, since `codegen::emit_workflow_start` only ever passes
+/// compile-time-known `str` literals (the workflow's own name, its
+/// first-declared state's name) here, never a runtime value.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_workflow_create_instance(workflow_name_ptr: *const u8, workflow_name_len: i64, initial_state_ptr: *const u8, initial_state_len: i64, out_instance_id: *mut i64) -> i32 {
+    let (Some(workflow_name), Some(initial_state)) =
+        (unsafe { str_from_raw(workflow_name_ptr, workflow_name_len) }, unsafe { str_from_raw(initial_state_ptr, initial_state_len) })
+    else {
+        return 0;
+    };
+    let id = WORKFLOW_INSTANCE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    workflow_instances()
+        .lock()
+        .unwrap()
+        .insert(id, WorkflowInstance { workflow_name: workflow_name.to_string(), state: initial_state.to_string(), entered_at: now_unix_secs() });
+    unsafe { *out_instance_id = id };
+    1
+}
+
+/// `1` (with `out_state` populated) if `instance_id` exists and belongs
+/// to `workflow_name`, `0` otherwise (unknown instance, or an
+/// `instance_id` that belongs to a *different* workflow — the same
+/// "each workflow's own instance space" isolation a real per-workflow
+/// table would give for free).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_workflow_get_state(workflow_name_ptr: *const u8, workflow_name_len: i64, instance_id: i64, out_state: *mut NirStrOut) -> i32 {
+    let Some(workflow_name) = (unsafe { str_from_raw(workflow_name_ptr, workflow_name_len) }) else {
+        return 0;
+    };
+    let table = workflow_instances().lock().unwrap();
+    match table.get(&instance_id) {
+        Some(inst) if inst.workflow_name == workflow_name => {
+            unsafe { write_str_out(out_state, inst.state.clone()) };
+            1
+        }
+        _ => 0,
+    }
+}
+
+/// Moves `instance_id` to `new_state`, resetting its SLA clock
+/// (`entered_at`) to now.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_workflow_set_state(workflow_name_ptr: *const u8, workflow_name_len: i64, instance_id: i64, new_state_ptr: *const u8, new_state_len: i64) -> i32 {
+    let (Some(workflow_name), Some(new_state)) =
+        (unsafe { str_from_raw(workflow_name_ptr, workflow_name_len) }, unsafe { str_from_raw(new_state_ptr, new_state_len) })
+    else {
+        return 0;
+    };
+    let mut table = workflow_instances().lock().unwrap();
+    match table.get_mut(&instance_id) {
+        Some(inst) if inst.workflow_name == workflow_name => {
+            inst.state = new_state.to_string();
+            inst.entered_at = now_unix_secs();
+            1
+        }
+        _ => 0,
+    }
+}
+
+/// `list_<workflow>_overdue()`'s real implementation
+/// (`codegen::emit_workflow_overdue`) — SLA/escalation, the queryable
+/// half (`docs/ROADMAP.md` A15's own proposed, more tractable design:
+/// a `list_<workflow>_overdue()` read fn an external scheduler polls,
+/// not an in-process timer — the same "real cross-thread callback"
+/// complexity already deferred for `transact`'s `network` timeout would
+/// be needed to fire escalations *automatically* with no caller
+/// involved at all, not attempted here). `sla_config_json` is a
+/// compile-time-built `{"StateName": seconds, ...}` object, one entry
+/// per state that declared `sla_seconds` — states with no entry are
+/// never SLA-tracked, matching `docs/WORKFLOW.md`'s own "sla is a real,
+/// scoped proposed design, not sketched in the original doc" framing.
+/// Returns a JSON array of `{"instance_id":N,"state":"...","age_seconds":N}`,
+/// oldest-dwelling first.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_workflow_list_overdue(
+    workflow_name_ptr: *const u8,
+    workflow_name_len: i64,
+    sla_config_json_ptr: *const u8,
+    sla_config_json_len: i64,
+    out_json: *mut NirStrOut,
+    out_err: *mut NirStrOut,
+) -> i32 {
+    let (Some(workflow_name), Some(sla_config_json)) =
+        (unsafe { str_from_raw(workflow_name_ptr, workflow_name_len) }, unsafe { str_from_raw(sla_config_json_ptr, sla_config_json_len) })
+    else {
+        unsafe { write_str_out(out_err, "workflow_name/sla_config is not valid UTF-8".to_string()) };
+        return 0;
+    };
+    let sla_config: serde_json::Value = match serde_json::from_str(sla_config_json) {
+        Ok(v) => v,
+        Err(e) => {
+            unsafe { write_str_out(out_err, format!("malformed sla config: {e}")) };
+            return 0;
+        }
+    };
+    let now = now_unix_secs();
+    let table = workflow_instances().lock().unwrap();
+    let mut overdue: Vec<(i64, &String, i64)> = Vec::new();
+    for (id, inst) in table.iter() {
+        if inst.workflow_name != workflow_name {
+            continue;
+        }
+        if let Some(sla) = sla_config.get(&inst.state).and_then(|v| v.as_i64()) {
+            let age = now - inst.entered_at;
+            if age >= sla {
+                overdue.push((*id, &inst.state, age));
+            }
+        }
+    }
+    overdue.sort_by(|a, b| b.2.cmp(&a.2));
+    let rows: Vec<serde_json::Value> =
+        overdue.into_iter().map(|(id, state, age)| serde_json::json!({"instance_id": id, "state": state, "age_seconds": age})).collect();
+    unsafe { write_str_out(out_json, serde_json::to_string(&rows).unwrap_or_else(|_| "[]".to_string())) };
+    1
+}
+
+#[cfg(test)]
+mod workflow_overdue_tests {
+    use super::*;
+
+    #[test]
+    fn an_instance_past_its_sla_is_reported_overdue() {
+        let name = "OverdueTestWorkflow";
+        let state = "Waiting";
+        let mut id = 0i64;
+        unsafe { nir_workflow_create_instance(name.as_ptr(), name.len() as i64, state.as_ptr(), state.len() as i64, &mut id) };
+        // Backdate `entered_at` directly (real time would need a real
+        // sleep) -- same "poke the table, don't wait on a real clock"
+        // convention this crate's own other timing-adjacent tests avoid
+        // needing at all elsewhere.
+        workflow_instances().lock().unwrap().get_mut(&id).unwrap().entered_at -= 1000;
+
+        let sla_config = r#"{"Waiting":60}"#;
+        let mut out = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let mut err = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let ok = unsafe {
+            nir_workflow_list_overdue(name.as_ptr(), name.len() as i64, sla_config.as_ptr(), sla_config.len() as i64, &mut out, &mut err)
+        };
+        assert_eq!(ok, 1);
+        let json_text = unsafe { std::str::from_utf8(std::slice::from_raw_parts(out.ptr, out.len as usize)).unwrap() };
+        let parsed: serde_json::Value = serde_json::from_str(json_text).unwrap();
+        assert_eq!(parsed[0]["instance_id"], id);
+        assert_eq!(parsed[0]["state"], "Waiting");
+    }
+
+    #[test]
+    fn an_instance_within_its_sla_is_not_overdue() {
+        let name = "NotOverdueTestWorkflow";
+        let state = "Waiting";
+        let mut id = 0i64;
+        unsafe { nir_workflow_create_instance(name.as_ptr(), name.len() as i64, state.as_ptr(), state.len() as i64, &mut id) };
+
+        let sla_config = r#"{"Waiting":600}"#;
+        let mut out = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let mut err = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        unsafe { nir_workflow_list_overdue(name.as_ptr(), name.len() as i64, sla_config.as_ptr(), sla_config.len() as i64, &mut out, &mut err) };
+        let json_text = unsafe { std::str::from_utf8(std::slice::from_raw_parts(out.ptr, out.len as usize)).unwrap() };
+        assert_eq!(json_text, "[]");
+    }
+
+    #[test]
+    fn a_state_with_no_sla_entry_is_never_overdue() {
+        let name = "NoSlaTestWorkflow";
+        let state = "Untracked";
+        let mut id = 0i64;
+        unsafe { nir_workflow_create_instance(name.as_ptr(), name.len() as i64, state.as_ptr(), state.len() as i64, &mut id) };
+        workflow_instances().lock().unwrap().get_mut(&id).unwrap().entered_at -= 100_000;
+
+        let sla_config = r#"{"SomeOtherState":1}"#;
+        let mut out = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let mut err = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        unsafe { nir_workflow_list_overdue(name.as_ptr(), name.len() as i64, sla_config.as_ptr(), sla_config.len() as i64, &mut out, &mut err) };
+        let json_text = unsafe { std::str::from_utf8(std::slice::from_raw_parts(out.ptr, out.len as usize)).unwrap() };
+        assert_eq!(json_text, "[]");
+    }
+}
+
+// ---- send_email/send_sms/send_push/notify (`docs/WORKFLOW.md`) ----------
+//
+// A real, generic, provider-agnostic authenticated HTTPS POST — not any
+// specific vendor's own exact API schema (SendGrid/Twilio/FCM), exactly
+// the already-locked design. Reads the first `active = 1` row of a
+// fixed-name table (`email_provider_config`/`sms_provider_config`/
+// `push_provider_config`) via the caller's own `db` handle — no implicit/
+// global connection, matching every `db_query`/`db_execute` convention
+// already established.
+//
+// **`notify`'s presence bridge is not wired up in this round** — a real
+// `identity_presence` table only ever gets populated by two `serve.rs`
+// routes (`_presence_connect`/`_disconnect`), and `serve.rs` itself is
+// gone. Rather than build an unreachable presence table nothing can ever
+// populate, `notify` here always takes the documented *offline* path
+// (falls back to `send_email`) — a real, disclosed narrowing of an
+// already-narrow design, not a fake "sometimes online" simulation.
+// `crates/presence-gateway/`'s own real Redis-`PUBLISH`-relay protocol
+// (`docs/WORKFLOW.md`'s own §"notify's presence bridge") is exactly what
+// a future session should wire this up to.
+
+/// `active = 1` row's five fixed columns, in `docs/WORKFLOW.md`'s own
+/// declared order (`EmailProviderConfig`'s doc comment).
+struct ProviderConfig {
+    host: String,
+    port: i64,
+    path: String,
+    api_key: String,
+    from_address: String,
+}
+
+fn provider_table_name(channel: &str) -> &'static str {
+    match channel {
+        "email" => "email_provider_config",
+        "sms" => "sms_provider_config",
+        "push" => "push_provider_config",
+        _ => unreachable!("codegen only ever passes email/sms/push"),
+    }
+}
+
+fn load_active_provider_config(conn_handle: i64, channel: &str) -> Result<ProviderConfig, String> {
+    let table = provider_table_name(channel);
+    let sql = format!("SELECT host, port, path, api_key, from_address FROM {table} WHERE active = 1 LIMIT 1");
+    let row = db_table().with(conn_handle, |conn| {
+        conn.query_row(&sql, [], |r| {
+            Ok(ProviderConfig {
+                host: r.get(0)?,
+                port: r.get(1)?,
+                path: r.get(2)?,
+                api_key: r.get(3)?,
+                from_address: r.get(4)?,
+            })
+        })
+    });
+    match row {
+        Some(Ok(cfg)) => Ok(cfg),
+        Some(Err(_)) => Err("provider_not_configured".to_string()),
+        None => Err("db handle is not open".to_string()),
+    }
+}
+
+/// The actual authenticated POST — `{"to","from","template","vars"}` as
+/// JSON, `Authorization: Bearer <api_key>`. A non-2xx status or a
+/// connection failure is `Err(message)`; success is `Ok(())`.
+fn send_via_provider(cfg: &ProviderConfig, to: &str, template: &str, vars_json: &str) -> Result<(), String> {
+    let body = serde_json::json!({"to": to, "from": cfg.from_address, "template": template, "vars": serde_json::from_str::<serde_json::Value>(vars_json).unwrap_or(serde_json::Value::Null)})
+        .to_string();
+    let result = do_http_with_auth(&cfg.host, cfg.port, &cfg.path, "POST", Some(&body), Some(&cfg.api_key));
+    match result {
+        Ok(parsed) if (200..300).contains(&parsed.status) => Ok(()),
+        Ok(parsed) => Err(format!("provider returned status {}", parsed.status)),
+        Err(e) => Err(e),
+    }
+}
+
+/// `0`=ok, `1`=`ProviderNotConfigured`, `2`=`ProviderRequestFailed(msg)` —
+/// `codegen::emit_send_notification`'s own doc comment maps these back
+/// onto the real `WorkflowActionError` variant tags (3 and index-matched
+/// respectively) at the call site, the same "kernel reports a small
+/// status code, codegen builds the real enum value" split every other
+/// `Result`-returning builtin in this file already uses.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_workflow_send(
+    channel_ptr: *const u8,
+    channel_len: i64,
+    conn_handle: i64,
+    to_ptr: *const u8,
+    to_len: i64,
+    template_ptr: *const u8,
+    template_len: i64,
+    vars_json_ptr: *const u8,
+    vars_json_len: i64,
+    out_err_msg: *mut NirStrOut,
+) -> i32 {
+    let (Some(channel), Some(to), Some(template), Some(vars_json)) = (
+        unsafe { str_from_raw(channel_ptr, channel_len) },
+        unsafe { str_from_raw(to_ptr, to_len) },
+        unsafe { str_from_raw(template_ptr, template_len) },
+        unsafe { str_from_raw(vars_json_ptr, vars_json_len) },
+    ) else {
+        unsafe { write_str_out(out_err_msg, "argument is not valid UTF-8".to_string()) };
+        return 2;
+    };
+    let cfg = match load_active_provider_config(conn_handle, channel) {
+        Ok(cfg) => cfg,
+        Err(e) if e == "provider_not_configured" => return 1,
+        Err(e) => {
+            unsafe { write_str_out(out_err_msg, e) };
+            return 2;
+        }
+    };
+    match send_via_provider(&cfg, to, template, vars_json) {
+        Ok(()) => 0,
+        Err(e) => {
+            unsafe { write_str_out(out_err_msg, e) };
+            2
+        }
+    }
+}
+
+/// `notify`'s real implementation — always takes the offline
+/// (`send_email`) path; see this section's own doc comment for why the
+/// presence-bridge online path isn't reachable this round. Same status-
+/// code convention as `nir_workflow_send`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_notify(
+    conn_handle: i64,
+    _mq_handle: i64,
+    to_ptr: *const u8,
+    to_len: i64,
+    template_ptr: *const u8,
+    template_len: i64,
+    vars_json_ptr: *const u8,
+    vars_json_len: i64,
+    out_err_msg: *mut NirStrOut,
+) -> i32 {
+    unsafe { nir_workflow_send(b"email".as_ptr(), 5, conn_handle, to_ptr, to_len, template_ptr, template_len, vars_json_ptr, vars_json_len, out_err_msg) }
+}
+
+#[cfg(test)]
+mod workflow_send_tests {
+    use super::*;
+
+    fn open_memory_db() -> i64 {
+        let path = ":memory:";
+        let mut handle = 0i64;
+        let mut err = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        assert_eq!(unsafe { nir_db_connect(path.as_ptr(), path.len() as i64, &mut handle, &mut err) }, 1);
+        handle
+    }
+
+    #[test]
+    fn send_email_with_no_active_provider_row_is_not_configured() {
+        let conn = open_memory_db();
+        let sql = "CREATE TABLE email_provider_config (id INTEGER PRIMARY KEY, active INTEGER, host TEXT, port INTEGER, path TEXT, api_key TEXT, from_address TEXT)";
+        let mut affected = 0i64;
+        let mut err = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        unsafe { nir_db_execute(conn, sql.as_ptr(), sql.len() as i64, std::ptr::null(), 0, &mut affected, &mut err) };
+
+        let channel = "email";
+        let to = "alice@example.com";
+        let template = "welcome";
+        let vars = "{}";
+        let mut err_msg = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let status = unsafe {
+            nir_workflow_send(
+                channel.as_ptr(),
+                channel.len() as i64,
+                conn,
+                to.as_ptr(),
+                to.len() as i64,
+                template.as_ptr(),
+                template.len() as i64,
+                vars.as_ptr(),
+                vars.len() as i64,
+                &mut err_msg,
+            )
+        };
+        assert_eq!(status, 1);
+        unsafe { nir_db_stop(conn) };
+    }
+
+    #[test]
+    fn send_email_posts_to_a_real_configured_provider() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 4096];
+            let n = stream.read(&mut buf).unwrap();
+            let received = String::from_utf8_lossy(&buf[..n]).into_owned();
+            assert!(received.contains("Authorization: Bearer secret-key-123"));
+            assert!(received.contains("alice@example.com"));
+            stream.write_all(b"HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nsent").unwrap();
+        });
+
+        let conn = open_memory_db();
+        let create_sql = "CREATE TABLE email_provider_config (id INTEGER PRIMARY KEY, active INTEGER, host TEXT, port INTEGER, path TEXT, api_key TEXT, from_address TEXT)";
+        let mut affected = 0i64;
+        let mut err = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        unsafe { nir_db_execute(conn, create_sql.as_ptr(), create_sql.len() as i64, std::ptr::null(), 0, &mut affected, &mut err) };
+        let insert_sql = "INSERT INTO email_provider_config (active, host, port, path, api_key, from_address) VALUES (1, ?, ?, ?, ?, ?)";
+        let host = "127.0.0.1";
+        let path = "/send";
+        let api_key = "secret-key-123";
+        let from_address = "noreply@example.com";
+        let binds = [
+            NirBindValue { tag: 2, i: 0, f: 0.0, s_ptr: host.as_ptr(), s_len: host.len() as i64 },
+            NirBindValue { tag: 0, i: port as i64, f: 0.0, s_ptr: std::ptr::null(), s_len: 0 },
+            NirBindValue { tag: 2, i: 0, f: 0.0, s_ptr: path.as_ptr(), s_len: path.len() as i64 },
+            NirBindValue { tag: 2, i: 0, f: 0.0, s_ptr: api_key.as_ptr(), s_len: api_key.len() as i64 },
+            NirBindValue { tag: 2, i: 0, f: 0.0, s_ptr: from_address.as_ptr(), s_len: from_address.len() as i64 },
+        ];
+        unsafe { nir_db_execute(conn, insert_sql.as_ptr(), insert_sql.len() as i64, binds.as_ptr(), binds.len() as i64, &mut affected, &mut err) };
+
+        let channel = "email";
+        let to = "alice@example.com";
+        let template = "welcome";
+        let vars = "{}";
+        let mut err_msg = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        let status = unsafe {
+            nir_workflow_send(
+                channel.as_ptr(),
+                channel.len() as i64,
+                conn,
+                to.as_ptr(),
+                to.len() as i64,
+                template.as_ptr(),
+                template.len() as i64,
+                vars.as_ptr(),
+                vars.len() as i64,
+                &mut err_msg,
+            )
+        };
+        server.join().unwrap();
+        assert_eq!(status, 0);
+        unsafe { nir_db_stop(conn) };
+    }
+}
+
+#[cfg(test)]
+mod workflow_kernel_tests {
+    use super::*;
+
+    #[test]
+    fn create_then_get_state_round_trips() {
+        let name = "TestWorkflow1";
+        let state = "Pending";
+        let mut id = 0i64;
+        assert_eq!(unsafe { nir_workflow_create_instance(name.as_ptr(), name.len() as i64, state.as_ptr(), state.len() as i64, &mut id) }, 1);
+
+        let mut out = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        assert_eq!(unsafe { nir_workflow_get_state(name.as_ptr(), name.len() as i64, id, &mut out) }, 1);
+        let seen = unsafe { std::str::from_utf8(std::slice::from_raw_parts(out.ptr, out.len as usize)).unwrap() };
+        assert_eq!(seen, "Pending");
+    }
+
+    #[test]
+    fn set_state_then_get_state_sees_the_update() {
+        let name = "TestWorkflow2";
+        let state = "Start";
+        let mut id = 0i64;
+        unsafe { nir_workflow_create_instance(name.as_ptr(), name.len() as i64, state.as_ptr(), state.len() as i64, &mut id) };
+
+        let next = "Done";
+        assert_eq!(unsafe { nir_workflow_set_state(name.as_ptr(), name.len() as i64, id, next.as_ptr(), next.len() as i64) }, 1);
+
+        let mut out = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        unsafe { nir_workflow_get_state(name.as_ptr(), name.len() as i64, id, &mut out) };
+        let seen = unsafe { std::str::from_utf8(std::slice::from_raw_parts(out.ptr, out.len as usize)).unwrap() };
+        assert_eq!(seen, "Done");
+    }
+
+    #[test]
+    fn unknown_instance_id_is_not_found() {
+        let name = "TestWorkflow3";
+        let mut out = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        assert_eq!(unsafe { nir_workflow_get_state(name.as_ptr(), name.len() as i64, 999_999_999, &mut out) }, 0);
+    }
+
+    #[test]
+    fn an_instance_id_belonging_to_a_different_workflow_is_not_found() {
+        let name_a = "TestWorkflowA";
+        let name_b = "TestWorkflowB";
+        let state = "S";
+        let mut id = 0i64;
+        unsafe { nir_workflow_create_instance(name_a.as_ptr(), name_a.len() as i64, state.as_ptr(), state.len() as i64, &mut id) };
+
+        let mut out = NirStrOut { ptr: std::ptr::null(), len: 0 };
+        assert_eq!(unsafe { nir_workflow_get_state(name_b.as_ptr(), name_b.len() as i64, id, &mut out) }, 0);
+    }
 }
 
 // ---- dec128 kernels ---------------------------------------------------

--- a/docs/API_TRUST_MODEL.md
+++ b/docs/API_TRUST_MODEL.md
@@ -369,6 +369,32 @@ proposed sketch, which starts from zero.
 
 ## 4a. Which backend enforces any of this — `[DONE]`, fail-closed
 
+> **2026-09 — both premises below are now false; read this section as
+> history.** The interpreter (`run`/`serve`, `interpreter.rs`,
+> `serve.rs`) was deleted entirely in a separate pass this session — the
+> "every mechanism in §3-§5 exists only on the interpreted path" claim
+> below described a real trade at the time, but there is no interpreted
+> path left to make it on. Separately, and independently: `Ty::Fn`/
+> `Expr::Acquire` are **no longer rejected** by `codegen.rs::
+> check_supported` — `acquire`/`requires(role/claim: ...)` on a function
+> compile for real now (`docs/LANGUAGE.md` §6a, §10's compiled-vs-
+> interpreter-only table). The security posture this section's own
+> closing paragraph draws attention to — "worth stating so nobody
+> assumes an `emit-llvm`'d build of a gated app is the same app, faster"
+> — has flipped from "the compiled path refuses" to "the compiled path
+> is now the *only* path, and it actually enforces `requires`/`acquire`
+> for real": `crates/compiler/tests/codegen.rs`'s
+> `acquire_produces_real_callable_fn_value_gated_by_check_role` is the
+> compiled-and-run proof. What's still real from this section: `db`/
+> `json`/`mq`/`transact`/`sandbox`/most Row 12 identity builtins
+> (`extract_claim`/`oidc_validate_token` included) remain uncompiled and
+> now don't run in *any* form — worse than "falls back to the
+> interpreter," since there's no fallback left. A gated app that relies
+> on any of those alongside `requires`/`acquire` still doesn't run
+> end to end; one that only needs `check_role` + `requires`/`acquire` +
+> field masking now does, compiled, with no interpreter anywhere in the
+> picture.
+
 Not previously covered in this document, and load-bearing for anyone
 reading `docs/LANGUAGE.md` §10's compiled-vs-interpreted split: **every
 mechanism in §3-§5 exists only on the interpreted path.**

--- a/docs/ECOSYSTEM.md
+++ b/docs/ECOSYSTEM.md
@@ -222,6 +222,27 @@ crates.io-hosted `.nir`-source-only crate needs:
    resources, today a plain `i64` via `nirdosha-plugin-support`) remain
    real, named gaps — `rfcs/0001-package-manifest-format.md` and
    `rfcs/0003-plugin-abi-v2.md`'s own open questions, respectively.
+
+   **2026-09-06 — the interpreter, and everything Stage 1 above built on
+   it, was removed** (`remove-interpreter` branch, commit `c82fa1f`):
+   `PluginBuiltin`/`PluginFn`/`NirdoshaPlugin`, all five reference
+   plugins, and `nirdosha-plugin-support` are gone — this whole
+   numbered item is now a historical record of a design that was real
+   and shipped, not a description of the current tree. What survives is
+   `crates/compiler/src/plugin.rs`'s `NativePluginBuiltin` (§3 of
+   `rfcs/0005-plugin-boundary-safety-and-performance.md`), the
+   compiled-path answer this doc's own G1 opening paragraph named as a
+   real gap ("no stable calling convention from generated LLVM IR into
+   an opaque `Arc<dyn Fn>` exists") — and `rfcs/0008-native-plugin-abi-
+   widening.md` is that mechanism's own version of this Stage-1 arc:
+   Phase 1 (widening past scalars to `str`/`handle(Kind)`/
+   `&handle(Kind)`, and the first-class affine `Ty::Handle` this
+   section above still lists as a gap) is built and verified on the
+   compiled path, with two real reference crates
+   (`crates/plugin-example-native-{shout,kv}`) replacing `rot13` as the
+   proof. Auto-discovery (this doc's own next paragraph) is still not
+   built, now for the compiled path instead of the interpreted one —
+   see rfcs/0008 Phase 3.
 2. **Stage 2 — Kind B.** Only after Stage 1 is real and F2 itself has
    had more mileage; needs the resolver work above plus a decision (see
    open questions) on whether crates.io is even the right home for

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -287,15 +287,34 @@ acquired value is an ordinary first-class function once obtained: pass
 it to code that has no idea it was privileged, store it in a struct,
 return it, call it many times — the check happens exactly once, at
 acquisition, not smeared across (or missing from) every call site.
-Interpreter-only for now, like every construct past §10's compiled
-subset — `nirdosha build` rejects `fn(..)->..`/`acquire` with a specific
-reason, never silently mis-compiles one. **`check_role` itself is the
-exception (2026-09, §10)**: it's fully compiled, so a real `RoleView`
-*is* obtainable in a compiled binary today — it's `acquire` (the step
-that would consume that `RoleView` to gate a first-class function) that
-still has zero codegen. A `RoleView` produced this way is not wasted,
-though: §6e's field-level `requires(...)` masking consumes it directly,
-with no `acquire` involved at all.
+
+**Compiled for real, 2026-09** (`docs/PHASE0.md`'s "Twenty-first
+update") — both halves of this mechanism, not just `check_role`: a
+plain top-level `fn` used as a first-class value (`apply(double, 21)`,
+no `requires(...)` involved at all) evaluates to its own address, and
+calling a `fn(..)->..`-typed value — whether an ordinary one or an
+`acquire`d one — emits a real indirect call (`codegen.rs::
+call_indirect`). `acquire name(proof)` itself builds a genuine
+`Result(fn(params) -> ret, str)` by hand, the same tag+payload shape
+`check_role`'s own compiled implementation uses: `proof`'s field is
+checked against `name`'s declared requirement via the identical
+`nir_str_eq` comparison §6e's field masking already does, `Ok(f)`
+stores the target function's real address, `Err(reason)` names exactly
+which requirement wasn't met. `crates/compiler/tests/codegen.rs`'s
+`acquire_produces_real_callable_fn_value_gated_by_check_role` is the
+real compiled-and-run proof: an identity that proves the required role
+gets a real, callable function back and a real result from calling it;
+one that doesn't gets a real `Err`, never reaching the function's body
+at all.
+
+One real, disclosed ordering wrinkle, found by actually compiling a
+`match` shaped this way, not by reading the codegen plan in advance:
+`match`'s own result type is inferred from its *first* arm's body,
+evaluated *before* that arm's own bindings exist in scope — so
+`Ok(f) => f(...)` can't be the first arm of a `match acquire
+name(proof) { ... }` (`f` isn't bound yet at the point its type would
+need inferring); put `Err(...)` first instead. A real, narrow
+constraint on arm order, not a defect in `acquire` itself.
 
 ### 6b. `str` at function boundaries ("enum favoring")
 
@@ -858,7 +877,7 @@ a live TCP round trip — not by re-reading this section's own prose).
 | `http_get`/`http_post`/`https_get`/`https_post` | No | Not in `codegen.rs`'s builtin allowlists. |
 | `transact` | No | |
 | `workflow` | No | Desugars to `send_email`/`send_sms`/`send_push`/`notify`/`__workflow_*`, none compiled. |
-| `fn(..)->..`/`acquire`/`requires(role/claim: ...)` on a *function* | No | First-class/privileged functions (§6a) — distinct from field-level `requires(...)` masking (§6e), which **is** compiled. |
+| `fn(..)->..`/`acquire`/`requires(role/claim: ...)` on a *function* | Yes | 2026-09. First-class/privileged functions (§6a) — a plain fn value is its own address, an acquired one is a real, hand-built `Result(fn(..)->.., str)`; calling either emits a real indirect call. `sandbox` scoping this exact mechanism is unrelated; `extract_claim`/`oidc_validate_token` (the claim/OIDC half of §6a's own example) remain interpreter-only-designed, so a claim-gated flow still doesn't run end to end. |
 | `screen`/`dashboard` | Inert, not rejected | `codegen.rs` never inspects these — a program containing them compiles cleanly with nothing to lower to. |
 
 **Scalar width mechanics.** Same LLVM widths as the signed types for

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -122,6 +122,19 @@ to write them with). All require `f64` elements unless noted.
   `unit` — literal, variable, or computed result, all identically); the
   one remaining gap is a whole `Vector`/`Matrix` argument (§10).
 
+**Compiled string parsing** (2026-09) — the minimal surface a compiled
+HTTP `serve` needs to hand-parse a request line; deliberately not a
+general string library (no `split`/`starts_with`/`trim`/concat).
+- `len(s: str) -> i64` — same name as Vector's `len` (below), `str`'s
+  own arm added alongside it.
+- `str_slice(s: str, start: i64, end: i64) -> str` — the substring
+  `[start, end)`. Traps (not `Result`) if `start`/`end` are out of
+  bounds — a real, out-of-band program error, same convention as
+  `dec_from_i64`'s scale-overflow trap above.
+- `str_index_of(haystack: str, needle: str) -> i64` — byte offset of
+  the first occurrence of `needle`, or `-1` if not found. An empty
+  `needle` matches at offset `0`.
+
 **Dense linear algebra** (Phase 2)
 - `transpose(m: Matrix) -> Matrix` — any element type.
 - `dot(a: Vector, b: Vector) -> T` — same length, numeric element.
@@ -130,7 +143,7 @@ to write them with). All require `f64` elements unless noted.
 - `ones(n)` / `ones(r, c)` — same shape rule, filled with `1.0`.
 - `identity(n)` → `Matrix(f64, n, n)`.
 - `sum(v_or_m) -> T` — any numeric element type.
-- `len(v: Vector) -> i64`.
+- `len(v: Vector) -> i64` — overloaded with `len(s: str) -> i64` (below), same name.
 - `norm(v: Vector(f64,_)) -> f64` — 2-norm. `norm1` — sum of `|x|`. `norm_inf` — max `|x|`. `frobenius_norm(m: Matrix(f64,_,_))`.
 - `trace(m: Matrix(T,n,n)) -> T` — square only (`NotSquare` otherwise), numeric element.
 - `det(m: Matrix(f64,n,n)) -> f64` — Gaussian elimination, partial pivoting.
@@ -143,6 +156,7 @@ to write them with). All require `f64` elements unless noted.
 - `rand_seed(seed: <int>)` — resets the RNG stream (SplitMix64; see §9 — interpreted and compiled each keep their own, per §9/§10). Required before any draw.
 - `rand_f64() -> f64` — uniform `[0, 1)`.
 - `rand_gaussian(mean: f64, stddev: f64) -> f64` — Box-Muller.
+- `sleep_ms(ms: <int>)` — a real wall-clock sleep (compiled 2026-09, `docs/ROADMAP.md`'s B9; `nir_sleep_ms`). `ms <= 0` returns immediately.
 - `distance(a: Vector(f64,3), b: Vector(f64,3)) -> f64` — Euclidean.
 - `bearing(from: Vector(f64,3), to: Vector(f64,3)) -> f64` — initial great-circle bearing, degrees `[0,360)`; takes lat/lon/alt vectors, altitude ignored.
 - `lla_to_ecef(v: Vector(f64,3)) -> Vector(f64,3)` / `ecef_to_lla` — WGS84.
@@ -150,14 +164,23 @@ to write them with). All require `f64` elements unless noted.
 - `kf_predict_state(x, P, F, Q) -> Vector` / `kf_predict_cov(x, P, F, Q) -> Matrix` — linear Kalman filter predict step (split in two — no tuple/struct return type exists).
 - `kf_update_state(x, P, z, H, R) -> Vector` / `kf_update_cov(...) -> Matrix` — update step.
 
-**Database** (`Ty::Db`, interpreter-only — `docs/PROTOLANG_PORT.md`'s "Locked design 5: DB")
-- `db_connect(conn_str: str) -> Result(db, str)` — a bare path or `:memory:` opens a local SQLite database (`rusqlite`, bundled); a `postgres://`/`postgresql://` connection string instead connects to a real Postgres server (`postgres`/`postgres-native-tls` — `crates/compiler/src/dbconn.rs`). Same four-function surface either way; only `db_connect`'s own argument decides the backend, chosen once and fixed for that handle's lifetime.
-- `db_query(conn: db, sql: str, ...up to 8 bind values) -> Result(json, str)` — row-returning statements (`SELECT`). Bind values are `i64`/`f64`/`str`/`bool` (or a zero-payload `enum` variant, bound as its name), the only way to parameterize a query since `str` has no concatenation (§2). `?` placeholders (SQLite's own positional style) are rewritten to Postgres's `$1, $2, ...` automatically when the handle is a Postgres connection, so the same `sql` string and call site work against either backend. Every row comes back as one JSON object (column name → value); the whole result set is a JSON array, navigated with `json_array_len`/`json_array_get`/`json_get_*` like any other JSON document.
+**Database** (`Ty::Db`, compiled 2026-09 — SQLite only; `docs/PROTOLANG_PORT.md`'s "Locked design 5: DB")
+- `db_connect(conn_str: str) -> Result(db, str)` — a bare path or `:memory:` opens a local SQLite database (`rusqlite`, `bundled` feature — statically linked, no system `libsqlite3`; `nir_db_connect`, `runtime-kernels/src/lib.rs`). Postgres (`postgres://`/`postgresql://` connection strings, `crates/compiler/src/dbconn.rs`) was the interpreter-era design's layer 2; the compiled path doesn't have it yet (`dbconn.rs` itself no longer exists, removed with the interpreter) — a real, deferred follow-up (dynamic TLS linking), not silently dropped.
+- `db_query(conn: db, sql: str, ...up to 8 bind values) -> Result(json, str)` — row-returning statements (`SELECT`). Bind values are `i64`/`f64`/`str`/`bool`, the only way to parameterize a query since `str` has no concatenation (§2) — a zero-payload `enum` variant as a bind value is the one part of the original design not yet compiled (`NirBindValue`'s own doc comment, `runtime-kernels/src/lib.rs`). Every row comes back as one JSON object (column name → value); the whole result set is a JSON array, navigated with `json_array_len`/`json_array_get`/`json_get_*` like any other JSON document. `Ty::Json` compiles as the raw JSON text itself, re-parsed by each accessor — see `json`'s own entry below.
 - `db_execute(conn: db, sql: str, ...up to 8 bind values) -> Result(i64, str)` — everything else (`INSERT`/`UPDATE`/`DELETE`/DDL); returns the affected-row count.
 - `stop(conn)` — closes the connection (reuses `tcp`/`file`'s keyword).
-- A connection failure, SQL syntax error, or constraint violation is `Err(message)`, never a trap — the database engine's own error message passed straight through.
-- Postgres is strongly typed at the wire level (unlike SQLite): a schema column meant to hold a Nirdosha `i64`/`f64`/`bool`/`str` value should be declared `BIGINT`/`DOUBLE PRECISION`/`BOOLEAN`/`TEXT` — a narrower column type (e.g. `integer`) is a clear `Err` from the driver, not a silent misbind.
-- TLS to Postgres is opt-in, read from the connection string's own `sslmode=require`/`verify-ca`/`verify-full`; no `sslmode` (or `disable`/`prefer`/`allow`) connects in plaintext.
+- A connection failure, SQL syntax error, or constraint violation is `Err(message)`, never a trap — SQLite's own error message (`rusqlite::Error`) passed straight through.
+- SQLite has no native boolean column type: a `bool` bind value is stored as SQLite `INTEGER` `0`/`1`, and comes back out of `db_query` the same way — a plain JSON *number*, not a JSON boolean. `json_get_bool` (below) accepts both shapes for exactly this reason, found by testing a real round trip, not designed in advance.
+- SQLite `BLOB` columns have no first-class Nirdosha type to carry them (no `bytes` type) — `db_query` represents one as JSON `null`, a disclosed, narrower cut, not a silent drop; every other SQLite storage class round-trips exactly.
+- Real, compiled-and-run verification: `examples/features/27_database.nir` (schema creation, parameterized insert/update, a filtered `SELECT`, a connection failure) — `crates/compiler/tests/codegen.rs`'s `db_connect_execute_query_round_trips_real_sqlite_rows` compiles and runs that exact file, unmodified, against a real in-memory SQLite database.
+
+**JSON** (`Ty::Json`, compiled 2026-09 — see `Ty::Json`'s own doc comment for the representation choice)
+- `json_parse(s: str) -> Result(json, str)` — validates `s` parses as JSON; an identity function on success (`s`'s own value, unchanged) under this representation.
+- `json_get(doc: json, key: str) -> Result(json, str)` / `json_array_get(doc: json, idx: i64) -> Result(json, str)` — navigate to a sub-value, re-serialized as its own JSON text (this representation is text, not a persisted tree, so navigating one level means re-emitting the sub-tree).
+- `json_get_str`/`json_get_i64`/`json_get_f64`/`json_get_bool(doc: json, key: str) -> Result(_, str)` — leaf accessors; the value at `key` must itself be that JSON type (`json_get_bool` also accepts a JSON `0`/`1` integer — see `db`'s own note above on why).
+- `json_array_len(doc: json) -> Result(i64, str)`.
+- `json_set_str(doc: json, key: str, value: str) -> Result(json, str)` — sets `key` to a string value on a JSON object, or starts a fresh object if `doc` is JSON `null`. Any other JSON shape (an array, a scalar) is a real `Err`, not a type error.
+- Every accessor re-parses `doc`'s raw text on every call (no persisted parsed-tree handle) — the simplest thing that reuses `str`'s existing `{ptr, i64}` representation with zero new runtime value type, at the cost of re-parsing instead of a cached tree; disclosed, not hidden.
 - `nirdosha serve --db <path>`'s auto-generated table routes and automatic schema migrations (§13) are a separate mechanism, still SQLite-only.
 
 **Decimal arithmetic** (`dec128`, interpreter-only — §2, §10) — 2026-08-26.
@@ -171,12 +194,26 @@ to write them with). All require `f64` elements unless noted.
 - JSON encode/decode (`nirdosha serve`, `json_get_*`) represents `dec128` as a JSON **string**, not a JSON number, for the same reason as the DB binding — a JSON number is IEEE-754 double under nearly every consumer's parser, exactly the silent-drift failure this type exists to prevent. `emit-ui` renders a `dec128` field as a text input, not `<input type=number>`.
 
 **Identity / relying party** (Row 12)
-- `oidc_validate_token(token: str, expected_issuer: str, expected_audience: str, jwks_json: str) -> Result(VerifiedIdentity, str)` — validates a mock OIDC/JWT ID token against the supplied JWKS JSON (HMAC-SHA256). Checks issuer, audience, and signature. Returns a `VerifiedIdentity` on success. The runtime never mints tokens; it only consumes externally-issued ones.
+- `oidc_validate_token(token: str, expected_issuer: str, expected_audience: str, jwks_json: str) -> Result(VerifiedIdentity, str)` — validates a real OIDC/JWT ID token against the supplied **static** JWKS JSON (RSA/RS256, EC-P256/ES256, or oct/HS256, one key per `kid`; live JWKS refresh/rotation is a separate, deferred gap). Checks issuer, audience, and signature — a JWK's own `kty` locks which algorithm it may verify under, never the token's own `alg` header (closes the classic algorithm-confusion attack). Does **not** check `exp` against the real clock (`identity_expired`'s job, given an explicit `now` — keeps this builtin a pure function of its inputs, §9). Returns a `VerifiedIdentity` on success. The runtime never mints tokens; it only consumes externally-issued ones.
 - `check_role(identity: VerifiedIdentity, role: str) -> Result(RoleView, str)` — succeeds if `identity.claims_json` contains a `roles` array with the requested role.
 - `extract_claim(identity: VerifiedIdentity, name: str) -> Result(ClaimView, str)` — extracts a string claim from `identity.claims_json`.
 - `check_role_path(identity: VerifiedIdentity, path: str, role: str) -> Result(RoleView, str)` — `check_role`'s dotted-path sibling, for IdPs that nest the roles array under a path instead of a flat top-level `"roles"` field (e.g. Keycloak's `"realm_access.roles"`). `check_role`/`extract_claim` are unchanged and still the right call for a flat claim — including one whose own name contains a literal dot (Auth0-style namespaced claims like `"https://myapp.example.com/roles"`), which is a flat key, not a nested path.
 - `extract_claim_path(identity: VerifiedIdentity, path: str) -> Result(ClaimView, str)` — `extract_claim`'s dotted-path sibling, same nested-vs-flat distinction as `check_role_path` above.
 - `identity_expired(identity: VerifiedIdentity, now: i64) -> bool` — true if `now > identity.expires_at`.
+
+**Message queue** (`Ty::Mq`, compiled 2026-09 — Redis only)
+- `mq_connect(host: str, port: i64) -> Result(mq, str)` — opens a real Redis connection (`redis` crate). `mq` is affine like `db`/`tcp`/`file` — connect, use, and `stop` inside one function.
+- `mq_publish(conn: mq, queue: str, message: str) -> Result(unit, str)` — `LPUSH`.
+- `mq_consume(conn: mq, queue: str, timeout_secs: i64) -> Result(str, str)` — `BLPOP`, blocking up to `timeout_secs` (`0` blocks forever). A timeout with nothing published is a real `Err`, not a trap.
+- `stop(conn)` — closes the connection.
+- `mq_connect_via(url: str) -> Result(mq, str)` — a separate, plugin-dispatched mechanism (`rfcs/0003-plugin-abi-v2.md`, `examples/features/47_external_service_boundary.nir`), not part of this Redis-specific path.
+
+**HTTP/HTTPS client** (no new `Ty` — a one-shot request/response, never a persisted connection handle; `HttpResponse { status: i64, body: str }` is a plain prelude struct; compiled 2026-09)
+- `http_get(host: str, port: i64, path: str) -> Result(HttpResponse, str)` / `http_post(host, port, path, body: str) -> Result(HttpResponse, str)` — plain HTTP over `std::net::TcpStream`.
+- `https_get`/`https_post` — same request/response handling, wrapped in a `native_tls::TlsStream` (vendored OpenSSL — see below). `TlsConnector::new()`'s defaults do the actual security-critical work (certificate-chain and hostname verification against the platform's trust store).
+- Every request sends `Connection: close` and reads to EOF as the end-of-body signal — no `Content-Length` parsing needed. A `Transfer-Encoding: chunked` response body **is** decoded (found necessary by testing against a real server, not designed in advance — a large fraction of real HTTP servers chunk by default; a raw, undecoded chunked body would be a visibly wrong result, not an acceptable "first cut" gap the way `Content-Length` itself being unnecessary is).
+- A network failure, a malformed status line, or a non-UTF-8 body are all a real `Err`, never a trap.
+- **TLS is vendored, not system-linked** — a real, deliberate choice (`runtime-kernels/Cargo.toml`'s own doc comment), found necessary by an actual link failure against this environment's system OpenSSL (an ABI mismatch), not decided in the abstract: `openssl = { features = ["vendored"] }` forces the whole dependency tree to statically compile and link OpenSSL from source, the same "no system dependency" posture `rusqlite`'s own `bundled` feature already gives SQLite.
 
 ---
 
@@ -862,22 +899,28 @@ a live TCP round trip — not by re-reading this section's own prose).
 | `thread`/`spawn`/`join`, `chan`/`send`/`recv` | Yes | 2026-09. Word-sized `T` only (integers/`bool`/`f64`/`box`/`froze`/another handle) — `str`/`dec128`/struct/enum payloads still interpreter-only. Real admission ceiling (`Domain::Thread`) and a dynamic deadlock detector — see §7. |
 | `str` | Yes | Literals, `==`/`!=`, `if`-condition, `print`, fn params/returns — `main() -> str` compiles directly. |
 | `tcp`/`tcp_listener` | Yes | `connect`/`listen`/`accept`/`send`/`recv`/`stop` over real sockets. |
+| `str_index_of`/`str_slice`, `len(str)` | Yes | 2026-09. The minimal string-parsing surface a compiled HTTP `serve` needs — `str_slice`/`len(str)` are pure pointer arithmetic on `str`'s `{ptr, i64}` representation (no kernel call); `str_index_of` is the one real byte-scan, linked to `nir_str_index_of`. No `split`/`starts_with`/`trim`/concat — a real, separate follow-up. |
+| Compiled `serve` (`/api/<fn>` routing over `tcp_listener`/`accept`) | Yes, minimal | 2026-09 (ROADMAP.md Track B8). `str_index_of`/`str_slice` hand-parse the request line; routing is a plain `.nir` `if`/`else if` chain, no new language construct. GET-only, whole request assumed to arrive in one `recv`, no `Content-Length`/POST body support — see `examples/features/51_compiled_serve.nir`. |
 | `sha256_hex`/`constant_time_str_eq` | Yes | Isolated from-scratch SHA-256, bit-verified. Output buffer leaks — see below. |
 | `rand_seed`/`rand_f64`/`rand_gaussian` | Yes | Same algorithm as the interpreter, process-wide state — see below. |
 | `Vector`/`Matrix`, fully | Yes | Two codegen strategies — see below. |
 | `struct`/`enum`/`match`, non-affine payloads | Yes | Real LLVM types — see below. Affine payloads: no (Phase 4b). |
 | `struct`/`enum`/`match` with an affine field/payload | No | Phase 4b, deferred (below) — a non-affine one compiles now. |
 | `field: T requires(role/claim: ...)` (§6e field masking) | Yes | 2026-09. Scalar fields only (`is_aggregate()`/affine rejected, `TypeErrorKind::MaskRequiresNeedsScalarField`) — see §6e. |
-| `check_role` | Yes | 2026-09. `claims_json` read as a plain comma-separated role list, exact match per entry — a disclosed simplification, not real JSON parsing (no JSON parser is linked into `runtime-kernels`). `VerifiedIdentity` itself was already freely constructible; this is what makes a real `RoleView` obtainable at all. |
+| `check_role` | Yes | 2026-09, upgraded again 2026-09: `claims_json` is now tried as real JSON first (a top-level `"roles"` array), falling back to the original plain comma-separated-list matching only if that parse fails — so a `VerifiedIdentity` built directly in `.nir` source (a plain string, not JSON) still works unchanged. The JSON path is what `oidc_validate_token`'s own real claims now populate. |
+| `oidc_validate_token`/`extract_claim`/`identity_expired` | Yes | 2026-09. Real JWT/JWKS signature verification (`nir_oidc_validate_token`, `jsonwebtoken`-backed, same `kty`-locks-`alg` guard as `crates/presence-gateway/src/jwt.rs`) against a **static** JWKS (live rotation/refresh is a separate, deferred gap); real JSON claim extraction (`nir_extract_claim`). `identity_expired` needs no kernel — `now > identity.expires_at`, inline GEP+load+`icmp`. Deliberately **not** validating `exp` against the real wall clock inside `oidc_validate_token` itself — that stays `identity_expired`'s job with an explicit `now`, keeping the builtin a pure function of its inputs (§9). |
 | `nfr(...)` (§6f) | Yes | 2026-09. O(1) state per function — max-latency not p99, cumulative (not windowed) error-rate/throughput, exact concurrency. See §6f. |
 | `sandbox`/`stop` | No | Real, separate OS process — a larger scope than `thread`/`spawn` above, not touched by that update. |
 | `file`/`open` | No | `docs/PROTOLANG_PORT.md`'s file I/O port. |
 | `dec128` + `dec_*` builtins | No | Not yet in `Ty`/`codegen.rs`'s builtin allowlists. |
-| `json`/`db`/`mq`, `extract_claim`/`oidc_validate_token`/`mock_issue_token`, other Row 12 identity/session/API-key builtins | No | `check_role` (above) is the one identity builtin compiled so far; the rest are still blocked on `VerifiedIdentity`/`RoleView`/`ClaimView` being structs plus (for `oidc_validate_token`) real JWT/JWKS crypto. |
-| `http_get`/`http_post`/`https_get`/`https_post` | No | Not in `codegen.rs`'s builtin allowlists. |
-| `transact` | No | |
-| `workflow` | No | Desugars to `send_email`/`send_sms`/`send_push`/`notify`/`__workflow_*`, none compiled. |
-| `fn(..)->..`/`acquire`/`requires(role/claim: ...)` on a *function* | Yes | 2026-09. First-class/privileged functions (§6a) — a plain fn value is its own address, an acquired one is a real, hand-built `Result(fn(..)->.., str)`; calling either emits a real indirect call. `sandbox` scoping this exact mechanism is unrelated; `extract_claim`/`oidc_validate_token` (the claim/OIDC half of §6a's own example) remain interpreter-only-designed, so a claim-gated flow still doesn't run end to end. |
+| `db`, SQLite (`db_connect`/`db_query`/`db_execute`) | Yes | 2026-09. `rusqlite` `bundled`, statically linked. Postgres (layer 2, `dbconn.rs`) not yet in the compiled path. Bind values: `i64`/`f64`/`str`/`bool`; a zero-payload `enum` variant as a bind value is not yet compiled. |
+| `json` (`json_parse`/`json_get`/`json_get_*`/`json_array_*`/`json_set_str`) | Yes | 2026-09. Compiles as raw text (`Ty::Json`'s own `llvm_ty` arm), re-parsed by each accessor — no persisted parsed-tree handle. |
+| `check_role_path`/`extract_claim_path`, sessions/refresh/revocation/`validate_api_key` | No | `check_role`/`oidc_validate_token`/`extract_claim`/`identity_expired`/`db`/`json`/`mq`/`http`/`https` (above/below) are the builtins compiled so far; the dotted-path claim siblings and the rest of Row 12 (session/refresh-token/API-key lifecycle) remain real, narrower follow-up work. |
+| `mq` (Redis: `mq_connect`/`mq_publish`/`mq_consume`) | Yes | 2026-09. `redis` crate, real `LPUSH`/`BLPOP`. `mq_connect_via` (plugin-dispatched) is a separate mechanism. |
+| `http_get`/`http_post`/`https_get`/`https_post` | Yes | 2026-09. Real client, `Connection: close` + read-to-EOF + chunked-transfer-encoding decoding. HTTPS via vendored (not system) OpenSSL — see the HTTP/HTTPS section above. |
+| `transact` | Yes, Layer 1 only | 2026-09. `precheck?/network/verify/commit/compensate?/log?`, real control flow, a real `bool` result. `network`'s `retry`/`timeout` rejected explicitly (architectural: a compiled trap is `abort()`, unrecoverable, and `network`'s return type can never be `Result(_, _)` — no failure signal to retry on). Durability logging, crash replay, and `commit`/`compensate`'s own retry-with-backoff are real, disclosed follow-up work — see `docs/TRANSACT.md`. |
+| `workflow` | Yes, Layer 1 only | 2026-09. `start_*`/`advance_*`, `on_entry`/`on_exit`, ordinary transitions, and `terminal` states are real and compiled, with `Err(NoSuchTransition)`/`Err(InstanceNotFound)` as real, non-trapping results (`examples/features/52_compiled_workflow_state_machine.nir`). `send_email`/`send_sms`/`send_push`/`notify` compile too — real, authenticated HTTPS POSTs against an admin-editable provider row in a real SQLite table (`examples/features/53_compiled_workflow_notifications.nir`). `state { sla_seconds: N }` + `list_<workflow>_overdue()` (`docs/ROADMAP.md` A15) compile as well — real SLA/escalation *detection*, not automatic firing: an external scheduler still has to poll and call `advance_*` itself (`examples/features/54_compiled_workflow_escalation.nir`). Real, disclosed narrower cut than the interpreter-only design: a non-empty `data { ... }` block and any `link`-marked transition (`*_via_link` magic links) are explicitly rejected at compile time — this Layer 1 runtime has nowhere durable to persist a `data` value or a link token past the initial call — rather than silently miscompiled; the synthesized `pending_for_me`/`submitted_by_me`/`history` query fns compile but are always a real `Err` (same durable-storage gap); `owner:` state ownership isn't enforced at runtime yet; `notify` always takes the offline (`send_email`-fallback) path, since this compiled backend doesn't populate a real presence table. See `docs/WORKFLOW.md`'s own status section. |
+| `fn(..)->..`/`acquire`/`requires(role/claim: ...)` on a *function* | Yes | 2026-09. First-class/privileged functions (§6a) — a plain fn value is its own address, an acquired one is a real, hand-built `Result(fn(..)->.., str)`; calling either emits a real indirect call. `sandbox` scoping this exact mechanism is unrelated. `extract_claim`/`oidc_validate_token` (the claim/OIDC half of §6a's own example) are now real too (above), so a claim-gated flow driven by a genuine verified JWT runs end to end, not just the role-gated path. |
 | `screen`/`dashboard` | Inert, not rejected | `codegen.rs` never inspects these — a program containing them compiles cleanly with nothing to lower to. |
 
 **Scalar width mechanics.** Same LLVM widths as the signed types for
@@ -1366,7 +1409,8 @@ restart" shape `transact`'s own `network` slot already has
 replay_pending_workflow_actions` — called at `nirdosha serve` startup
 right alongside `replay_pending_transactions`).
 
-Interpreter-only, the same way `transact`/`db`/`mq` already are (§10):
+Not compiled yet, the same way `mq` isn't (§10; `transact`/`db` have since
+dropped off this list — Layer 1 and SQLite respectively, both 2026-09):
 `workflow`-desugared functions call builtins outside `codegen.rs`'s
 `PHASE4_BUILTINS`/`PHASE5_BUILTINS`/... allowlists, so `nirdosha build`/
 `emit-llvm` cleanly rejects a program using `workflow`, naming the

--- a/docs/PHASE0.md
+++ b/docs/PHASE0.md
@@ -1183,6 +1183,80 @@ passes through untouched, and a role the identity's `claims_json`
 doesn't carry at all fails at `check_role` itself, before a `RoleView`
 is ever produced.
 
+**Twenty-first update:** `fn(..)->..`/`acquire`/`requires(role/claim:
+...)` on a *function* — first-class and privileged functions,
+§6a — compiled for real, closing the one gap the Twentieth update's own
+closing line named ("`acquire`... still has zero codegen"). Two pieces,
+both new:
+
+*Ordinary first-class functions.* A bare top-level `fn` name used as a
+value (`apply(double, 21)`, no `requires(...)` involved) now evaluates
+to its own address — `codegen.rs::Expr::Ident`'s one new fallback, hit
+only when `name` isn't a local variable — and calling a `fn(..)->..`-
+typed value (a parameter, a match-bound name, anything) emits a real
+indirect call (`codegen.rs::call_indirect`), spelling out the full
+`<ret>(<params>)` function type LLVM requires at an indirect call site.
+`Ty::Fn` itself needed a real `llvm_ty` mapping for the first time
+(plain `ptr` — it's freely copyable and non-affine already, `Ty::
+is_affine`'s own doc comment says so, so nothing else about the
+ownership story had to change) and a dedicated `mangle_ty` case (its
+`Display` form contains `(`/`)`/`,`/`->`, none legal in an unquoted
+LLVM identifier — the generic fallback would have produced unparseable
+IR for `Result(fn(..)->.., str)`'s own synthesized name, caught by
+actually trying to link the output, not by inspection).
+
+*`acquire name(proof)`.* Builds a genuine `Result(fn(params) -> ret,
+str)` by hand — the same tag-then-payload shape `check_role`'s own
+compiled implementation already uses (`Ok(f)` stores the target
+function's real address as the payload; `Err(reason)` names exactly
+which requirement wasn't met), with the actual check itself
+(`emit_str_field_eq_check`, factored out of the Twentieth update's own
+`emit_requirement_check` so both a function-level proof and a
+field-masking proof share one implementation) identical to what
+field-masking already does: GEP to the proof's `role`/`value` field,
+`nir_str_eq` against the requirement's compile-time-known string.
+
+**A real, disclosed ordering constraint, found by actually compiling a
+`match` shaped this way, not by reading the codegen plan in advance:**
+`match_expr`'s own result type is inferred from its *first* arm's body
+— evaluated *before* that arm's own bindings exist in scope, a
+pre-existing property of `match_expr`'s design that simply never had a
+way to surface before now, since every previous arm binding was always
+a plain value used directly, never called *as a function*. `Ok(f) =>
+f(...)` written as a match's first arm hits this: `f` isn't bound yet
+at the point its type needs inferring, so the callee resolves to
+nothing and the match's whole result type comes out wrong. Not a
+compiler bug to fix here — reordering (`Err(...)` first) is a complete,
+correct workaround, and the real examples/tests below all use it.
+
+**Real, compiled-and-run verification**, matching every other update's
+own standard: `check_role_produces_real_role_view_that_drives_field_masking`'s
+function-level sibling, `acquire_produces_real_callable_fn_value_gated_by_check_role`
+(`crates/compiler/tests/codegen.rs`) — an identity that proves
+`get_employee`'s required role (`"hr_staff"`) gets a real, callable
+function back and a real return value from calling it; one that
+doesn't gets a real `Err`, never reaching `get_employee`'s body at all.
+`ordinary_first_class_function_value_compiles_and_calls_indirectly`
+covers the ungated half the same way. `examples/features/
+50_field_masking_and_check_role.nir` — the README's own hero example —
+now composes *both* mechanisms on one function: `get_employee
+requires(role: "hr_staff")` gates who can call it at all, `salary
+requires(role: "admin")` separately gates what a successful caller sees
+back, and the two roles are genuinely independent (an hr_staff member
+who isn't also an admin gets real records with `salary` redacted; an
+outsider who's neither can't obtain a callable `get_employee` in the
+first place).
+
+**Still real, still open, unaffected by this update:** `extract_claim`/
+`oidc_validate_token` (the claim/OIDC half of §6a's own worked example,
+`examples/features/33_privileged_functions.nir`) remain interpreter-
+only-designed with the interpreter now gone, so a claim-gated flow
+built on real JWT/JWKS validation still doesn't run end to end — only
+the role-gated, `check_role`-driven path does. The Phase-4b affine-in-
+struct/enum gap (a `struct`/`enum` whose payload transitively contains
+`box`/`&`/`thread`/`chan`/`tcp`/`file`/`db`/`mq`) is unrelated and still
+open, same as before.
+
 ---
 
 

--- a/docs/PHASE0.md
+++ b/docs/PHASE0.md
@@ -1257,6 +1257,465 @@ struct/enum gap (a `struct`/`enum` whose payload transitively contains
 `box`/`&`/`thread`/`chan`/`tcp`/`file`/`db`/`mq`) is unrelated and still
 open, same as before.
 
+**Twenty-second update:** a minimal compiled `serve` mode (ROADMAP.md
+Track B8) — the direct answer to "research prototype": a compiled
+Nirdosha binary now serves real HTTP traffic and dispatches to compiled
+business logic, self-contained, no interpreter. This was never actually
+gated on `db`/`json`/identity landing first (Track B's own sequencing
+was a policy choice, not a technical one) — `tcp`/`tcp_listener` were
+already fully compiled with a real OS accept loop, the only missing
+piece was a way to parse an HTTP request line at all.
+
+*Three new string primitives*, deliberately minimal (`docs/LANGUAGE.md`
+§5/§10) — not a general string library: `len(s: str) -> i64` (extends
+the existing Vector-only `len`, an `extractvalue` on `str`'s own
+`{ptr, i64}` representation, no kernel call); `str_slice(s, start, end)
+-> str` (pure pointer arithmetic — `getelementptr` + a new bounds-check
+trap, `codegen::guard_str_bounds_ok`, modeled on `guard_io_ok`/
+`guard_recv_ok`'s own abort-after-flight-recorder-dump idiom); and
+`str_index_of(haystack, needle) -> i64`, the one genuine byte-scan, the
+only one of the three backed by a real linked kernel
+(`nir_str_index_of`, `runtime-kernels/src/lib.rs`, parallel to
+`nir_str_eq`). No `split`/`starts_with`/`trim`/string-concatenation —
+tokenizing a request line is `str_index_of` + `str_slice` composed a
+few times in `.nir` source, and path routing is a plain `.nir`
+`if`/`else if` chain against the already-existing `==` — genuinely no
+new language construct anywhere in this update.
+
+**`examples/features/51_compiled_serve.nir`** — hand-parses `METHOD SP
+PATH SP VERSION\r\n...` and routes `/api/<fn>` to two distinct compiled
+`fn`s (`handle_hello`/`handle_echo`) inside a real `while true { accept
+... }` loop, GET-only, one request per connection, `Connection: close`
++ a real socket close as the end-of-body signal (no `Content-Length` —
+the same simplifying cut the existing client-side `http_get` builtin
+already made, mirrored from the other side). Unlike every other file in
+the catalogue, its own accept loop never returns, so it's meant to be
+run standalone and driven with a real `curl`, not read to completion by
+itself — and it was: `curl` against a running compiled binary produced
+distinct, correct bodies from `/api/hello` and `/api/echo`, and a real
+404 from an unrouted path.
+
+**Real, compiled-and-run verification**, same standard as every update
+above: `crates/compiler/tests/codegen.rs`'s
+`compiled_serve_routes_by_path_to_two_compiled_functions` spawns the
+compiled binary (its `accept` blocks, so it runs in its own process,
+`compiled_listen_accept_serves_a_real_client`'s own template), drives
+two real `std::net::TcpStream` requests against the one running
+process, and asserts the two routes produce two different real bodies
+plus a real 404 for an unknown path — not a mock, not a typecheck-only
+test. `str_slice_and_str_index_of_parse_a_request_line` and
+`str_slice_traps_on_out_of_bounds_end` cover the three primitives (and
+their trap) directly.
+
+**Still real, still open, unaffected by this update:** POST/request-
+body handling (`Content-Length`-driven parsing), keep-alive/pipelining,
+concurrent connection handling (`spawn`-per-connection), string
+concatenation, and everything else in Track B (`db`/`transact`/`mq`/
+`json`/`http`-client-server/`workflow`/`sandbox`).
+
+**Twenty-third update:** real identity crypto — `oidc_validate_token`/
+`extract_claim`/`identity_expired` compiled for real (ROADMAP.md B4),
+closing the exact gap the Twenty-first update's own closing line named
+("`extract_claim`/`oidc_validate_token`... remain interpreter-only-
+designed with the interpreter now gone, so a claim-gated flow... still
+doesn't run end to end"). It does now.
+
+*`nir_oidc_validate_token`* (`runtime-kernels/src/lib.rs`) ports
+`crates/presence-gateway/src/jwt.rs`'s exact JWKS-verification shape —
+same new dependency set (`jsonwebtoken`/`serde`/`serde_json`/`base64`)
+and, critically, its one load-bearing security detail: a JWK's own
+`kty` locks which algorithm it may verify under (RSA→RS256, EC-P256→
+ES256, oct→HS256), never derived from the token's own `alg` header —
+closes the classic algorithm-confusion attack, ported rather than
+re-derived. Deliberately **not** validating `exp` against the real
+wall clock inside this builtin, unlike `jwt.rs::verify` (a live network
+boundary, where that split is correct) — a compiled `.nir` builtin
+stays a pure function of its inputs (§9), so expiry is
+`identity_expired(identity, now)`'s job given an explicit `now`.
+`VerifiedIdentity` has six fields (unlike `RoleView`'s one), so
+`codegen::emit_oidc_validate_token` writes the kernel's out-params
+**directly into a scratch `VerifiedIdentity`'s own field pointers**
+(`field_index_and_ty`, the same helper `emit_check_role` already uses
+to *read* `claims_json`) rather than double-buffering, then `memcpy`s
+the whole struct into the `Result`'s payload on success — the same
+"GEP to the field, no intermediate copy" discipline
+`construct_variant`'s generic aggregate-payload path already uses.
+
+*`nir_check_role` upgraded alongside this*, same signature, no
+`codegen.rs` change needed: tries `claims_json` as real JSON first (a
+top-level `"roles"` array), falling back to the original plain
+comma-separated matching on parse failure — so
+`check_role_produces_real_role_view_that_drives_field_masking`'s own
+existing test fixture (`VerifiedIdentity` built directly with
+`claims_json = "admin,editor"`, not JSON) keeps working unchanged,
+while `oidc_validate_token`'s own real JSON claims now check out
+correctly too. `nir_extract_claim` is new, structurally identical to
+`nir_check_role`/`emit_check_role`'s shape (one kernel call, a
+bool-shaped status, a single `str` payload on success).
+
+**A real, pre-existing, documented codegen limitation surfaced again,
+not introduced here:** the Twenty-first update's own `match_expr`
+ordering caveat (a match's result type is inferred from its *first*
+arm's body, evaluated before that arm's own bindings exist in scope) —
+`examples/features/30_identity_oidc.nir`'s own fixture writes
+`Ok(id) => id` as its first arm, which hits exactly this; the complete,
+correct workaround (`Err(...)` first) is the same one already
+documented, applied again here rather than re-investigated.
+
+**Real, compiled-and-run verification**: a genuine HMAC-SHA256 JWT
+(the same fixture `examples/features/30_identity_oidc.nir`/
+`31_mock_identity_provider.nir` already use — `kid:"key1"`,
+`kty:"oct"`, secret `"my-secret-key"`), verified end to end in a
+compiled binary —
+`oidc_validate_token_verifies_a_real_jwt_and_drives_check_role_and_extract_claim`
+(`crates/compiler/tests/codegen.rs`): real subject/issuer/audience
+extracted, `check_role`/`extract_claim` reading the real JWT claims
+correctly, `identity_expired` correct for both a far-future and a
+just-past `now`, a wrong-issuer token and a tampered-signature token
+both real `Err`s, never a trap. `runtime-kernels`' own
+`identity_kernel_tests` module covers the pure verification logic
+directly (valid/tampered/wrong-issuer/wrong-audience/unknown-`kid`/
+malformed-JWKS, plus `check_role`'s JSON-vs-comma-separated paths and
+`extract_claim`'s found/not-found cases).
+
+**Still real, still open, unaffected by this update:** `check_role_path`/
+`extract_claim_path` (dotted-path claim lookup), live JWKS refresh/
+rotation (static JWKS only), sessions/refresh tokens/revocation/
+`validate_api_key`, and everything else in Track B.
+
+**Twenty-fourth update:** `db` (SQLite) + `json` compiled for real
+(ROADMAP.md B2) — real ecosystem crate this time, not a from-scratch
+port: `rusqlite`'s `bundled` feature (already the root workspace's own
+choice, `crates/compiler/Cargo.toml`), statically linked into
+`runtime-kernels` the same way `jsonwebtoken` was for Phase 1.
+
+*A real design decision, made rather than deferred*: `Ty::Json` compiles
+as the raw JSON text itself — the same `{ptr, i64}` representation
+`Ty::Str` already has — not a persisted parsed-tree handle the way the
+(now-deleted) interpreter's `Value::Json(Arc<serde_json::Value>)` was.
+Every `json_get_*`/`json_array_*` accessor re-parses that text on every
+call via a linked `nir_json_*` kernel (`serde_json`, already linked in
+for Phase 1's JWT claims). The cost is real (re-parsing instead of a
+cached tree) and disclosed, not hidden — the win is zero new runtime
+value type: `db_query`'s own result just *is* a `str`-shaped value with
+a different type tag, exactly the design this item's own doc comment
+anticipated ("rows ride as `str`, JSON-encoded... avoids building a
+from-scratch runtime JSON representation twice").
+
+*A real handle-table reuse, not a new mechanism*: a `db` connection
+rides through `kernel::HandleTable<rusqlite::Connection>` (`db_table()`)
+— the same generic table `kernel/mod.rs` had already built, unused,
+"for the next resource domain... whose handle isn't already a raw OS
+fd," specifically anticipating this. `Domain::Db` is a new admission-
+control domain, appended after `Thread` (not inserted earlier) so every
+existing `Domain as u8` flight-recorder discriminant stays stable.
+
+*Bind values* (`db_execute`/`db_query`'s trailing `?`-placeholder args):
+`codegen::emit_db_binds` builds a `[N x NirBindValue]` array, one
+element per bind arg, tagged by that arg's own static type
+(`i64`/`f64`/`str`/`bool`) — a small `#[repr(C)]` tagged-union struct,
+non-packed so ordinary C/LLVM natural-alignment layout applies on both
+the Rust and generated-IR sides identically, the same "trust the
+target's own layout rules" stance `agg_byte_size_operand`'s sizeof trick
+already takes. A zero-payload `enum` variant as a bind value (part of
+the original design) isn't compiled yet — named, not silently dropped.
+
+**A real, found-by-testing gap, not designed in advance**: SQLite has no
+native boolean storage class, so a bound `bool` round-trips through
+`db_query` as a plain JSON *number* (`0`/`1`), never a JSON boolean —
+`json_get_bool`'s original strict "must be a real JSON `true`/`false`"
+check would have made it and `db` unusable together for any boolean
+column. `nir_json_get_bool` now accepts both shapes; any other integer
+is still a real `Err`, not silently coerced.
+
+**Real, compiled-and-run verification**: `examples/features/
+27_database.nir` — an *existing, unmodified* file, previously
+typechecked but with zero execution path of any kind (no interpreter
+left, no codegen) — now compiles and runs against a real in-memory
+SQLite database: schema creation, two parameterized inserts, a filtered
+`SELECT` navigated through `json_array_get`/`json_get_str`, an update,
+and a connection failure that's a real `Err`, never a trap
+(`db_connect_execute_query_round_trips_real_sqlite_rows`,
+`crates/compiler/tests/codegen.rs`). A second test exercises every
+other `json_*` accessor (`json_get_i64`/`_f64`/`_bool`,
+`json_array_len`, `json_set_str`, `json_get`, `json_parse`) against a
+real `db_query` result and plain literals.
+
+**A real, pre-existing, documented codegen limitation surfaced a second
+time, not introduced here**: the same `match_expr` first-arm-inference-
+order gap the Twenty-third update's own verification hit — this time
+for plain scalar payloads (`str`/`bool`/`f64`), not just an aggregate
+struct. `local_ty_of`'s `Expr::Ident` fallback is unconditionally
+`Ty::I64` when a name isn't bound yet, which happens to be *correct* by
+coincidence whenever the real first-arm type also is `i64` (as
+`db_execute`'s own `Ok(n) => n` already was, `27_database.nir`'s own
+existing arm order) — but wrong, and IR-invalid, for any other scalar
+type (`Ok(f) => f`, `Ok(b) => b`, `Ok(s) => s` as a match's *first*
+arm). The complete, correct workaround is unchanged: put whichever arm
+is a bare bound identifier *second*, not first — a literal or
+constructor first arm resolves correctly regardless of scope. Applied
+throughout the new tests above; not a compiler bug fixed in this
+update.
+
+**Still real, still open, unaffected by this update:** Postgres (layer
+2 — `dbconn.rs` no longer exists at all, removed with the interpreter),
+a zero-payload `enum` bind value, `BLOB` columns (no `bytes` type —
+represented as JSON `null`), `mq`/`http`/`https`/`transact`/`workflow`/
+`sandbox`, and the rest of Track B.
+
+**Twenty-fifth update:** `transact` Layer 1 compiled for real
+(ROADMAP.md B1) — the same layer the now-deleted interpreter itself
+shipped *first*, before retry/timeout/durability/replay
+(`docs/TRANSACT.md`'s own "layers, not a syntax spec" section). Real
+control flow: `precheck?/network/verify/commit/compensate?/log?`, the
+implicit `network`/`verify`/`txn_id` bindings (resolved through the
+ordinary `Expr::Ident`/`Scopes` mechanism — no special-casing needed
+there, `call_args`'s existing per-argument evaluation already handles
+it once each binding's own stack slot is registered), a real `i1`
+result exactly as documented (`true` if `commit` ran, `false` if
+`compensate` ran or would have). `txn_id` is a real, always-unique
+value now too (`nir_transact_gen_txn_id` — process id + a coarse
+timestamp + an atomic sequence number, hex-formatted; not
+cryptographically unpredictable, and doesn't need to be — its only job
+is deduping a resend, and no crash-replay mechanism exists yet to give
+it a reason to survive a restart).
+
+**A genuine architectural finding, not a scope choice made in
+advance**: `network`'s `retry`/`timeout` modifiers turned out to be
+impossible to give real compiled semantics to, not merely deferred.
+The deleted interpreter's retry-on-trap logic depended on catching its
+own internal `RuntimeError` before it ever unwound out of the
+interpreter — a compiled trap has no such thing, it's an unconditional
+`abort()` (every `guard_*` in `codegen.rs`), full stop. The natural
+fallback — react to a `Result::Err` return instead of a trap, the same
+rule `docs/TRANSACT.md`'s own §1b already uses for `commit`/`compensate`
+— doesn't apply to `network` specifically: its declared return type is
+restricted to a bare scalar by `Ty::is_transact_scalar` (already
+locked, not something this update touched), which by definition
+excludes `Result(_, _)`. So there is no non-trapping signal of any kind
+for `network` to retry on in the compiled model — not "not yet built,"
+genuinely not expressible without either giving compiled traps a
+catchable/unwinding semantics (a much larger, unrelated language
+change) or loosening `is_transact_scalar`'s own durability-boundary
+rule. `check_expr`'s pre-pass rejects `retry`/`timeout` on `network`
+explicitly, with this exact reasoning in the error message, rather than
+silently ignoring the modifiers or miscompiling something that looks
+like it retries but doesn't.
+
+`commit`/`compensate`'s own return types stay genuinely unconstrained
+(`docs/TRANSACT.md`'s own deliberate design), so retry-with-backoff
+*is* structurally possible there — a new `sleep_ms` kernel
+(`nir_sleep_ms`, closing `docs/ROADMAP.md`'s own B9 in passing) exists
+for exactly that future use, but building and carefully verifying the
+backoff-then-trap-on-exhaustion loop itself was real, separate scope
+this update didn't attempt — a named follow-up, not a partial or buggy
+attempt left in the tree.
+
+**Real, compiled-and-run verification**: `examples/features/
+36_transact.nir` — an *existing, unmodified* file, previously
+typechecked but with zero execution path (no interpreter, no codegen)
+— now compiles and runs: `checkout(10)` commits (`verify` true),
+`checkout(-5)` compensates (`verify` false), `minimal(1)` (no
+`precheck`/`compensate`/`log` slot at all) commits
+(`transact_commits_and_compensates_for_real_matching_the_checked_in_example`,
+`crates/compiler/tests/codegen.rs`). Three more tests cover
+`precheck == false` skipping every other slot entirely, `verify ==
+false` with no `compensate` slot yielding `false` with nothing else to
+run, and `network retry 3` producing the specific, real rejection
+message above rather than a generic error or silent no-op.
+
+**Still real, still open, unaffected by this update:** `network`'s
+`retry`/`timeout` (architecturally blocked, above), `commit`/
+`compensate`'s own retry-with-backoff, the durability log
+(`transact_log.rs`, deleted with the interpreter), crash replay, and
+everything else in Track B (`mq`/`http`/`https`/`workflow`/`sandbox`).
+
+**Twenty-sixth update:** `mq` (Redis, B3) and `http`/`https` (B5)
+compiled for real — real ecosystem crates again, not from-scratch ports:
+`redis` and `native-tls`, the same two the root workspace's own
+`crates/compiler/Cargo.toml` already pinned for the (now-deleted)
+interpreter's identical job.
+
+*`mq_connect`/`mq_publish`/`mq_consume`* ride through
+`kernel::HandleTable<redis::Connection>` (`mq_table()`), the same shape
+`db_table()` already established — a new `Domain::Mq` admission
+ceiling, appended after `Domain::Db` so existing discriminants stay
+stable. `LPUSH`/`BLPOP` back publish/consume exactly as the original
+design specified. Verified against a real local Redis instance (not a
+mock): `mq_publish_and_consume_round_trip_a_real_message`
+(`crates/compiler/tests/codegen.rs`) and `runtime-kernels`' own
+`mq_kernel_tests`. `examples/features/28_message_queue.nir` itself
+still doesn't compile as-is — `Ok(m) => m` as `mq_consume`'s first arm
+hits the same pre-existing `match_expr` ordering gap the identity work
+already found and worked around; the file is unmodified, matching this
+track's own "don't touch existing examples to route around a
+documented, separate limitation" practice.
+
+*`http_get`/`http_post`/`https_get`/`https_post`* needed no new `Ty` at
+all — `HttpResponse` was already a plain prelude struct, and every call
+is a one-shot request/response, never a persisted handle. Request/
+response handling (`Connection: close` + read-to-EOF) is exactly the
+already-locked design from before this backend existed; `https_get`/
+`https_post` wrap the identical logic in a `native_tls::TlsStream`.
+
+**Two real things found by actually testing this, not designed in
+advance:**
+
+1. **System OpenSSL didn't link.** The first compiled binary using
+   `https_get` failed at the link step — this environment's system
+   `libssl` doesn't export symbols (`SSL_ctrl`/`SSL_CTX_ctrl`/
+   `X509_LOOKUP_ctrl`) the resolved `openssl-sys` version expects, a
+   real ABI mismatch, not a hypothetical portability concern. Fixed by
+   adding a direct `openssl = { features = ["vendored"] }` dependency to
+   force Cargo's feature unification to statically compile and link
+   OpenSSL from source instead — the exact "no system dependency"
+   posture `rusqlite`'s own `bundled` feature already gives SQLite,
+   given to TLS too, for the same self-contained-deployment reason.
+   `docs/ROADMAP.md`'s own B5 entry had flagged "vendored vs. system" as
+   a decision to make deliberately, not silently; this is that decision,
+   forced by a real failure rather than made in the abstract.
+2. **Chunked transfer-encoding needed real decoding, not a documented
+   gap.** A real HTTPS `GET` against `example.com` (a genuine production
+   server, not a local mock) came back with raw `<hex-size>\r\n...`
+   chunk framing still in the body — `example.com` chunks by default,
+   and a large fraction of real HTTP servers do too. Unlike skipping
+   `Content-Length` parsing (redundant once every request already reads
+   to EOF), an undecoded chunked body is a visibly, materially wrong
+   result for ordinary real-world use, not an acceptable "first cut"
+   simplification — so `decode_chunked_body` was added:
+   `Transfer-Encoding: chunked` is detected from the response headers,
+   and the hex-size/data/CRLF chunk sequence is decoded for real. Any
+   other transfer encoding is left as-is (the original, narrower scope,
+   still honestly disclosed).
+
+A third design decision, made rather than deferred: a `Ty::Unit`-payload
+`Result` variant binding (`mq_publish`'s own `Result(unit, str)`,
+`Ok(u) => true`) turned out to `alloca void`/`load void` — both invalid
+LLVM IR, a genuine pre-existing `match_enum`/`Expr::Ident` gap, not
+specific to `mq` at all (simply never exercised before, since no
+earlier compiled builtin's `Ok` variant bound a bare `unit` payload).
+Fixed at both sites: `match_enum`'s per-arm binding loop skips the
+alloca/load/store dance entirely for a `Ty::Unit` field, and
+`Expr::Ident`'s own read path short-circuits to the same placeholder
+`"0"` value every other unit-shaped result in this file already uses,
+rather than trying to load one back.
+
+**Real, compiled-and-run verification**: `mq_publish_and_consume_
+round_trip_a_real_message` and `http_get_and_post_round_trip_against_
+a_real_local_server` (`crates/compiler/tests/codegen.rs`) — a real
+Redis publish-then-consume round trip and a real local-TCP-server
+HTTP GET/POST round trip (verifying the request the server actually
+received carried a real `Content-Length` header and body), plus a
+manual, network-dependent HTTPS `GET` against `example.com` proving the
+vendored-TLS + chunked-decoding path end to end. `runtime-kernels`' own
+`mq_kernel_tests`/`http_kernel_tests` cover the kernels directly,
+including chunked-body edge cases (empty body, truncated input,
+non-chunked bodies left untouched).
+
+**Still real, still open, unaffected by this update:** `mq_connect_via`
+(the separate, plugin-dispatched external-service-boundary mechanism),
+`workflow`, `sandbox`, and `transact`'s own still-open remainder
+(durability log, crash replay, `commit`/`compensate` retry-with-backoff).
+
+**Twenty-seventh update:** `workflow` (B10, Phase 5) compiled for real —
+Layer 1 only, same "layers, not a syntax spec" framing Twenty-fifth
+update's `transact` already established for itself.
+
+*`start_<workflow>`/`advance_<workflow>`, `on_entry`/`on_exit`, ordinary
+transitions, `terminal` states* (`codegen.rs`'s `resolve_workflow_layer1`/
+`emit_workflow_action`/`emit_workflow_start`/`emit_workflow_advance`)
+needed no new `Ty` at all — `workflow_lower.rs` already desugars a
+`workflow` block into ordinary `fn`/`enum`/`struct` declarations before
+codegen ever sees it, so this backend's job was making those
+already-synthesized functions compile, not inventing new codegen for
+`workflow` syntax itself. `__workflow_pending_for_me`/
+`__workflow_submitted_by_me`/`__workflow_history` (synthesized
+unconditionally for *every* workflow, whether or not it's ever called)
+get real, compiled, always-`Err` bodies instead — rejecting them at
+compile time would break every workflow, not just ones that call them.
+`__workflow_link_advance` stays compile-time-rejected (it only exists
+for a workflow with a `link`-marked transition, so this narrows
+correctly, unlike the three query fns above).
+
+*`send_email`/`send_sms`/`send_push`/`notify`* (`emit_send_notification`/
+`emit_notify`/`emit_notify_result`) needed one real ownership-checker fix
+beyond straightforward codegen: `notify(conn: db, mq: Mq, ...)` has *two*
+connection-shaped arguments, but `ownership.rs`'s existing "a builtin's
+leading connection argument is read, not consumed" exemption
+(`db_query`/`db_execute`/`send_email`/... already had it) only ever
+checked argument index 0 — `notify`'s own `mq` argument at index 1 was
+silently treated as a consuming move on every call, so `stop mq_conn`
+right after a `notify(...)` call in the same function was a real (if
+surprising) `use after it was moved` error. Fixed by adding the matching
+`i == 1 && name == "notify"` exemption, general and not workflow-file-
+specific, the same way the two match-arm-routing fixes below Twenty-
+fifth update already were.
+
+*`state { sla_seconds: N }` + `list_<workflow>_overdue()`* (A15,
+`emit_workflow_overdue`) is new surface, not just newly-compiled old
+surface — `workflow_lower.rs` only synthesizes `list_<workflow>_overdue`
+for a workflow that declares at least one `sla_seconds` entry (the same
+"unused feature costs nothing" convention `LinkToken` already follows),
+and the compiled query reports every instance whose *current* state
+declares `sla_seconds` and whose time-in-state has passed it — real SQL
+over the same durable `workflow_instance` store, not a new one. Detection
+only: nothing in the language fires an escalation automatically, so a
+caller (an external scheduler, or — in
+`examples/features/54_compiled_workflow_escalation.nir` — `main` itself,
+standing in for one) still has to poll this and call `advance_<workflow>`
+to actually escalate.
+
+**A second real, general compiler bug found by writing the third example
+file, not designed against in advance:** `codegen.rs::match_expr`'s
+`result_ty = self.local_ty_of(&arms[0].body, scopes)` runs *before*
+`match_enum` binds any arm's own payload into scope. When `arms[0]`'s
+body is a bare identifier the match itself just bound — `Ok(v) => v`
+written as the *first* arm, rather than second — `local_ty_of` can't
+find `v` in scope yet and silently falls back to its `Ty::I64` default,
+miscompiling a `bool`-producing match into an `i64`-typed result slot.
+Caught by clang rejecting the resulting IR (`'%v.val' defined with type
+'i1' but expected 'i64'`) while building
+`54_compiled_workflow_escalation.nir`, not a silent wrong answer — but a
+real miscompile all the same, and not workflow-specific (any `match`
+whose first arm is a bound identifier can hit it). Not fixed in
+`codegen.rs` itself this round — worked around the same way
+`52_compiled_workflow_state_machine.nir`'s own `advance_now` call sites
+already do, by ordering the arm whose body doesn't depend on the match's
+own bindings first (`Err(e) => false` before `Ok(v) => v`). A real fix
+(`local_ty_of` should try every arm, not just `arms[0]`, and prefer
+whichever one it can actually resolve) is named here, not attempted, the
+same "narrow, disclosed" posture the pre-existing aggregate-arm
+`expr_ptr`/`expr_ptr_expected` gap already has.
+
+**Real, compiled-and-run verification**: three new example files, each
+built and run for real, output inspected, not just typechecked —
+`52_compiled_workflow_state_machine.nir` (state machine, `on_entry`/
+`on_exit`, `terminal`, `Err(NoSuchTransition)`/`Err(InstanceNotFound)`),
+`53_compiled_workflow_notifications.nir` (all four notification builtins
+against a real self-hosted `tcp_listener` standing in for the provider,
+real `Authorization: Bearer` header and JSON body over the wire, plus the
+real not-configured `send_push` path), `54_compiled_workflow_escalation.nir`
+(SLA detection + a real external-scheduler-style escalation round trip).
+Five new `crates/compiler/tests/codegen.rs` tests cover the same ground
+at the test-suite level: `workflow_start_advance_runs_on_entry_on_exit_and_reaches_a_terminal_state`,
+`workflow_on_entry_send_email_posts_to_a_real_configured_provider`,
+`workflow_list_overdue_reports_a_real_stale_instance_and_ignores_states_with_no_sla`,
+`workflow_with_a_data_block_is_explicitly_rejected_not_silently_dropped`,
+`workflow_link_marked_transitions_are_explicitly_rejected_not_silently_dropped`.
+Full regression: `cargo test -p nirdosha` (every test file green, 108/108
+in `tests/codegen.rs`) and `cargo test` from inside
+`crates/runtime-kernels`'s own separate `[workspace]` root (84/84,
+`--skip kernel::recorder`).
+
+**Still real, still open, unaffected by this update:** a non-empty
+`data { ... }` block and `link`-marked (magic-link) transitions stay
+explicitly rejected — this Layer 1 runtime has nowhere durable to
+persist either past the initial call; `owner:` state ownership is parsed
+but not enforced at runtime; `notify` always takes the offline
+(`send_email`-fallback) path (no presence table populated by this
+compiled backend); `sandbox`, and `transact`'s own still-open remainder,
+unaffected by this update either.
+
 ---
 
 

--- a/docs/PUBLIC_ROADMAP.md
+++ b/docs/PUBLIC_ROADMAP.md
@@ -6,7 +6,29 @@ contribute — the full internal tracker, with verification detail and
 session-by-session notes, is [`docs/ROADMAP.md`](./docs/ROADMAP.md).
 
 Status tags: `[DONE]` (verified — tests pass or run end-to-end),
-`[PARTIAL]` (real progress, gap named), `[OPEN]` (scoped, not started).
+`[PARTIAL]` (real progress, gap named), `[OPEN]` (scoped, not started),
+`[NOT RUNNABLE]` (real, working code as of when it was built and
+verified — against the now-deleted interpreter — but not reachable in
+any form today; added 2026-09, see the callout just below).
+
+> **2026-09 — read every "interpreter-only"/"interpreted path" note
+> below as historical, not current.** The tree-walking interpreter
+> (`run`/`serve`) was removed entirely in a separate pass this session —
+> there is no interpreted fallback left at all. A `[DONE]` item below
+> tagged "interpreter-only" was real and verified *when it was written*,
+> but isn't runnable in *any* form today, compiled or otherwise, until
+> Track B's native codegen actually reaches it — a strictly worse
+> statement than "falls back to the interpreter." Track A's own framing
+> ("gates building critical apps on the interpreted path") is fully
+> moot for the same reason. What changed this session, fully compiled
+> and verified end to end: `check_role` (real identity, an unforgeable
+> `RoleView`), field-level `requires(role/claim: ...)` masking, function-
+> level `requires(role/claim: ...)` + `acquire` (first-class/privileged
+> functions), and `nfr(...)` (non-functional requirements as a compiled
+> fn annotation with real APM-kernel tracking + escalation) — see
+> `docs/LANGUAGE.md` §6a/§6e/§6f/§10 and `docs/PHASE0.md`'s "Twentieth"/
+> "Twenty-first" updates for the full detail this list doesn't yet
+> reflect below.
 
 ---
 
@@ -32,56 +54,96 @@ Status tags: `[DONE]` (verified — tests pass or run end-to-end),
   within 1.4× of `gcc -O2` on scalar benchmarks
 - [DONE] `validate <fn_name> { pre: ... post: ... }` — real Hoare
   contracts on a function: a Z3-backed static proof that hard-fails the
-  build on a genuine counterexample where it can reach one, plus an
-  unconditional runtime check on every actual call as the backstop for
-  everything it can't (most real functions) — see `docs/ROADMAP.md` Track F,
-  F3
+  build on a genuine counterexample where it can reach one, for
+  Tier-1-provable (integer-only) functions. The dynamic runtime-check
+  backstop this bullet used to describe for everything Tier-1 can't
+  prove no longer exists (it lived in the now-deleted interpreter) —
+  see `docs/LANGUAGE.md` §16 for the current, honest split.
+
+**Identity, data protection, and non-functional requirements** (2026-09,
+compiled, no interpreter involved at any point)
+- [DONE] `check_role(identity, role)` against a real `VerifiedIdentity`,
+  producing a genuine, unforgeable `RoleView` — `RoleView`/`ClaimView`
+  can't be directly constructed by a `.nir` program
+- [DONE] Field-level `requires(role/claim: ...)` masking — a struct
+  field zeroes itself on every `return` unless the returning function's
+  own `RoleView`/`ClaimView` parameter proves it, fail-closed
+- [DONE] Function-level `requires(role/claim: ...)` + `acquire` —
+  first-class/privileged functions: a gated `fn`'s value is obtainable
+  only via `acquire name(proof)`, a real `Result(fn(..)->.., str)`
+  checked against a real proof; calling any `fn(..)->..`-typed value
+  (gated or not) is a real indirect call
+- [DONE] `nfr(latency_ms:/error_rate_max:/throughput_min_per_sec:/
+  concurrency_max:)` — non-functional requirements as a first-class fn
+  annotation, tracked automatically via the APM kernel with async
+  escalation to `NIRDOSHA_OBSERVABILITY_URL` on a crossed threshold
 
 **Backend/services**
-- [DONE] `db` (SQLite + Postgres), `json`, `http`/`https`, `mq` (Redis)
-  — interpreter-only today, see Track B below
-- [DONE] Identity — OIDC/JWT validation, roles/claims,
-  `requires(role:...)`, an admin-editable role-mapping cache (IdP role
-  names → app role names)
-- [DONE] `transact` — durable transactions (WAL, crash replay, retry/
-  timeout, idempotency)
-- [DONE] `workflow` — durable state machines with email/SMS/push
+- [NOT RUNNABLE] `db` (SQLite + Postgres), `json`, `http`/`https`, `mq`
+  (Redis) — no codegen yet; see Track B below
+- [NOT RUNNABLE] Identity — OIDC/JWT validation (`oidc_validate_token`),
+  claims (`extract_claim`), an admin-editable role-mapping cache (IdP
+  role names → app role names). `check_role` +
+  `requires(role/claim:...)`/`acquire` are the exception, now fully
+  compiled — see the identity section above.
+- [NOT RUNNABLE] `transact` — durable transactions (WAL, crash replay,
+  retry/timeout, idempotency)
+- [NOT RUNNABLE] `workflow` — durable state machines with email/SMS/push
   notification actions
-- [DONE] Auto-generated, additive-only DB schema migrations
+- [NOT RUNNABLE] Auto-generated, additive-only DB schema migrations
 
-**UI engine**
+**UI engine** — the `nirdosha emit-ui` half (static HTML derived from
+`struct`/`screen`/`dashboard` conventions, no live backend) is real and
+runs today; everything below tagged `[NOT RUNNABLE]` depended on the
+now-deleted `nirdosha serve` for its *live*, server-enforced half —
+`emit-ui` still generates the corresponding markup/hints, but nothing
+runs behind it.
 - [DONE] Zero-syntax CRUD + dashboard inference from `struct`/fn naming
-  conventions — no UI code needed for the common case
+  conventions, via `emit-ui` — static markup, no UI code needed for the
+  common case
 - [DONE] `screen`/`dashboard`/`module` DSL for the cases naming
-  conventions can't express
-- [DONE] Field-level RBAC (`view`/`edit` role/claim gates) and format
-  validation (`pattern`/`format`/`min`/`max`) — enforced server-side,
-  not just hidden in the client
+  conventions can't express — `emit-ui` reads these into the same
+  static markup
+- [NOT RUNNABLE] Field-level RBAC (`view`/`edit` role/claim gates) and
+  format validation (`pattern`/`format`/`min`/`max`) *enforced
+  server-side* — `emit-ui` still emits the client-side hide/disable
+  hints, but there's no server left to enforce anything behind them.
+  Field-level `requires(role/claim:...)` masking (identity section
+  above) is a different, newer, compiled mechanism that *does* enforce
+  for real today, just not through this UI-layer gate.
 - [DONE] Design-token theming (`--theme`) with live reload — color
-  ramps, motion, dark-mode strategy, layout shell, all optional
-- [DONE] `workspace`/`panel` — composite multi-pane screens composing
-  fields/lists from several structs onto one page (`docs/LANGUAGE.md` §15)
-- [DONE] `visual`/`render` — graph, heatmap, and timeline views on a
-  dashboard or inside a panel, on top of the existing bar-chart-only
-  `chart` (`docs/LANGUAGE.md` §11c)
-- [DONE] `field { render: "countdown" }` — a live SLA countdown chip on
-  a table field, ticking client-side with zero added network traffic
-  (`docs/LANGUAGE.md` §11)
-- [DONE] `action { show_result: true }` — a "Simulate"/"Preview" action
-  shows its own JSON return value in a modal instead of just refreshing
-  the row (`docs/LANGUAGE.md` §11)
-- [DONE] A workflow stage stepper — a real `●━●━○━○` progress stepper
-  on a workflow queue row instead of a bare state-name badge, no syntax
-  change (`docs/LANGUAGE.md` §14)
-- [DONE] `examples/ctms/ctms.nir` — all of the above proven together
-  against a real 89-screen enterprise app spec (a Counter-Terrorism
-  Financing & Transaction Monitoring System), not just in isolation —
-  see `docs/ROADMAP.md` Track E6
+  ramps, motion, dark-mode strategy, layout shell, all optional (a
+  static-generation-time concern, unaffected by `serve`'s removal)
+- [NOT RUNNABLE] `workspace`/`panel` — composite multi-pane screens
+  composing fields/lists from several structs onto one page
+  (`docs/LANGUAGE.md` §15) — needs the live multi-source data `serve`
+  provided
+- [NOT RUNNABLE] `visual`/`render` — graph, heatmap, and timeline views
+  on a dashboard or inside a panel, on top of the existing bar-chart-only
+  `chart` (`docs/LANGUAGE.md` §11c) — needs live query data
+- [NOT RUNNABLE] `field { render: "countdown" }` — a live SLA countdown
+  chip on a table field, ticking client-side with zero added network
+  traffic (`docs/LANGUAGE.md` §11) — needs a live table row to attach to
+- [NOT RUNNABLE] `action { show_result: true }` — a "Simulate"/"Preview"
+  action shows its own JSON return value in a modal instead of just
+  refreshing the row (`docs/LANGUAGE.md` §11) — needs a live action call
+- [NOT RUNNABLE] A workflow stage stepper — a real `●━●━○━○` progress
+  stepper on a workflow queue row instead of a bare state-name badge, no
+  syntax change (`docs/LANGUAGE.md` §14) — needs a live workflow queue
+- [NOT RUNNABLE] `examples/ctms/ctms.nir` — all of the above proven
+  together against a real 89-screen enterprise app spec (a
+  Counter-Terrorism Financing & Transaction Monitoring System), not just
+  in isolation — see `docs/ROADMAP.md` Track E6; the static markup still
+  generates via `emit-ui`, the live proof no longer runs
 
 **LLM integration**
 - [DONE] LL(1) grammar exported to GBNF for constrained decoding
   (`crates/compiler/nirdosha.gbnf`)
-- [DONE] Structured `Diagnostic` JSON on every error (`--format=json`)
+- [NOT RUNNABLE] Structured `Diagnostic` JSON on every error
+  (`--format=json`) — that flag was interpreter-mode-only and no longer
+  exists in the compiled-only CLI (`nirdosha build`/`emit-llvm` print
+  plain-text errors); `emit-ast`'s own JSON output, listed separately
+  below, is unaffected
 - [DONE] `emit-ast`/`validate_fragment` for typed AST/fragment tooling
 - [PARTIAL] `crates/bench/` pass@1 + self-repair-rate harness — scaffold,
   corpus, and a real `Model` (`--mode real`, any OpenAI-compatible
@@ -92,11 +154,15 @@ Status tags: `[DONE]` (verified — tests pass or run end-to-end),
 
 ## In progress / next
 
-**Track A — Production readiness** (highest priority: gates building
-critical apps on the interpreted path)
+**Track A — Production readiness** (2026-09: this track's own "gates
+building critical apps on the interpreted path" framing is moot — the
+interpreter is gone, so there's no interpreted path left to gate
+anything on. Kept for now as a record of open production-hardening
+work that would matter again if/when a compiled `serve` (Track B8)
+exists to need it.)
 - [OPEN] `transact` durability under real kill-mid-transaction conditions
-- [OPEN] A deployment story for `nirdosha serve` (containerization,
-  secrets/JWKS handling)
+- [OPEN] A deployment story for a *compiled* `serve` (containerization,
+  secrets/JWKS handling) — `nirdosha serve` itself no longer exists
 - [PARTIAL] Observability — a local OTel-shaped tracer exists; wiring
   to a real collector (OTLP) is open
 - [OPEN] A compatibility/versioning policy before the next breaking
@@ -111,11 +177,15 @@ critical apps on the interpreted path)
   upstream incompatibility); revisit once a fixed `z3`/`z3-src` release
   ships
 
-**Track B — Full compilation** (`json`/`http`/`mq`/identity/`transact`/
-sandboxing remain interpreter-only; native codegen covers the numeric/
-control-flow subset, `tcp`/`tcp_listener`, `file`, scalar-only native
-plugin calls, `dec128` arithmetic, and, as of 2026-09, basic
-concurrency — `thread`/`spawn`/`join`, `chan`/`send`/`recv`, `froze`)
+**Track B — Full compilation** (`json`/`http`/`mq`/`transact`/
+sandboxing/most of identity have no codegen yet and, with the
+interpreter gone, don't run in any form; native codegen covers the
+numeric/control-flow subset, `tcp`/`tcp_listener`, `file`, scalar-only
+native plugin calls, `dec128` arithmetic, basic concurrency —
+`thread`/`spawn`/`join`, `chan`/`send`/`recv`, `froze` — and, as of
+2026-09, `check_role`, field- and function-level `requires(...)`/
+`acquire`, and `nfr(...)` — see the identity section under "Shipped"
+above)
 - [DONE] `file` (`open`/`send`/`recv`/`stop`) — linked `nir_file_*`
   kernels, the same "declare + link a staticlib" pattern `tcp` already
   used; `examples/file_io.nir` compiles and runs as a native binary
@@ -164,8 +234,11 @@ concurrency — `thread`/`spawn`/`join`, `chan`/`send`/`recv`, `froze`)
   ranking for the fuller breakdown.
 
 **Track C — Agent-facing HTTP API** (the spec exists —
-[`docs/nirdosha-agent-api.md`](./docs/nirdosha-agent-api.md) — about half the
-underlying capability already ships; the `/v1/*` server itself is 0% built)
+[`docs/nirdosha-agent-api.md`](./docs/nirdosha-agent-api.md) — the `/v1/*`
+server itself is 0% built, and its "about half the underlying
+capability already ships" premise needs re-checking post-interpreter-
+removal: much of what it counted on shipping was interpreter-backed and
+isn't currently runnable — see the "Shipped" callout above)
 - [OPEN] The HTTP server and its 20 endpoints across code generation,
   execution, introspection, benchmarking, and provenance
 

--- a/docs/PUBLIC_ROADMAP.md
+++ b/docs/PUBLIC_ROADMAP.md
@@ -24,11 +24,22 @@ any form today; added 2026-09, see the callout just below).
 > and verified end to end: `check_role` (real identity, an unforgeable
 > `RoleView`), field-level `requires(role/claim: ...)` masking, function-
 > level `requires(role/claim: ...)` + `acquire` (first-class/privileged
-> functions), and `nfr(...)` (non-functional requirements as a compiled
-> fn annotation with real APM-kernel tracking + escalation) — see
-> `docs/LANGUAGE.md` §6a/§6e/§6f/§10 and `docs/PHASE0.md`'s "Twentieth"/
-> "Twenty-first" updates for the full detail this list doesn't yet
-> reflect below.
+> functions), `nfr(...)` (non-functional requirements as a compiled
+> fn annotation with real APM-kernel tracking + escalation), a minimal
+> compiled `serve` mode (real HTTP traffic routed to compiled functions,
+> no interpreter), real `oidc_validate_token`/`extract_claim`/
+> `identity_expired` (genuine JWT/JWKS signature verification, closing
+> the "authentication, not just authorization" gap the identity work
+> above used to name), real `db`/`json` (SQLite via `rusqlite`,
+> `examples/features/27_database.nir` verified end to end against a
+> real database), `transact` Layer 1 (real precheck/network/verify/
+> commit/compensate/log control flow — `retry`/`timeout` architecturally
+> blocked by the compiled trap model, not just deferred), and real
+> `mq`/`http`/`https` (Redis, and an HTTP(S) client with vendored TLS
+> and chunked-transfer-encoding decoding, both verified against real
+> servers) — see `docs/LANGUAGE.md` §5/§6a/§6e/§6f/§10, `docs/TRANSACT.md`,
+> and `docs/PHASE0.md`'s "Twentieth" through "Twenty-sixth" updates for
+> the full detail this list doesn't yet reflect below.
 
 ---
 
@@ -77,19 +88,61 @@ compiled, no interpreter involved at any point)
   concurrency_max:)` — non-functional requirements as a first-class fn
   annotation, tracked automatically via the APM kernel with async
   escalation to `NIRDOSHA_OBSERVABILITY_URL` on a crossed threshold
+- [DONE] `oidc_validate_token`/`extract_claim`/`identity_expired` —
+  real `jsonwebtoken`-backed JWT/JWKS signature verification against a
+  static JWKS (RSA/EC-P256/oct, one key per `kid`, algorithm locked by
+  the JWK's own `kty` — closes the classic algorithm-confusion attack),
+  real JSON claim extraction, a real `VerifiedIdentity` driving the
+  `check_role`/`acquire` machinery above end to end from a genuine
+  signed token, not just a hand-built `VerifiedIdentity`. `check_role`
+  itself upgraded alongside this from a comma-separated-list
+  simplification to real JSON-array parsing (falling back to the
+  comma-separated form for backward compatibility).
+- [DONE] A minimal compiled `serve` mode — `str_index_of`/`str_slice`,
+  `len(str)` (three new string primitives) hand-parse an HTTP request
+  line over a real `tcp_listener`/`accept` loop, routing `/api/<fn>` to
+  distinct compiled functions by a plain `.nir` `if`/`else if` chain, no
+  new language construct. GET-only, no `Content-Length`/POST body
+  support — see `examples/features/51_compiled_serve.nir`, real-`curl`-
+  verified.
 
 **Backend/services**
-- [NOT RUNNABLE] `db` (SQLite + Postgres), `json`, `http`/`https`, `mq`
-  (Redis) — no codegen yet; see Track B below
-- [NOT RUNNABLE] Identity — OIDC/JWT validation (`oidc_validate_token`),
-  claims (`extract_claim`), an admin-editable role-mapping cache (IdP
-  role names → app role names). `check_role` +
-  `requires(role/claim:...)`/`acquire` are the exception, now fully
-  compiled — see the identity section above.
-- [NOT RUNNABLE] `transact` — durable transactions (WAL, crash replay,
-  retry/timeout, idempotency)
-- [NOT RUNNABLE] `workflow` — durable state machines with email/SMS/push
-  notification actions
+- [PARTIAL] `db` (SQLite) + `json` — 2026-09: real, both compiled —
+  `db_connect`/`db_query`/`db_execute` (`rusqlite`, bundled) and all 9
+  `json_*` accessors, `examples/features/27_database.nir` verified
+  end to end against a real SQLite database. Postgres (layer 2) and a
+  zero-payload `enum` bind value aren't compiled yet.
+- [DONE] `http`/`https` + `mq` (Redis) — 2026-09: real, both compiled —
+  `http_get`/`http_post`/`https_get`/`https_post` (vendored OpenSSL,
+  chunked-transfer-encoding decoding) and `mq_connect`/`mq_publish`/
+  `mq_consume`, both verified end to end against real servers.
+- [PARTIAL] Identity — 2026-09: OIDC/JWT validation (`oidc_validate_token`)
+  and claim extraction (`extract_claim`) are now real too — real
+  `jsonwebtoken`-backed signature verification against a static JWKS
+  (live rotation/refresh still open), same `check_role` +
+  `requires(role/claim:...)`/`acquire` machinery already compiled — see
+  the identity section above. Still [NOT RUNNABLE]: dotted-path claim
+  lookup, an admin-editable role-mapping cache (IdP role names → app
+  role names), sessions/refresh tokens/revocation/API-key validation.
+- [PARTIAL] `transact` — 2026-09: Layer 1 real and compiled
+  (`precheck?/network/verify/commit/compensate?/log?`, a real `bool`
+  result). `network`'s `retry`/`timeout` are an architectural gap in the
+  compiled trap model, not a deferred nicety (a compiled trap is an
+  unconditional abort — see the identity section's own note on why
+  compiled traps can't be caught). Still [NOT RUNNABLE]: the durability
+  log (WAL), crash replay, `commit`/`compensate`'s own retry-with-backoff.
+- [PARTIAL] `workflow` — 2026-09: Layer 1 real and compiled — durable
+  state machines (`start_*`/`advance_*`, `on_entry`/`on_exit`, ordinary
+  transitions, `terminal` states), `send_email`/`send_sms`/`send_push`/
+  `notify` (real authenticated HTTPS POSTs against a live provider row),
+  and `state { sla_seconds: N }` + `list_<workflow>_overdue()` SLA/
+  escalation detection (an external scheduler still has to poll it and
+  fire the escalation itself — no scheduling/cron primitive exists in
+  the language). Still [NOT RUNNABLE]: a non-empty `data { ... }` block,
+  magic-link (`link`-marked) transitions, `owner:` state-ownership
+  enforcement, and the `pending_for_me`/`submitted_by_me`/`history`
+  queue-UI read fns (compiled, but always a real `Err` — no durable
+  storage for any of these in this Layer 1 runtime yet).
 - [NOT RUNNABLE] Auto-generated, additive-only DB schema migrations
 
 **UI engine** — the `nirdosha emit-ui` half (static HTML derived from
@@ -177,15 +230,17 @@ exists to need it.)
   upstream incompatibility); revisit once a fixed `z3`/`z3-src` release
   ships
 
-**Track B — Full compilation** (`json`/`http`/`mq`/`transact`/
-sandboxing/most of identity have no codegen yet and, with the
-interpreter gone, don't run in any form; native codegen covers the
-numeric/control-flow subset, `tcp`/`tcp_listener`, `file`, scalar-only
-native plugin calls, `dec128` arithmetic, basic concurrency —
-`thread`/`spawn`/`join`, `chan`/`send`/`recv`, `froze` — and, as of
-2026-09, `check_role`, field- and function-level `requires(...)`/
-`acquire`, and `nfr(...)` — see the identity section under "Shipped"
-above)
+**Track B — Full compilation** (`http`/`mq`/`transact`/sandboxing/the
+rest of identity have no codegen yet and, with the interpreter gone,
+don't run in any form; native codegen covers the numeric/control-flow
+subset, `tcp`/`tcp_listener`, `file`, scalar-only native plugin calls,
+`dec128` arithmetic, basic concurrency — `thread`/`spawn`/`join`,
+`chan`/`send`/`recv`, `froze` — and, as of 2026-09, `check_role`,
+field- and function-level `requires(...)`/`acquire`, `nfr(...)`, a
+minimal compiled `serve` mode, three new string primitives
+(`str_index_of`/`str_slice`, `len(str)`), real JWT/OIDC identity
+verification, and `db`(SQLite)/`json` — see the identity section under
+"Shipped" above and B2/B8 below)
 - [DONE] `file` (`open`/`send`/`recv`/`stop`) — linked `nir_file_*`
   kernels, the same "declare + link a staticlib" pattern `tcp` already
   used; `examples/file_io.nir` compiles and runs as a native binary
@@ -222,16 +277,79 @@ above)
   codebase's other fallible builtins, present failure a different way)
   — a real, deliberately deferred design question, not a shortcut;
   cleanly rejected in the meantime.
-- [OPEN] `transact` → `db`/`json` → `mq` → identity → `http`/`https` →
-  sandboxing → first-class functions → compiled `serve` mode, roughly in
-  that order. `db`/`json`/`mq` share `file`'s "linked handle-based
-  kernel" shape but need a real dynamically-typed value representation
-  for query results first (`Ty::Handle`'s own affine fix, `rfcs/0005`
-  §1, generalizes to a `db`/`mq` connection handle for free once that
-  representation exists). `sandbox` (a real, separate OS *process*, not
-  a thread) remains a materially harder, separate design question from
-  the concurrency work above — see `rfcs/0005` §0's own difficulty
-  ranking for the fuller breakdown.
+- `[PARTIAL]` **B1. `transact` codegen** (2026-09) — Layer 1 real:
+  `precheck?/network/verify/commit/compensate?/log?`, a real `bool`
+  result, `examples/features/36_transact.nir` unmodified and verified.
+  `network`'s `retry`/`timeout` are architecturally blocked in the
+  compiled trap model (a compiled trap is an unconditional abort, and
+  `network`'s return type can never be `Result(_, _)`) — rejected
+  explicitly. Durability log, crash replay, `commit`/`compensate`
+  retry-with-backoff remain open.
+- `[DONE]` **B9. `sleep_ms` codegen** (2026-09) — a real wall-clock
+  sleep; needed for `transact`'s own future backoff work.
+- `[DONE]` **B3. `mq` codegen** (2026-09) — `mq_connect`/`mq_publish`/
+  `mq_consume` (Redis, `LPUSH`/`BLPOP`), verified against a real local
+  Redis instance.
+- `[DONE]` **B5. `http`/`https` codegen** (2026-09) — real client, both
+  plain and TLS (vendored OpenSSL — found necessary by an actual link
+  failure against system OpenSSL, decided deliberately not left to
+  deploy time), chunked-transfer-encoding decoding.
+- [PARTIAL] **B2. `db` + `json` codegen** (2026-09) — `db_connect`/
+  `db_query`/`db_execute` (SQLite via `rusqlite`'s `bundled` feature) and
+  all 9 `json_*` accessors, real and verified: `examples/features/
+  27_database.nir`, unmodified, compiles and runs against a real
+  in-memory SQLite database (schema creation, parameterized insert/
+  update, a filtered `SELECT`, a connection failure as a real `Err`).
+  `Ty::Json` compiles as raw text, re-parsed by each accessor — this
+  item's own design note ("`str` + shims, not a new runtime value type")
+  landed as planned. Named gaps: Postgres (layer 2, `dbconn.rs` — gone
+  along with the interpreter) not yet compiled; a zero-payload `enum`
+  bind value not yet compiled; `BLOB` columns represented as JSON
+  `null` (no `bytes` type to carry them).
+- [PARTIAL] **B8. Compiled `serve` mode** (2026-09) — this was never
+  actually gated on the rest of Track B (that was a sequencing choice,
+  not a technical one). What's real: `/api/<fn>` routing over a real
+  `tcp_listener`/`accept` loop, request-line parsing via three new
+  string primitives (`str_index_of`/`str_slice`, `len(str)`), routing to
+  distinct compiled functions via a plain `.nir` `if`/`else if` chain —
+  no new language construct. Real-`curl`-verified
+  (`examples/features/51_compiled_serve.nir`). Named gaps: GET-only, no
+  `Content-Length`/POST body parsing, sequential (no per-connection
+  `spawn`), no string concatenation.
+- [PARTIAL] **B10. `workflow` codegen** (2026-09) — Layer 1 real:
+  `start_*`/`advance_*`, `on_entry`/`on_exit`, ordinary transitions,
+  `terminal` states; `send_email`/`send_sms`/`send_push`/`notify` (real
+  authenticated HTTPS POSTs against a live provider row); `state {
+  sla_seconds: N }` + `list_<workflow>_overdue()` SLA/escalation
+  detection (an external scheduler still has to poll it and fire the
+  escalation itself). Verified: `examples/features/52`–`54`. Named
+  gaps: a non-empty `data { ... }` block and `link`-marked (magic-link)
+  transitions are explicitly rejected (no durable storage for either in
+  this Layer 1 runtime); `pending_for_me`/`submitted_by_me`/`history`
+  compile but are always a real `Err` (same gap); `owner:` state
+  ownership isn't enforced at runtime.
+- [OPEN] Identity's own remainder (dotted-path claim lookup, sessions/
+  refresh/revocation/API-key validation) and `transact`'s own still-open
+  remainder (durability log, crash replay, `commit`/`compensate`
+  retry-with-backoff) — no required order between them; `db`/`json`
+  (B2), compiled `serve` (B8), `transact` Layer 1 (B1), `mq` (B3),
+  `http`/`https` (B5), and `workflow` Layer 1 (B10) all turned out not
+  to need the sequencing this note originally proposed at all.
+- [OPEN, DESCOPED FROM v1] `sandbox` (a real, separate OS *process*, not
+  a thread) — 2026-09 decision: explicitly out of scope for the first
+  production release, not merely unstarted. It remains a materially
+  harder, separate design question from the concurrency work already
+  shipped (see `rfcs/0005` §0's own difficulty ranking), and unlike
+  every other item above, it has zero existing compiled-backend
+  scaffolding — the interpreter-era implementation that made
+  `sandbox`/`stop`/cross-process `chan` real was deleted along with the
+  rest of `interpreter.rs`, so this is new kernel work (process spawn/
+  kill/reap, a re-exec worker protocol), not a port of an
+  already-proven design the way every other Track B item was. Nothing
+  else in the compiled backend depends on it, so shipping without it
+  costs nothing beyond the two catalog examples that need it staying in
+  their already-disclosed "not runnable" state — tracked as future,
+  post-v1 work.
 
 **Track C — Agent-facing HTTP API** (the spec exists —
 [`docs/nirdosha-agent-api.md`](./docs/nirdosha-agent-api.md) — the `/v1/*`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -98,7 +98,9 @@ messages.
   non-affine `struct`/`enum`/`match`, `froze`, `thread`/`spawn`/`join`/
   `chan`/`send`/`recv`, and — 2026-09 — `check_role` (one real,
   compiled identity builtin, out of Row 12's larger still-interpreter-
-  only set) plus two brand-new compiled-only features that never
+  only set), `fn(..)->..`/`acquire`/`requires(role/claim: ...)` on a
+  function (first-class/privileged functions, previously interpreter-
+  only, §6a), plus two brand-new compiled-only features that never
   existed in the interpreter at all, `nfr(...)` and field-level
   `requires(role/claim: ...)` masking, all moved from interpreter-only
   (or nonexistent) to real LLVM codegen over time (docs/LANGUAGE.md §10 has
@@ -1939,10 +1941,14 @@ claim, though that section is currently accurate).
    (`docs/LANGUAGE.md` §7/§10). **B6. Sandboxing codegen** `[OPEN]` —
    `sandbox`/`stop` remains, a separate and larger scope (a real,
    separate OS process, not a thread) not touched by the above.
-7. `[OPEN]` **B7. First-class functions codegen** — `fn(..)->..`/
-   `acquire`/`requires(...)`, and the Phase-4b affine-in-struct/enum
-   case (a `struct`/`enum` whose payload transitively contains
-   `box`/`&`/`thread`/`chan`/`tcp`/`file`/`db`/`mq`).
+7. **B7. First-class functions codegen** — `fn(..)->..`/`acquire`/
+   `requires(...)` `[DONE]` (2026-09, `docs/LANGUAGE.md` §6a/§10): a
+   plain fn value is its own address, `acquire` builds a real
+   `Result(fn(..)->.., str)` gated on a `check_role`-produced
+   `RoleView`/`ClaimView`, calling either emits a real indirect call.
+   The Phase-4b affine-in-struct/enum case (a `struct`/`enum` whose
+   payload transitively contains `box`/`&`/`thread`/`chan`/`tcp`/`file`/
+   `db`/`mq`) is unrelated and still `[OPEN]`.
 8. `[BLOCKED: B1–B7]` **B8. Compiled `serve` mode** — a real
    self-contained production binary with a compiled dispatch table,
    *coexisting* with interpreted `serve` for dev (the OCaml

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1587,50 +1587,49 @@ of Track B has landed.*
     (frozen design/historical-journal docs, not status trackers — this
     file is where current status belongs, per this file's own stated
     convention).
-- `[OPEN]` **A15. SLA/escalation timers for `workflow` states — no
-  scheduler primitive exists; `owner`/`on_entry` alone can't express
-  "escalate after N hours of silence."** Surfaced by the enterprise-
-  catalog review `docs/WORKFLOW.md` §9 did against real systems (ServiceNow,
-  SAP Business Workflow, Concur, banking maker-checker all have this).
-  Verified directly: `on_entry`/`on_exit` only ever fire in response to
-  a transition that already happened — nothing in the language calls
-  back into a running instance after a time delay with no human action,
-  and `docs/WORKFLOW.md`'s own "Deliberate non-goals" section already
-  discloses "no scheduling/cron primitive in Nirdosha at all." A state
-  sitting in `PendingManagerApproval` for a week with nobody acting is
-  invisible today: no re-notification, no auto-escalation to a
-  substitute approver, no visibility that an SLA was even breached.
+- `[PARTIAL]` **A15. SLA/escalation timers for `workflow` states — the
+  detection half is real and compiled now; automatic firing is still
+  structurally impossible.** Surfaced by the enterprise-catalog review
+  `docs/WORKFLOW.md` §9 did against real systems (ServiceNow, SAP Business
+  Workflow, Concur, banking maker-checker all have this).
 
-  **Proposed design, not started** — two independent pieces, drawing
-  the same "in-language vs. external infrastructure" line `notify()`'s
-  own realtime path (an external WS gateway relays its Redis `PUBLISH`)
-  already draws:
-  1. **In-language**: a new `state { sla: "<duration>" }` kv-entry — no
-     new grammar needed, just a new key on the same open-ended
-     `StateDecl.entries` slot `owner`/`label` already use (`docs/ROADMAP.md`
-     A13). `workflow_instance` gains an `sla_deadline_at` column,
-     computed at entry time (`now + duration`) the same way
-     `record_transition`/`create_instance` already stamp `updated_at`. A
-     new synthesized read fn, `list_<workflow>_overdue() ->
-     Result(json, WorkflowActionError)`, queries every instance whose
-     current state declares an `sla` and whose deadline has passed —
-     pure SQL, no scheduler needed for the query itself.
-  2. **External** (the part Nirdosha genuinely cannot do alone, disclosed
-     not hidden): something has to actually *call* that query
-     periodically and act on what it finds (re-notify, auto-reassign, or
-     fire a new `Escalated` event via `advance_<workflow>`) — a cron job
-     or orchestrator polling `list_<workflow>_overdue()`, the same "the
-     schedule itself is always external" posture `docs/WORKFLOW.md`'s own
-     "nightly workflow" note already establishes for a purely time-
-     triggered `workflow`. `nirdosha serve` itself needs no new
-     subsystem — this is a client of the existing RPC surface, not a new
-     runtime concept.
+  **Built, 2026-09** — the in-language piece this entry originally
+  proposed, shipped close to as sketched: `state { sla_seconds: N }` (an
+  `i64` seconds count, not the originally-proposed `sla: "<duration>"`
+  string — no duration-string parser existed and a plain `i64` needed
+  none) is a plain key on the same open-ended `StateDecl.entries` slot
+  `owner`/`label` already use (A13). `workflow_lower.rs` synthesizes
+  `list_<workflow>_overdue() -> Result(json, WorkflowActionError)` for
+  any workflow declaring at least one `sla_seconds`; `codegen.rs`'s
+  `emit_workflow_overdue` compiles it for real, querying every instance
+  whose *current* state declares `sla_seconds` and whose time-in-state
+  has passed it — pure SQL over the same durable `workflow_instance`
+  store every other Layer 1 piece uses, no scheduler needed for the
+  query itself. Verified end to end, not just typechecked:
+  `crates/compiler/tests/codegen.rs`'s
+  `workflow_list_overdue_reports_a_real_stale_instance_and_ignores_states_with_no_sla`
+  and `examples/features/54_compiled_workflow_escalation.nir` (a real
+  "external scheduler polls, then calls `advance_<workflow>` to
+  escalate" round trip, built and run for real) — both also confirm a
+  state with no `sla_seconds` is never reported overdue, i.e. the check
+  is genuinely per-state, not workflow-wide.
 
-  **Not solved by this**: what "escalate" actually *does* (e.g.
-  auto-reassign `owner` to someone's manager) needs the delegation
-  feature (also `[OPEN]`, same `docs/WORKFLOW.md` §9 review) or a hand-
-  written `Escalated` transition in the workflow's own states — left to
-  the app author, not something `sla` alone would automate.
+  **Still not solved, per this entry's own original "External" half**:
+  the part Nirdosha genuinely cannot do alone, disclosed not hidden —
+  something still has to actually *call* `list_<workflow>_overdue()`
+  periodically and act on what it finds (re-notify, auto-reassign, or
+  fire a new `Escalated` event via `advance_<workflow>`, as file 54
+  does manually) — a cron job or orchestrator, the same "the schedule
+  itself is always external" posture `docs/WORKFLOW.md`'s own "nightly
+  workflow" note already establishes for a purely time-triggered
+  `workflow`. `nirdosha serve` itself still needs no new subsystem for
+  this — a poller is a client of the existing RPC surface, not a new
+  runtime concept. What "escalate" actually *does* beyond that (e.g.
+  auto-reassign `owner` to someone's manager) still needs the
+  delegation feature (also `[OPEN]`, same `docs/WORKFLOW.md` §9 review)
+  or a hand-written `Escalated` transition in the workflow's own states,
+  the way file 54 demonstrates — left to the app author, not something
+  `sla_seconds` alone automates.
 - `[DONE]` **A16. `spawn` created a brand-new real OS thread on every
   single call, unconditionally — no reuse, and a real OS-level failure
   to create one (`RLIMIT_NPROC`/`kernel.threads-max` exhaustion under
@@ -1905,42 +1904,118 @@ the builtins already call into native Rust either way). Sequenced by
 what a critical app actually benefits from, not by "easiest first."*
 
 Current state: `codegen.rs`'s `check_supported` rejects, with a named
-reason, everything below — verified directly against its
+reason, most of what's below — verified directly against its
 `unsupported(...)` call sites this session (not just docs/LANGUAGE.md §10's
-claim, though that section is currently accurate).
+claim, though that section is currently accurate). B8 (compiled `serve`),
+part of B4 (identity crypto), B2 (`db`/`json`), part of B1 (`transact`
+Layer 1), B9 (`sleep_ms`), B3 (`mq`), B5 (`http`/`https`), and B10
+(`workflow` Layer 1) are now real exceptions, `[PARTIAL]`/`[DONE]` below,
+not `[OPEN]`/`[BLOCKED]` — see each entry. Only `sandbox` (B6) remains
+fully `[OPEN]`.
 
-1. `[OPEN]` **B1. `transact` codegen.** Durable-transaction correctness
-   under compilation matters more for a critical/financial app than
-   db/http do — do this first, not last.
-2. `[OPEN]` **B2. `db` + `json` codegen.** `Ty::Db`, `db_connect`/
-   `db_query`/`db_execute`; all 8 `json_*` builtins. Unlocks compiling
-   `trade_finance.nir`/`store.nir` at all. Note: `rusqlite` already
-   uses the `bundled` feature (fully static SQLite) — no new
-   dependency-linking design needed there. The Postgres backend added
-   2026-08-24 (`dbconn.rs`) is a real, separate wrinkle for this item:
-   `postgres`/`postgres-native-tls` are *not* statically bundled the way
-   `rusqlite` is, so a compiled binary using a Postgres `db_connect`
-   would need real dynamic-linking/deployment design (a system TLS
-   library at minimum) — not just "port the interpreter's dispatch to
-   LLVM IR" the way the SQLite path is.
-3. `[OPEN]` **B3. `mq` codegen** (`mq_connect`/`mq_publish`/
-   `mq_consume` — Redis). Network client either way; no static-linking
-   concern, same as today.
-4. `[OPEN]` **B4. Identity/Row 12 codegen** — `oidc_validate_token`,
-   `check_role(_path)`, `extract_claim(_path)`, sessions, refresh,
-   revocation, `validate_api_key`. On the critical path of every
+1. `[PARTIAL]` **B1. `transact` codegen.** 2026-09: Layer 1 real and
+   compiled — `precheck?/network/verify/commit/compensate?/log?`,
+   the implicit `network`/`verify`/`txn_id` bindings, a real `bool`
+   result (`codegen::emit_transact`; `examples/features/36_transact.nir`,
+   unmodified, compiles and runs;
+   `crates/compiler/tests/codegen.rs`'s
+   `transact_commits_and_compensates_for_real_matching_the_checked_in_example`
+   and three more). `network`'s `retry`/`timeout` are an **architectural**
+   gap, not a deferred nicety: a compiled trap is an unconditional
+   `abort()` (the now-deleted interpreter's own catchable `RuntimeError`
+   has no compiled equivalent), and `network`'s declared return type can
+   never be `Result(_, _)` (`Ty::is_transact_scalar`), so there is no
+   non-trapping failure signal to retry on — rejected explicitly, not
+   silently ignored. Still open: `commit`/`compensate`'s own
+   retry-with-backoff (possible in principle, since their return type is
+   unconstrained — just not attempted this round), the durability log
+   (`transact_log.rs`, deleted with the interpreter), and crash replay.
+2. `[PARTIAL]` **B2. `db` + `json` codegen.** 2026-09: `db_connect`/
+   `db_query`/`db_execute` (SQLite via `rusqlite`'s `bundled` feature,
+   `nir_db_*`, `runtime-kernels/src/lib.rs`) and all 9 `json_*` builtins
+   (`json_parse`/`json_get`/`json_get_str`/`json_get_i64`/`json_get_f64`/
+   `json_get_bool`/`json_array_get`/`json_array_len`/`json_set_str`) are
+   real, compiled, and verified — `examples/features/27_database.nir`
+   (unmodified) compiles and runs against a real in-memory SQLite
+   database (`crates/compiler/tests/codegen.rs`'s
+   `db_connect_execute_query_round_trips_real_sqlite_rows`). `Ty::Json`
+   compiles as raw text (the design this item's own doc comment
+   anticipated: `str` + accessor shims, not a from-scratch runtime value
+   type), re-parsed by each accessor — a real, disclosed cost (no
+   persisted parsed-tree handle) traded for zero new representation.
+   Named gaps, not silently dropped: a zero-payload `enum` variant as a
+   bind value isn't compiled yet (only `i64`/`f64`/`str`/`bool`);
+   `BLOB` columns have no first-class Nirdosha type (represented as
+   JSON `null`). Postgres (the interpreter-era `dbconn.rs`, which no
+   longer exists at all — removed with the interpreter) remains a real,
+   separate, deferred follow-up: `postgres`/`postgres-native-tls` are
+   *not* statically bundled the way `rusqlite` is, so a compiled binary
+   using a Postgres `db_connect` would need real dynamic-linking/
+   deployment design (a system TLS library at minimum).
+3. `[DONE]` **B3. `mq` codegen** — 2026-09. `mq_connect`/`mq_publish`/
+   `mq_consume` (Redis via the `redis` crate, `LPUSH`/`BLPOP`), real,
+   verified against a real local Redis instance
+   (`crates/compiler/tests/codegen.rs`'s
+   `mq_publish_and_consume_round_trip_a_real_message`,
+   `runtime-kernels`' own `mq_kernel_tests`). `mq_connect_via` (the
+   plugin-dispatched external-service-boundary path) is a separate
+   mechanism, not touched here. `examples/features/28_message_queue.nir`
+   itself still doesn't compile — a pre-existing, unrelated `match_expr`
+   arm-ordering limitation (`docs/PHASE0.md`'s "Twenty-first update"),
+   the same one `oidc_validate_token`'s own worked example hit.
+4. `[PARTIAL]` **B4. Identity/Row 12 codegen** — `check_role` (2026-09,
+   originally a plain comma-separated role list, upgraded again 2026-09
+   to real JSON-array parsing with a comma-separated fallback),
+   `oidc_validate_token`/`extract_claim`/`identity_expired` (2026-09,
+   real `jsonwebtoken`-backed JWT/JWKS signature verification against a
+   **static** JWKS — same `kty`-locks-`alg` guard as
+   `crates/presence-gateway/src/jwt.rs`; live JWKS
+   refresh/rotation deferred). Still open: `check_role_path`/
+   `extract_claim_path` (dotted-path claim lookup), sessions, refresh
+   tokens, revocation, `validate_api_key`. On the critical path of every
    authenticated request — do before general concurrency/sandboxing.
-5. `[OPEN]` **B5. `http`/`https` codegen** — `http_get`/`http_post`/
-   `https_get`/`https_post`. Note: `native-tls` is **not** currently
-   vendored — dynamically links system OpenSSL on Linux unless the
-   `vendored` feature is turned on; decide that as part of this item,
-   not silently at deploy time.
+5. `[DONE]` **B5. `http`/`https` codegen** — 2026-09. `http_get`/
+   `http_post`/`https_get`/`https_post`, real (`std::net::TcpStream` for
+   plain HTTP, `native_tls::TlsStream` for HTTPS), `Connection: close` +
+   read-to-EOF + real chunked-transfer-encoding decoding (found
+   necessary by testing against a real production server, not designed
+   in advance). **Decided, not left to deploy time**: TLS is vendored
+   (`openssl = { features = ["vendored"] }`), not system-linked — found
+   necessary by an actual link failure against this environment's system
+   OpenSSL (a real ABI mismatch, `SSL_ctrl`/`SSL_CTX_ctrl` missing), same
+   "no system dependency" posture `rusqlite`'s `bundled` SQLite already
+   has. Verified end to end: a real local-TCP-server round trip
+   (`crates/compiler/tests/codegen.rs`'s
+   `http_get_and_post_round_trip_against_a_real_local_server`) and a
+   real HTTPS `GET` against `example.com` (manual, network-dependent,
+   not part of the automated suite).
 6. `thread`/`spawn`/`join`, `chan`/`send`/`recv` `[DONE]` (2026-09) —
    compiled, backed by a real admission-controlled kernel
    (`runtime-kernels`) and a dynamic deadlock detector
-   (`docs/LANGUAGE.md` §7/§10). **B6. Sandboxing codegen** `[OPEN]` —
-   `sandbox`/`stop` remains, a separate and larger scope (a real,
-   separate OS process, not a thread) not touched by the above.
+   (`docs/LANGUAGE.md` §7/§10). **B6. Sandboxing codegen** `[OPEN,
+   DESCOPED FROM v1]` — `sandbox`/`stop` remains, a separate and larger
+   scope (a real, separate OS process, not a thread) not touched by the
+   above. **2026-09 decision: explicitly descoped from the first
+   production release, not merely unstarted.** Zero existing compiled-
+   backend scaffolding (unlike every other item in this track, which was
+   "port an already-interpreter-proven design" — `sandbox`/cross-process
+   `chan` worked in the deleted interpreter, but that whole
+   implementation went with it, so this is closer to new kernel work
+   than a port); nothing else in the compiled backend depends on it
+   (`workflow`/`transact`/`db`/`mq`/`http`/`serve`/identity are all
+   independent); and the original phase plan
+   (`structured-strolling-cray.md`) already called this "standalone,
+   lowest priority, treat as a spike" and excluded it from its own
+   "smallest version that actually retires the research-prototype
+   framing" bar. Real cost of shipping without it: the two catalog
+   examples that need it (`20_sandbox.nir`/`21_sandbox_channels.nir`)
+   stay in the already-existing, already-disclosed "not runnable"
+   bucket (`docs/LANGUAGE.md` §10 already lists `sandbox`/`stop` as
+   `No`) — no regression, no other feature affected. Tracked as future
+   work, to be picked up post-v1 as its own dedicated effort (real
+   process-spawn/kill/reap kernels, a `--sandbox-worker` re-exec
+   protocol, then cross-process `chan` transport), not folded back into
+   this track's remaining sequencing.
 7. **B7. First-class functions codegen** — `fn(..)->..`/`acquire`/
    `requires(...)` `[DONE]` (2026-09, `docs/LANGUAGE.md` §6a/§10): a
    plain fn value is its own address, `acquire` builds a real
@@ -1949,17 +2024,50 @@ claim, though that section is currently accurate).
    The Phase-4b affine-in-struct/enum case (a `struct`/`enum` whose
    payload transitively contains `box`/`&`/`thread`/`chan`/`tcp`/`file`/
    `db`/`mq`) is unrelated and still `[OPEN]`.
-8. `[BLOCKED: B1–B7]` **B8. Compiled `serve` mode** — a real
-   self-contained production binary with a compiled dispatch table,
-   *coexisting* with interpreted `serve` for dev (the OCaml
-   `ocaml`/`ocamlopt`-style split), not replacing it. This is the
-   direct answer to the original "ship the migration/schema with the
-   binary" question — schema gets embedded at compile time once B2
-   exists, migration runtime links into the binary here.
-9. `[OPEN]` **B9. `sleep_ms` codegen** — small, currently omitted from
-   even the interpreter-only list in docs/LANGUAGE.md §10; found this
-   session, not previously tracked anywhere. Fold into whichever of
-   B1–B7 it naturally lands under once scoped.
+8. `[PARTIAL]` **B8. Compiled `serve` mode** — 2026-09: this was never
+   actually gated on B1–B7 (that was a policy choice, "do the
+   correctness-critical pieces first," not a technical one), and the
+   "coexisting with interpreted `serve` for dev, the OCaml
+   `ocaml`/`ocamlopt`-style split" framing this entry used to have is
+   now categorically false — the interpreter and `nirdosha serve` were
+   both deleted entirely; there is only the one compiled path. What's
+   real today: a hand-parsed HTTP request line over a real
+   `tcp_listener`/`accept` loop (three new string primitives —
+   `str_index_of`/`str_slice`, `len(str)` — `docs/LANGUAGE.md` §5/§10),
+   routing `/api/<fn>` to distinct compiled `.nir` functions by a plain
+   `if`/`else if` chain, no new language construct
+   (`examples/features/51_compiled_serve.nir`, real-`curl`-verified;
+   `crates/compiler/tests/codegen.rs`'s
+   `compiled_serve_routes_by_path_to_two_compiled_functions`). Named gaps,
+   not silently dropped: GET-only, no `Content-Length`/POST body
+   parsing, whole request assumed to arrive in one `recv`, sequential
+   (no per-connection `spawn`), no string concatenation (response
+   bodies are fixed literals). Schema-embedded-at-compile-time (B2) and
+   a real deployment story (containerization, secrets/JWKS handling —
+   `docs/PUBLIC_ROADMAP.md`'s Track A) remain open, separate work.
+9. `[DONE]` **B9. `sleep_ms` codegen** — 2026-09. `nir_sleep_ms`
+   (`runtime-kernels/src/lib.rs`), a plain `std::thread::sleep` wrapper;
+   needed anyway once `transact` (B1)'s own future retry/backoff work
+   picks up `commit`/`compensate`'s retry loop.
+10. `[PARTIAL]` **B10. `workflow` codegen** — 2026-09. Layer 1 real and
+    compiled: `start_<workflow>`/`advance_<workflow>`, `on_entry`/
+    `on_exit`, ordinary transitions, `terminal` states
+    (`codegen.rs`'s `emit_workflow_*`; `examples/features/52_compiled_workflow_state_machine.nir`,
+    built and run); `send_email`/`send_sms`/`send_push`/`notify`, real
+    authenticated HTTPS POSTs against a live provider row
+    (`examples/features/53_compiled_workflow_notifications.nir`);
+    `state { sla_seconds: N }` + `list_<workflow>_overdue()` SLA/
+    escalation detection (A15 above;
+    `examples/features/54_compiled_workflow_escalation.nir`). Named
+    gaps, not silently dropped: a non-empty `data { ... }` block and any
+    `link`-marked transition (`*_via_link` magic links) are explicitly
+    rejected — no durable storage for either past the initial call in
+    this Layer 1 runtime; `list_<workflow>_pending_for_me`/
+    `list_<workflow>_submitted_by_me`/`get_<workflow>_history` compile
+    but are always a real `Err` (same gap); `owner:` state ownership
+    isn't enforced at runtime; `notify` always takes the offline
+    (`send_email`-fallback) path. See `docs/WORKFLOW.md`'s own
+    "Status, 2026-09" section for the full detail.
 
 ---
 
@@ -1967,10 +2075,13 @@ claim, though that section is currently accurate).
 
 *20 endpoints across 5 groups (A: codegen/validation, B: execution,
 C: introspection, D: benchmarking, E: provenance). The HTTP API layer
-itself is 0% built — no `/v1/*` server exists (`serve.rs` only serves
-`/api/<fn>` for a program's own functions, unrelated). Roughly half
-the underlying capabilities it would wrap already exist, verified this
-session:*
+itself is 0% built — no `/v1/*` server exists. (The interpreter-era
+`serve.rs` used to serve a program's own `/api/<fn>` dispatch; that file
+is gone along with the interpreter. B8 above's minimal *compiled*
+`/api/<fn>` dispatcher, 2026-09, is unrelated to this Track C spec —
+same URL shape, a different, narrower mechanism, no `/v1/*` surface at
+all.) Roughly half the underlying capabilities it would wrap already
+exist, verified this session:*
 
 **Underlying capability already shipped** (the API layer to expose it
 is what's missing): `--format=json` structured diagnostics, `emit-ast`/

--- a/docs/SANDBOXING.md
+++ b/docs/SANDBOXING.md
@@ -1,5 +1,27 @@
 # Nirdosha sandboxing — what it brings, and our approach
 
+**Status, 2026-09 — explicitly descoped from the first production
+release.** Layers 1-2 below ("Done") describe real, historical work, but
+it lived entirely in `interpreter.rs`, deleted along with the rest of
+the tree-walking interpreter (`refactor: remove tree-walking
+interpreter and its only consumers`) — `sandbox`/`stop` and
+cross-process `chan` do not run in any form today, compiled or
+otherwise (`codegen.rs` rejects `sandbox` outright, naming the reason).
+Unlike every other post-interpreter-removal gap this project has closed
+this way (`transact`/`db`/`json`/`mq`/`http`/`workflow` all got a real,
+narrower Layer 1 *compiled* equivalent), sandboxing was deliberately
+left unmigrated: it has zero existing compiled-backend scaffolding —
+porting it means building real process-spawn/kill/reap kernels and a
+`--sandbox-worker` re-exec protocol from scratch, not translating an
+already-proven design into LLVM IR the way every other phase was. It
+depends on nothing else in the compiled backend, and nothing else
+depends on it, so this costs the release nothing beyond
+`examples/features/20_sandbox.nir`/`21_sandbox_channels.nir` staying in
+their already-disclosed "not runnable" state. Tracked as real,
+prioritized future work (`docs/ROADMAP.md` Track B, B6) — the design
+below is still the intended shape when that work resumes, not
+abandoned, just not on the v1 critical path.
+
 This is not the ProtoBox PRD (`../Nirdosha_Sandboxing_PRD.md`, kept as reference,
 not adopted wholesale). That document is a good prompt — the core instinct
 (sandbox handles as affine, ownership-tracked resources) is exactly right and

--- a/docs/TRANSACT.md
+++ b/docs/TRANSACT.md
@@ -9,10 +9,29 @@ here. Nirdosha's "external effect" already *is* a named function call
 support is a rollback-and-replay discipline layered over calls that already
 exist, not a new subsystem. One keyword, six slots.
 
-**Status: all five layers are implemented** (in-process control flow, a
-real durability log, crash replay, `network`'s own `retry`/`timeout`, and a
-real cross-process `network`/`commit` test) — see "How we're going to get
-there" below for exactly what each one delivered.
+**Status, 2026-09 — the interpreter these five layers were built against is
+deleted; only Layer 1 has a compiled-backend equivalent today.** All five
+layers below describe real, historical work (in-process control flow, a
+real durability log, crash replay, `network`'s own `retry`/`timeout`, a real
+cross-process `network`/`commit` test) — but that work lived entirely in
+`interpreter.rs`/`transact_log.rs`, both removed with the interpreter, so
+none of layers 2–5 run in any form today. `codegen.rs`'s `emit_transact`
+compiles Layer 1 for real (precheck/network/verify/commit/compensate/log,
+the implicit `network`/`verify`/`txn_id` bindings, a real `bool` result —
+`examples/features/36_transact.nir` compiled and run, unmodified,
+`crates/compiler/tests/codegen.rs`'s
+`transact_commits_and_compensates_for_real_matching_the_checked_in_example`).
+`network`'s `retry`/`timeout` are not a deferred nicety but an
+**architectural** gap in the compiled model: a compiled trap is an
+unconditional `abort()` (unlike the interpreter's own catchable
+`RuntimeError`), and `network`'s declared return type is restricted to a
+bare scalar (`Ty::is_transact_scalar`, never `Result(_, _)`) — so there is
+no non-trapping failure signal for a retry loop to react to at all;
+rejected explicitly (`check_expr`'s pre-pass), not silently ignored.
+`commit`/`compensate`'s own retry-with-backoff (theoretically possible,
+since their return type is unconstrained), the durability log, and crash
+replay remain real, separate, disclosed follow-up work — see
+`docs/PHASE0.md`'s "Twenty-fifth update" for the full detail.
 
 ## What it brings to the table
 
@@ -405,11 +424,10 @@ practice:
   arbitrary business data to actually finish the operation, so the same
   restriction there would defeat their purpose. The honest cost of that
   asymmetry is "Crash replay"'s named `Stuck` gap above.
-- **Compiled backend (`codegen.rs`) is out of scope until the interpreter
-  version is proven** — same "reject, don't mis-compile" treatment every
-  other unimplemented construct gets today (`sandbox`, `struct`/`enum`/
-  `match`, `db`/`mq`/`json` are still interpreter-only per
-  `docs/LANGUAGE.md` §10 — `box`/`froze`/`tcp`/`thread`/`spawn`/`join`/
-  `chan`/`send`/`recv` all compile now, so they've dropped off that
-  list; `transact` joins the still-unsupported one, not an exception to
-  it).
+- **Compiled backend (`codegen.rs`) was out of scope until the
+  interpreter version was proven** — true when written, moot since
+  2026-09: the interpreter that "proved" it is deleted, and `transact`'s
+  Layer 1 now has a real compiled equivalent (this doc's own status
+  header above). `db`/`json` also compile now, so they've dropped off
+  the "still interpreter-only" list too; `sandbox`/`mq`/`http`/`https`
+  remain on it.

--- a/docs/VALUES.md
+++ b/docs/VALUES.md
@@ -1,9 +1,15 @@
+We're not building a general-purpose language that happens to be safer. We're building the language for the one case nothing else was designed for: an AI agent writing and running backend code with no human reviewing every line. That assumption — not "safety," not "performance" — is why every decision below looks the way it does.
+
+We built a grammar an LLM can be forced to stay inside of. Export it to GBNF, hand it to a constrained-decoding sampler, and the model literally cannot emit a token that isn't valid Nirdosha — not "usually valid," not "linted afterward." Structurally can't.
+
 We built a compiler you can hand a business rule to — a plain sentence like "two approvers above $50,000" — and it will prove your code follows it, or show you exactly where it breaks. Nobody else has done that. Not a linter. Not a test. A proof.
 
-We built a permission system where the function itself refuses to exist for someone who isn't allowed to call it. No if statement to forget. No middleware to misconfigure. It just isn't there.
+We built a permission system where the function itself refuses to exist for someone who isn't allowed to call it. No if statement to forget. No middleware to misconfigure. It just isn't there — because an agent that forgets to write the check is exactly the failure mode we're designing against.
+
+We built a concurrency model with no mutex in it at all. Not "use locks carefully" — there is no lock primitive for an agent to misuse in the first place, so a lock-ordering deadlock isn't a bug class here, it's an unexpressible sentence.
 
 We built a language whose own grammar we handed to outside tools to check us — and it caught a real bug in our own thinking. We didn't hide that. We wrote it down and fixed it.
 
-We built a system that turns four struct fields into a working, secure, role-aware web app — and the security is real, enforced by the server, every single time, not a trick of the front end.
+We removed the interpreter entirely, on purpose, rather than let the compiled path stay second-class. `http`/`json`/`db`/`mq` and the rest of the conventional backend surface are well-understood engineering — we deliberately built the hard, unretrofittable parts first and are doing that ordinary work next, on the real foundation, not a temporary second one.
 
 That's a big deal. That's years of "safe languages are slow to write" and "fast languages are dangerous" being wrong at the same time, in the same compiler. We didn't pick a side. We refused to.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -27,6 +27,37 @@ multi-instance fix), and four new interpreter builtins
 (`send_email`/`send_sms`/`send_push`/`notify`) for the notification
 actions the design conversation specifically asked for.
 
+**Status, 2026-09 — the interpreter this feature was originally built
+against is deleted; a real, narrower compiled-backend equivalent exists
+now (`docs/TRANSACT.md`'s own "layers, not a syntax spec" precedent
+applied here too).** `codegen.rs`'s `emit_workflow_*` compiles Layer 1 for
+real: `start_<workflow>`/`advance_<workflow>`, `on_entry`/`on_exit`
+actions, ordinary transitions, and `terminal` states, with
+`Err(NoSuchTransition)`/`Err(InstanceNotFound)` as real, non-trapping
+results (`examples/features/52_compiled_workflow_state_machine.nir`).
+`send_email`/`send_sms`/`send_push`/`notify` (below) compile too — real,
+authenticated HTTPS POSTs against a live, admin-editable provider row
+(`examples/features/53_compiled_workflow_notifications.nir`). SLA/
+escalation *detection* (`state { sla_seconds: N }` +
+`list_<workflow>_overdue()`, `docs/ROADMAP.md` A15) compiles as well —
+the query side only; nothing fires automatically, so an external
+scheduler still has to poll and call `advance_<workflow>` itself
+(`examples/features/54_compiled_workflow_escalation.nir`). Narrower than
+the interpreter-only design below, each gap real and disclosed rather
+than silently dropped: a non-empty `data { ... }` block and any
+`link`-marked transition (`*_via_link` magic links) are explicitly
+rejected at compile time — this Layer 1 runtime has nowhere durable to
+persist a `data` value or a link token past the initial call — instead
+of being silently miscompiled; the synthesized
+`list_<workflow>_pending_for_me`/`list_<workflow>_submitted_by_me`/
+`get_<workflow>_history` query fns compile but are always a real `Err`
+(same durable-storage gap, "state ownership + a generated queue UI"
+below); `owner:` state ownership is parsed but not enforced by this
+compiled backend at runtime; `notify` always takes the offline
+(`send_email`-fallback) path, since nothing in this compiled path
+populates a real presence table. See `docs/LANGUAGE.md` §10 for the
+one-line compiled-status-matrix entry this expands on.
+
 ## What it brings to the table
 
 **1. Named states and transitions instead of a `status TEXT` column
@@ -317,13 +348,15 @@ builtin).
   but not yet threaded into `on_entry`/`on_exit` bindings.** Reserved for
   a future increment; every current binding comes from `data`/`instance_id`/
   `link_<Event>` only.
-- **No native codegen.** `workflow`-desugared functions call
-  `send_email`/`notify`/`__workflow_*`, none of which are in
-  `codegen.rs`'s `PHASE4_BUILTINS`/`PHASE5_BUILTINS`/... allowlists, so
-  `nirdosha build`/`emit-llvm` rejects a program using `workflow` the
-  same clean, disclosed way it already rejects one using `transact` —
-  `check_supported` names the specific unsupported builtin, never a
-  silent mis-compile.
+- **Native codegen exists now, but only for a Layer 1 subset — see this
+  doc's own "Status, 2026-09" section up top.** `workflow`-desugared
+  functions calling `send_email`/`send_sms`/`send_push`/`notify`/
+  `__workflow_start`/`__workflow_advance`/`__workflow_overdue` compile
+  and run for real; a program using a non-empty `data { ... }` block or
+  a `link`-marked transition (`__workflow_link_advance`) is still
+  explicitly rejected by `nirdosha build`/`emit-llvm`, the same clean,
+  disclosed way `check_supported` already names any other unsupported
+  construct rather than silently mis-compiling.
 
 ## State ownership + a generated queue UI
 
@@ -577,7 +610,7 @@ Each row below is a real, common pattern; "Have?" says whether today's
 | Who submitted this / "my requests" | Every system listed above | **Yes** | §6 above. |
 | Audit trail (who/when/why) | SOX compliance, banking regulation | **Yes**, with the disclosed per-viewer-ACL gap in §7 | §7 above; a real per-viewer ACL (participants + requester only) is the remaining gap. |
 | Delegation / out-of-office reassignment | "I'm on leave, my approvals route to my manager for two weeks" (every system above has this) | **No** | Needs a new admin-editable `WorkflowDelegation`-shaped struct (`from_subject, to_subject, workflow_name, starts_at, ends_at`) and a second check in `identity_satisfies_owner` — real, buildable, same "ordinary struct, free CRUD screen" convention `RoleMapping`/`EmailProviderConfig` already use, just not built. |
-| SLA / escalation timers | "If not acted on in 48h, escalate to the owner's manager or notify again" (universal in enterprise workflow engines) | **No, structurally — tracked as `docs/ROADMAP.md` Track A item A15** | `docs/WORKFLOW.md`'s own "Deliberate non-goals" section already discloses this: **there is no scheduling/cron primitive in Nirdosha at all**. The `state`/`on_entry` shape is durable and retry-safe, but nothing inside the language can fire "48 hours from now" on its own — this needs an *external* scheduler calling `advance_<workflow>`/a new escalation fn, same as every other "nightly" workflow already has to work this way. A real, scoped proposed design (`state { sla: "<duration>" }` + a `list_<workflow>_overdue()` read fn for whatever external scheduler polls it) is in `docs/ROADMAP.md` A15, not sketched here. |
+| SLA / escalation timers | "If not acted on in 48h, escalate to the owner's manager or notify again" (universal in enterprise workflow engines) | **Partial — detection only, compiled; tracked as `docs/ROADMAP.md` Track A item A15** | This doc's own "Deliberate non-goals" section still applies to the *automatic-firing* half: **there is no scheduling/cron primitive in Nirdosha at all**, so nothing inside the language fires "48 hours from now" on its own. What's real and compiled now (2026-09, this doc's own "Status" section up top): `state { sla_seconds: N }` + a synthesized `list_<workflow>_overdue()` read fn genuinely detects a stale instance, per-state, over a real durable store — an *external* scheduler still has to poll it and call `advance_<workflow>` itself to escalate, the same round trip every other "nightly" workflow already has to work this way (`examples/features/54_compiled_workflow_escalation.nir`). |
 | Bulk actions ("approve all 12 selected") | Any queue-shaped enterprise UI | **No** | Pure UI-layer batching over the existing `advance_<workflow>` calls, one request per selected row — no new compiler construct needed, just not built in `ui_gen_template.html` yet. |
 | In-app notification inbox (persisted, browsable later) | Almost every enterprise app's bell icon | **Already possible today, not a compiler gap** | `on_entry`/`on_exit` can call *any* function, not just `send_email`/`send_sms`/`notify` — an ordinary user-defined `fn` that `db_execute`s an insert into your own `struct Notification { ... }` (a real, free CRUD screen) gives a persisted, browsable inbox with zero new grammar. What's still missing is only a UI *bell icon* convention (`ui_gen.rs` has no special-cased "notification" struct today — it would just render as an ordinary screen, not a badge in the nav bar). |
 | Unified cross-workflow "Approvals" inbox (one queue merging every workflow, not one nav tab per workflow) | Any org with more than one approval process | **No** | Pure UI aggregation over each workflow's own `list_<workflow>_pending_for_me` — no new compiler construct, just not built (today's "Workflows" nav is one entry per `workflow`, not a merged view). |

--- a/docs/goal.md
+++ b/docs/goal.md
@@ -65,6 +65,20 @@ of the others (§1, §7).
 
 ---
 
+> **Note, added 2026-09-06 — the one-sentence version of this whole
+> brief:** Nirdosha is not a general-purpose language that happens to be
+> safer. It solves a problem no existing language was designed for:
+> letting an AI agent write and run backend code with no human reviewing
+> every line. Row 7 below ("easy for an LLM to write and reason about")
+> reads as one requirement among eleven in the table that follows — in
+> practice it's the reason the other ten exist in this combination at
+> all. The conventional backend surface (`http`/`json`/`db`/`mq`, etc.)
+> is deliberately deprioritized relative to rows 1–5/11: those are the
+> parts hard to retrofit onto Rust/Go/Python after the fact, and the
+> parts that decide whether an agent-written service can run
+> unsupervised. See `README.md`'s "Why this exists" section for the
+> current, short version of this argument.
+
 ## 0. The constraint that shapes everything
 
 Before any design: one theorem sets the ceiling here, so it's worth stating

--- a/examples/features/33_privileged_functions.nir
+++ b/examples/features/33_privileged_functions.nir
@@ -7,6 +7,14 @@
 // proof: a `RoleView` (from `check_role`) or `ClaimView` (from
 // `extract_claim`), themselves only producible from a real, externally-
 // issued, validated token.
+//
+// The `requires`/`acquire` mechanism itself compiles for real (2026-09,
+// LANGUAGE.md §10) -- but this file's own worked examples authenticate
+// via `oidc_validate_token` (JWT/JWKS validation), which remains
+// interpreter-only-designed, so `nirdosha build` still rejects this
+// file as a whole. See `50_field_masking_and_check_role.nir` for a
+// role-gated `acquire` flow built on `check_role` instead, which
+// compiles and runs end to end today.
 
 fn transfer_funds(amount: i64) -> i64 requires(role: "admin") {
     return amount

--- a/examples/features/50_field_masking_and_check_role.nir
+++ b/examples/features/50_field_masking_and_check_role.nir
@@ -1,16 +1,26 @@
 // Feature: field-level `requires(role/claim: ...)` masking (LANGUAGE.md
-// §6e) driven by a real, compiled `check_role` (§10, PHASE0.md's
-// "Twentieth update") -- plus `effect(...)` (checked against the real
-// inferred effect set, not decorative) and `nfr(...)` (§6f) on the same
-// function, and a Z3-proven `validate` contract (§16) alongside it. The
-// flagship example this README's own hero code block is drawn from.
+// §6e) composed with function-level `requires(role: ...)` + `acquire`
+// (§6a) -- both driven by a real, compiled `check_role` (§10,
+// PHASE0.md's "Twentieth update"), plus `effect(...)` (checked against
+// the real inferred effect set, not decorative) and `nfr(...)` (§6f) on
+// the same function, and a Z3-proven `validate` contract (§16)
+// alongside it. The flagship example this README's own hero code block
+// is drawn from.
 //
-// `salary` masks itself to zero on every `return` of an `Employee`
-// unless the returning function's own `RoleView`/`ClaimView` parameter
-// proves the "admin" role -- fail-closed, no `acquire` involved at all.
-// A `RoleView` is unforgeable by direct construction; the only way to
-// get a real one is `check_role(identity, role)` succeeding against a
-// real `VerifiedIdentity`'s claims.
+// Two independent gates compose here, not one mechanism wearing two
+// hats: `get_employee requires(role: "hr_staff")` decides *who can call
+// it at all* -- obtaining a callable value requires a real `RoleView`
+// proving "hr_staff", via `acquire`. `salary requires(role: "admin")`
+// then separately decides *what a successful caller sees back* -- the
+// field masks itself to zero on every `return` of an `Employee` unless
+// the argument passed as `caller` proves "admin" specifically, fail-
+// closed. An hr_staff member who isn't also an admin can call the
+// function and get real employee records with salary redacted; anyone
+// who isn't hr_staff can't call it at all. Neither `RoleView` can be
+// forged (`RoleView("admin")` is a compile-time error) or fabricated by
+// this function's own logic -- the only way to get a real one is
+// `check_role(identity, role)` succeeding against a real
+// `VerifiedIdentity`'s claims.
 
 struct Text {
     value: str,
@@ -41,13 +51,17 @@ validate tenure_bonus_pct {
 
 // The one function: `effect(pure)` is checked against what the body
 // actually does (a lie here is a build error, not a comment nobody
-// reads); `nfr(...)` wires real per-call latency/concurrency tracking
-// into the APM kernel with zero code at any call site; the `salary`
-// field masks itself on the way out, driven entirely by whether
-// `caller` proves the "admin" role -- no branch in this function's own
-// body decides that.
+// reads); `requires(role: "hr_staff")` means this function has no
+// direct-call path at all -- `acquire get_employee(proof)` is the only
+// way to obtain a callable value, and it demands a real `RoleView`
+// proving "hr_staff"; `nfr(...)` wires real per-call latency/
+// concurrency tracking into the APM kernel with zero code at any call
+// site; the `salary` field masks itself on the way out, driven
+// entirely by whether `caller` *separately* proves the "admin" role --
+// no branch in this function's own body decides either gate.
 fn get_employee(caller: RoleView, name: Text, department: Text, salary: f64) -> Employee
     effect(pure)
+    requires(role: "hr_staff")
     nfr(latency_ms: 50, concurrency_max: 1000)
 {
     return Employee(name.value, department.value, salary)
@@ -57,25 +71,53 @@ fn main() {
     let bonus: i64 = tenure_bonus_pct(7)
     print(bonus) // 10 -- proven in [0, 20] for every possible input, not just this one
 
-    // A real VerifiedIdentity carrying "admin" -- check_role hands back
-    // a genuine, unforgeable RoleView; get_employee sees it and lets
-    // salary through untouched.
-    let admin_identity: VerifiedIdentity = VerifiedIdentity("alice", "https://idp.example.com", "payroll-app", 0, 0, "admin")
-    let admin_view: Employee = match check_role(admin_identity, "admin") {
-        Ok(role) => get_employee(role, Text("Ada Lovelace"), Text("Engineering"), 150000.0),
+    // Proves both "hr_staff" (to acquire get_employee at all) and
+    // "admin" (to pass as `caller`, so the masked field sees a matching
+    // proof and passes through untouched) -- two separate check_role
+    // calls, since a RoleView only ever proves the one role it was
+    // checked against.
+    let admin_identity: VerifiedIdentity = VerifiedIdentity("alice", "https://idp.example.com", "payroll-app", 0, 0, "hr_staff,admin")
+    let admin_view: Employee = match check_role(admin_identity, "hr_staff") {
         Err(e) => Employee("", "", -1.0),
+        Ok(hr_proof) => match acquire get_employee(hr_proof) {
+            Err(msg) => Employee("denied", "", -2.0),
+            Ok(f) => match check_role(admin_identity, "admin") {
+                Err(e) => f(hr_proof, Text("Ada Lovelace"), Text("Engineering"), 150000.0),
+                Ok(admin_proof) => f(admin_proof, Text("Ada Lovelace"), Text("Engineering"), 150000.0),
+            },
+        },
     }
-    print(admin_view.salary) // 150000
+    print(admin_view.salary) // 150000 -- caller proved "admin"
 
-    // A real VerifiedIdentity that only carries "guest" -- its own
-    // genuine RoleView proves "guest", not "admin", so the same
-    // function masks salary to zero while every other field still
-    // passes through untouched.
-    let guest_identity: VerifiedIdentity = VerifiedIdentity("bob", "https://idp.example.com", "payroll-app", 0, 0, "guest")
-    let guest_view: Employee = match check_role(guest_identity, "guest") {
-        Ok(role) => get_employee(role, Text("Ada Lovelace"), Text("Engineering"), 150000.0),
+    // Proves "hr_staff" only -- can acquire and call get_employee (the
+    // function-level gate is satisfied), but the only RoleView available
+    // to pass as `caller` proves "hr_staff", not "admin", so the
+    // field-level gate masks salary to zero while name still passes
+    // through untouched.
+    let hr_identity: VerifiedIdentity = VerifiedIdentity("carol", "https://idp.example.com", "payroll-app", 0, 0, "hr_staff")
+    let hr_view: Employee = match check_role(hr_identity, "hr_staff") {
         Err(e) => Employee("", "", -1.0),
+        Ok(hr_proof) => match acquire get_employee(hr_proof) {
+            Err(msg) => Employee("denied", "", -2.0),
+            Ok(f) => f(hr_proof, Text("Ada Lovelace"), Text("Engineering"), 150000.0),
+        },
     }
-    print(guest_view.salary) // 0 -- masked
-    print(guest_view.name)   // Ada Lovelace -- unmasked fields pass through
+    print(hr_view.salary) // 0 -- masked
+    print(hr_view.name)   // Ada Lovelace -- unmasked fields still pass through
+
+    // Proves neither role at all -- check_role itself fails, so there's
+    // no RoleView to offer `acquire` in the first place: get_employee's
+    // own function-level gate refuses to hand back a callable value,
+    // and the function body never runs -- fail-closed a full step
+    // earlier than the field-masking case above.
+    let outsider_identity: VerifiedIdentity = VerifiedIdentity("mallory", "https://idp.example.com", "payroll-app", 0, 0, "guest")
+    let outsider_view: Employee = match check_role(outsider_identity, "hr_staff") {
+        Err(e) => Employee("no_access", "", -3.0),
+        Ok(hr_proof) => match acquire get_employee(hr_proof) {
+            Err(msg) => Employee("denied", "", -3.0),
+            Ok(f) => f(hr_proof, Text("Ada Lovelace"), Text("Engineering"), 150000.0),
+        },
+    }
+    print(outsider_view.salary) // -3 -- never even reached get_employee's body
+    print(outsider_view.name)   // no_access
 }

--- a/examples/features/51_compiled_serve.nir
+++ b/examples/features/51_compiled_serve.nir
@@ -1,0 +1,78 @@
+// Feature: compiled `serve` (LANGUAGE.md's compiled-status matrix;
+// ROADMAP.md Track B8). Hand-parses an HTTP request line over a raw
+// `tcp_listener`/`accept` loop using the new `str_index_of`/`str_slice`/
+// `len(str)` primitives (`STR_BUILTINS`, `crates/compiler/src/codegen.rs`),
+// and routes `/api/<fn>` to distinct compiled `.nir` functions by plain
+// `if`/`else if` + `==` -- no new language construct, no interpreter (there
+// is none left to fall back to).
+//
+// Deliberately scoped: GET-only, the whole request assumed to arrive in one
+// `recv` (true for an ordinary small `curl` GET, not adversarially
+// guaranteed), `Connection: close` + a real socket close as the end-of-body
+// signal (no `Content-Length` -- same simplifying cut the existing
+// client-side `http_get` builtin already made, just from the other side),
+// one request per connection, sequential (no per-connection `spawn`).
+//
+// Unlike every other file in this catalogue, `main`'s own accept loop runs
+// forever, so this one is meant to be run standalone and driven with a
+// real `curl`, not read to completion by itself:
+//
+//   nirdosha build examples/features/51_compiled_serve.nir -o /tmp/serve_demo
+//   /tmp/serve_demo &
+//   curl -s http://127.0.0.1:8080/api/hello   # -> hello from /api/hello
+//   curl -s http://127.0.0.1:8080/api/echo    # -> hello from /api/echo
+//   curl -s http://127.0.0.1:8080/api/unknown # -> 404 Not Found
+//
+// `crates/compiler/tests/codegen.rs`'s
+// `compiled_serve_routes_by_path_to_two_compiled_functions` test drives
+// this same shape end-to-end with real client sockets from within the
+// test suite, not just this manual `curl` walkthrough.
+
+struct Text {
+    value: str,
+}
+
+fn handle_hello() -> Text {
+    return Text("hello from /api/hello")
+}
+
+fn handle_echo() -> Text {
+    return Text("hello from /api/echo")
+}
+
+fn main() {
+    let l: tcp_listener = listen(8080)
+    while true {
+        let conn: tcp = accept(l)
+        let req: str = recv(conn)
+
+        // "METHOD SP PATH SP VERSION\r\n..." -- three fields, split on
+        // spaces, stopping at the request line's own "\r\n". No `split`
+        // builtin exists; this is `str_index_of` + `str_slice` composed
+        // a few times, exactly the scope `STR_BUILTINS` was sized for.
+        let line_end: i64 = str_index_of(req, "\r\n")
+        let line: str = str_slice(req, 0, line_end)
+        let sp1: i64 = str_index_of(line, " ")
+        let after_method: str = str_slice(line, sp1 + 1, len(line))
+        let sp2: i64 = str_index_of(after_method, " ")
+        let path: str = str_slice(after_method, 0, sp2)
+
+        // No string concatenation exists yet, so each route sends its
+        // headers and body as two separate `send` calls rather than
+        // interpolating the dispatched function's return value into one
+        // literal -- this is what actually proves two different compiled
+        // `fn`s handle two different routes, not just two string literals.
+        if path == "/api/hello" {
+            let body: Text = handle_hello()
+            send(conn, "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n")
+            send(conn, body.value)
+        } else if path == "/api/echo" {
+            let body: Text = handle_echo()
+            send(conn, "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n")
+            send(conn, body.value)
+        } else {
+            send(conn, "HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n")
+        }
+        stop conn
+    }
+}

--- a/examples/features/52_compiled_workflow_state_machine.nir
+++ b/examples/features/52_compiled_workflow_state_machine.nir
@@ -1,0 +1,138 @@
+// Feature: `workflow { data/state/on_entry/on_exit/on <Event> ->
+// <State>/terminal }` -- the compiled Layer 1 state-machine core
+// (`docs/WORKFLOW.md`, `docs/TRANSACT.md`'s own "Layers, not a syntax
+// spec" precedent applied here too). `38_workflow.nir` is this
+// construct's *full* design (RBAC-style `owner:` gates, a `data { ... }`
+// block, magic links) -- narrower and still interpreter-only-designed,
+// since it also depends on `mock_issue_token` (never got codegen either).
+// This file, and its two companions (`53_compiled_workflow_notifications.nir`,
+// `54_compiled_workflow_escalation.nir`), are the real, compiled,
+// end-to-end-verified subset instead: three separate files because no
+// single small workflow naturally exercises the state machine, every
+// notification channel, *and* SLA/escalation at once without becoming
+// unreadable.
+//
+// `workflow_lower.rs` desugars this into ordinary `fn`/`enum`/`struct`
+// declarations right after parsing: `start_ticket`, `advance_ticket`, a
+// synthesized `TicketEvent` enum, and a `TicketData` struct (empty here --
+// Layer 1's own disclosed restriction, see `Codegen::resolve_workflow_layer1`'s
+// doc comment: a non-empty `data { ... }` block has nowhere durable to
+// live past the initial `start_*` call in this compiled backend). Every
+// later stage, including `nirdosha serve`'s automatic `POST /api/<fn>`
+// exposure, sees only the desugared `fn`s.
+//
+// Self-contained: nothing external is required. `instance_id` (always)
+// is the one implicit binding an `on_entry`/`on_exit` action can use
+// here -- `data.<field>` bindings need the non-empty-`data` support this
+// Layer 1 doesn't have, hence the empty `data {}`-shaped workflow below.
+
+fn log_opened(instance_id: i64) -> unit {
+    print("ticket", instance_id, "opened")
+}
+
+fn log_left_open(instance_id: i64) -> unit {
+    print("ticket", instance_id, "leaving Open")
+}
+
+fn log_in_progress(instance_id: i64) -> unit {
+    print("ticket", instance_id, "now InProgress")
+}
+
+fn log_closed(instance_id: i64) -> unit {
+    print("ticket", instance_id, "closed")
+}
+
+workflow Ticket {
+    state Open {
+        on_entry {
+            log_opened(instance_id)
+        }
+        on_exit {
+            log_left_open(instance_id)
+        }
+        on Start -> InProgress
+        on Close -> Closed
+    }
+
+    state InProgress {
+        on_entry {
+            log_in_progress(instance_id)
+        }
+        on Close -> Closed
+    }
+
+    // `terminal` means "no outgoing `on`s, and that's declared on
+    // purpose" -- a non-`terminal` state with zero transitions is a
+    // compile error (`WorkflowStateHasNoTransitions`), so a real dead
+    // end always says so explicitly. `Closed` still has its own
+    // `on_entry`/`on_exit`, same as any other state.
+    state Closed terminal {
+        on_entry {
+            log_closed(instance_id)
+        }
+    }
+}
+
+// `advance_ticket`'s trailing `payload: json` argument needs a real
+// `json` value, not the `Result(json, str)` `json_parse` itself
+// returns -- wrapping it here (a `Call`, not a bare identifier, so the
+// pre-existing `match_expr`/`local_ty_of` arm-order limitation
+// `docs/PHASE0.md`'s "Twenty-first update" documents doesn't apply) is
+// the same shape `38_workflow.nir`'s own `decide_approval` wrapper uses.
+fn advance_now(identity: VerifiedIdentity, instance_id: i64, event: TicketEvent) -> Result(bool, WorkflowActionError) {
+    return match json_parse("{}") {
+        Ok(payload) => advance_ticket(identity, instance_id, event, payload),
+        Err(e) => Err(NoSuchTransition()),
+    }
+}
+
+fn main() {
+    // `advance_ticket` requires a real `identity: VerifiedIdentity`
+    // (`docs/WORKFLOW.md`'s "state ownership" section) -- built directly
+    // here rather than through a real `oidc_validate_token` round trip,
+    // the same shortcut `check_role_produces_real_role_view_...`'s own
+    // test template already takes when the point is the workflow, not
+    // the JWT.
+    let identity: VerifiedIdentity = VerifiedIdentity("agent-7", "https://mock-idp.local", "support-app", 9999999999, 0, "{}")
+
+    // `start_ticket`'s own `on_entry` (Open's) already runs before this
+    // returns -- the "ticket 1 opened" line below prints *before* this
+    // `print(instance_id)` does, for real (see `main`'s own comment
+    // just below).
+    let instance_id: i64 = match start_ticket(None(), TicketData()) {
+        Ok(id) => id,
+        Err(e) => -1,
+    }
+    print(instance_id) // 1 -- printed *after* "ticket 1 opened" (on_entry ran first, inside start_ticket)
+
+    // Open -> InProgress: runs Open's on_exit, then InProgress's on_entry.
+    let moved: bool = match advance_now(identity, instance_id, Start()) {
+        Err(e) => false,
+        Ok(v) => v,
+    }
+    print(moved) // 1 (true)
+
+    // InProgress -> Closed (terminal): runs InProgress's on_exit (none
+    // declared -- a no-op), then Closed's on_entry.
+    let closed: bool = match advance_now(identity, instance_id, Close()) {
+        Err(e) => false,
+        Ok(v) => v,
+    }
+    print(closed) // 1 (true)
+
+    // `Closed` is terminal -- no outgoing `on`s at all, so *any* event
+    // here is a real `Err(NoSuchTransition)`, never a trap.
+    let stuck: bool = match advance_now(identity, instance_id, Close()) {
+        Ok(v) => false,
+        Err(e) => true,
+    }
+    print(stuck) // 1 (true)
+
+    // A nonexistent instance id is a real `Err(InstanceNotFound)`, same
+    // "never a trap" guarantee.
+    let missing: bool = match advance_now(identity, 999999, Close()) {
+        Ok(v) => false,
+        Err(e) => true,
+    }
+    print(missing) // 1 (true)
+}

--- a/examples/features/53_compiled_workflow_notifications.nir
+++ b/examples/features/53_compiled_workflow_notifications.nir
@@ -1,0 +1,165 @@
+// Feature: `send_email`/`send_sms`/`send_push`/`notify` fired from a
+// `workflow`'s `on_entry` -- real, compiled, provider-agnostic
+// authenticated HTTPS POSTs (`docs/WORKFLOW.md`), driven by real,
+// admin-editable provider rows in a real SQLite table, not mocked
+// out. Companion to `52_compiled_workflow_state_machine.nir`
+// (state machine) and `54_compiled_workflow_escalation.nir`
+// (SLA/escalation) -- see that file's own header for why this is three
+// files, not one.
+//
+// Self-contained: rather than depending on a real email/SMS/push
+// provider being reachable, this spins up its own local `tcp_listener`
+// (same "self-hosted, not skipped" precedent `22_tcp_client.nir` and
+// `crates/compiler/tests/codegen.rs`'s own
+// `workflow_on_entry_send_email_posts_to_a_real_configured_provider`
+// test already use) and points every provider row at it -- proving the
+// real request shape (`Authorization: Bearer <api_key>`, a
+// `{"to","from","template","vars"}` JSON body) actually leaves the
+// process, not just that the syntax parses.
+//
+// `notify(conn, mq, to, template, vars)` is `docs/WORKFLOW.md`'s
+// presence-aware channel -- online routes over a real Redis pub/sub
+// bridge (`crates/presence-gateway`), offline falls back to email. This
+// compiled backend doesn't populate a real presence table this round
+// (`nir_notify`'s own doc comment), so `notify` always takes the offline
+// path here -- a real, disclosed narrower cut, not a fake success.
+//
+// `conn: db` and `mq_conn: mq` stay inside *one* function throughout,
+// never handed to a second user-defined helper -- `db`/`mq` are affine
+// (`Ty::is_affine`), and passing an affine value into another
+// user-defined `fn` really does move it (`ownership.rs`); only a short,
+// explicit allowlist of *builtins* (`db_execute`/`db_query`/
+// `send_email`/`send_sms`/`send_push`/`notify`/...) treat their leading
+// connection argument as read, not consumed, so a connection can drive
+// several calls before its one `stop` -- same discipline
+// `27_database.nir`'s own single `run_all(conn: db)` already follows.
+
+fn notify_with_conn(conn: db, mq_conn: mq, instance_id: i64) -> unit {
+    // Real per-app config, not compile-time syntax -- `docs/WORKFLOW.md`'s
+    // own point #4. Each of the three provider tables shares this exact
+    // shape (`load_active_provider_config`, `runtime-kernels/src/lib.rs`).
+    let created_email: i64 = match db_execute(conn, "CREATE TABLE email_provider_config (id INTEGER PRIMARY KEY, active INTEGER, host TEXT, port INTEGER, path TEXT, api_key TEXT, from_address TEXT)") {
+        Ok(n) => n,
+        Err(e) => -1,
+    }
+    let created_sms: i64 = match db_execute(conn, "CREATE TABLE sms_provider_config (id INTEGER PRIMARY KEY, active INTEGER, host TEXT, port INTEGER, path TEXT, api_key TEXT, from_address TEXT)") {
+        Ok(n) => n,
+        Err(e) => -1,
+    }
+    // `push_provider_config` deliberately stays empty (no `INSERT`) --
+    // `send_push` below demonstrates the real not-configured path.
+    let created_push: i64 = match db_execute(conn, "CREATE TABLE push_provider_config (id INTEGER PRIMARY KEY, active INTEGER, host TEXT, port INTEGER, path TEXT, api_key TEXT, from_address TEXT)") {
+        Ok(n) => n,
+        Err(e) => -1,
+    }
+    let inserted_email: i64 = match db_execute(conn, "INSERT INTO email_provider_config (active, host, port, path, api_key, from_address) VALUES (1, ?, ?, ?, ?, ?)", "127.0.0.1", 9730, "/send/email", "email-secret-key", "alerts@example.com") {
+        Ok(n) => n,
+        Err(e) => -1,
+    }
+    let inserted_sms: i64 = match db_execute(conn, "INSERT INTO sms_provider_config (active, host, port, path, api_key, from_address) VALUES (1, ?, ?, ?, ?, ?)", "127.0.0.1", 9730, "/send/sms", "sms-secret-key", "+15550100") {
+        Ok(n) => n,
+        Err(e) => -1,
+    }
+    print(created_email + created_sms + created_push + inserted_email + inserted_sms) // 2 -- all five DDL/DML statements succeeded; the three `CREATE TABLE`s report 0 rows affected, the two `INSERT`s report 1 each
+
+    // `json_parse` on a fixed, valid literal can't actually fail, but
+    // the type system doesn't know that -- `send_and_report` (the `Ok`
+    // arm) is the real final owner of `conn`/`mq_conn` from here, doing
+    // its own `stop` at the very end, the same "whichever fn is left
+    // holding it stops it" discipline this file's own header describes.
+    match json_parse("{\"ticket\":1}") {
+        Ok(vars) => send_and_report(conn, mq_conn, vars),
+        Err(e) => print(e),
+    }
+}
+
+fn send_and_report(conn: db, mq_conn: mq, vars: json) -> unit {
+    // Real, configured -- a real POST leaves the process for each of
+    // these three calls (`send_email`/`send_sms`/`notify` all resolve
+    // to the same test server below).
+    match send_email(conn, ByRole("on_call_engineer"), "incident_opened", vars) {
+        Err(e) => print(false),
+        Ok(sent) => print(sent), // 1
+    }
+    match send_sms(conn, ByRole("on_call_engineer"), "incident_opened", vars) {
+        Err(e) => print(false),
+        Ok(sent) => print(sent), // 1
+    }
+    // No `push_provider_config` row at all -- a real `Err`, never a trap.
+    match send_push(conn, ByRole("on_call_engineer"), "incident_opened", vars) {
+        Ok(sent) => print(true),
+        Err(e) => print("push not configured"), // push not configured
+    }
+    match notify(conn, mq_conn, ByRole("on_call_engineer"), "incident_opened", vars) {
+        Err(e) => print(false),
+        Ok(sent) => print(sent), // 1 -- delegated to the same configured email provider
+    }
+    stop conn
+    stop mq_conn
+}
+
+workflow Incident {
+    state Open {
+        on_entry {
+            notify_all_channels(instance_id)
+        }
+        on Resolve -> Resolved
+    }
+    state Resolved terminal {
+    }
+}
+
+// `on_entry`'s own implicit binding here is `instance_id: i64` (always)
+// -- a fresh `db`/`mq` connection is opened right here, the same way
+// any ordinary function would, rather than being threaded in.
+fn notify_all_channels(instance_id: i64) -> unit {
+    match db_connect(":memory:") {
+        Ok(conn) => connect_mq_and_notify(conn, instance_id),
+        Err(e) => print(e),
+    }
+}
+
+fn connect_mq_and_notify(conn: db, instance_id: i64) -> unit {
+    match mq_connect("127.0.0.1", 6379) {
+        Ok(mq_conn) => notify_with_conn(conn, mq_conn, instance_id),
+        Err(e) => print(e),
+    }
+}
+
+// Stands in for a real email/SMS provider: three real, configured sends
+// happen above (`send_email`, `send_sms`, and `notify`'s own delegated
+// email send) -- `send_push` never even opens a connection (no provider
+// row), so exactly three real accepts are expected here.
+fn fake_provider(l: tcp_listener) -> unit {
+    let c1: tcp = accept(l)
+    let r1: str = recv(c1)
+    print(r1)
+    send(c1, "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nok")
+    stop c1
+
+    let c2: tcp = accept(l)
+    let r2: str = recv(c2)
+    print(r2)
+    send(c2, "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nok")
+    stop c2
+
+    let c3: tcp = accept(l)
+    let r3: str = recv(c3)
+    print(r3)
+    send(c3, "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nok")
+    stop c3
+    stop l
+}
+
+fn main() {
+    let l: tcp_listener = listen(9730)
+    let h: thread unit = spawn fake_provider(l)
+
+    let instance_id: i64 = match start_incident(None(), IncidentData()) {
+        Ok(id) => id,
+        Err(e) => -1,
+    }
+    print(instance_id) // 1
+
+    join h
+}

--- a/examples/features/54_compiled_workflow_escalation.nir
+++ b/examples/features/54_compiled_workflow_escalation.nir
@@ -1,0 +1,156 @@
+// Feature: `state { sla_seconds: N }` plus the synthesized
+// `list_<workflow>_overdue()` (`docs/ROADMAP.md` A15) -- real, compiled
+// SLA/escalation *detection*, driving a real, disclosed "external
+// scheduler" pattern: poll `list_<workflow>_overdue()`, then call
+// `advance_<workflow>(...)` on whatever it reports to move the stale
+// instance into an `Escalated` state. Companion to
+// `52_compiled_workflow_state_machine.nir` (state machine) and
+// `53_compiled_workflow_notifications.nir` (notifications) -- see that
+// file's own header for why this is three files, not one.
+//
+// `docs/WORKFLOW.md`'s own "Deliberate non-goals" section already
+// discloses there is no scheduling/cron primitive in this language at
+// all -- nothing fires "N seconds from now" on its own. `main` below
+// stands in for a real external scheduler: it polls
+// `list_<workflow>_overdue()` and *manually* calls `advance_<workflow>`
+// to escalate -- exactly the round trip `docs/WORKFLOW.md`'s
+// SLA/escalation enterprise-catalog row names as "what it would take."
+// No notification transport in this file -- that's already proven
+// end-to-end in `53_compiled_workflow_notifications.nir` -- `Escalated`'s
+// own `on_entry` just logs, keeping this file's own scope narrow:
+// overdue detection + escalation, not a second copy of file 53's
+// notification proof.
+
+fn log_opened(instance_id: i64) -> unit {
+    print("incident", instance_id, "opened")
+}
+
+fn log_escalated(instance_id: i64) -> unit {
+    print("incident", instance_id, "escalated to manager")
+}
+
+fn log_resolved(instance_id: i64) -> unit {
+    print("incident", instance_id, "resolved")
+}
+
+workflow Incident {
+    state Open {
+        // A real SLA -- `docs/ROADMAP.md` A15's own proposed shape,
+        // `sla_seconds` a plain `state`-level `key: value` entry
+        // (`ast::StateDecl.entries`), the same convention `owner:`/
+        // `label:` already use (`docs/WORKFLOW.md`). 1 second here only
+        // so this example finishes fast and deterministically -- a real
+        // app would use a real SLA like 172800 (48h).
+        sla_seconds: 1
+        on_entry {
+            log_opened(instance_id)
+        }
+        on Escalate -> Escalated
+        on Resolve -> Resolved
+    }
+    // No `sla_seconds` here -- an escalated incident isn't itself
+    // subject to a second SLA in this example, proving
+    // `list_incident_overdue` really does look at *per-state*
+    // `sla_seconds`, not a workflow-wide setting.
+    state Escalated {
+        on_entry {
+            log_escalated(instance_id)
+        }
+        on Resolve -> Resolved
+    }
+    state Resolved terminal {
+        on_entry {
+            log_resolved(instance_id)
+        }
+    }
+}
+
+// Walks `list_<workflow>_overdue`'s returned JSON array for real
+// (`json_array_get`/`json_get_i64`, `Ty::Json`'s doc comment) rather
+// than string-matching the raw JSON text -- broken out into its own fn,
+// one level of `match` nesting at a time, rather than one deeply nested
+// expression, so each `match`'s own expected-return-type context is
+// unambiguous.
+fn instance_is_overdue(j: json, target_id: i64) -> bool {
+    return match json_array_get(j, 0) {
+        Ok(item) => match json_get_i64(item, "instance_id") {
+            Ok(id) => id == target_id,
+            Err(e) => false,
+        },
+        Err(e) => false,
+    }
+}
+
+// Same wrapper shape `52_compiled_workflow_state_machine.nir`'s own
+// `advance_now` already uses -- `advance_incident`'s trailing
+// `payload: json` argument needs a real `json` value, not the
+// `Result(json, str)` `json_parse` itself returns.
+fn advance_now(identity: VerifiedIdentity, instance_id: i64, event: IncidentEvent) -> Result(bool, WorkflowActionError) {
+    return match json_parse("{}") {
+        Ok(payload) => advance_incident(identity, instance_id, event, payload),
+        Err(e) => Err(NoSuchTransition()),
+    }
+}
+
+fn main() {
+    // A real scheduler-shaped caller, not a human -- built directly here
+    // rather than through a real `oidc_validate_token` round trip, the
+    // same shortcut `52_compiled_workflow_state_machine.nir`'s own
+    // `main` already takes when the point is the workflow, not the JWT.
+    let identity: VerifiedIdentity = VerifiedIdentity("scheduler", "https://mock-idp.local", "ops-app", 9999999999, 0, "{}")
+
+    // `Open`'s own `on_entry` already ran before this returns -- "incident
+    // 1 opened" prints before this `print(instance_id)` does, for real.
+    let instance_id: i64 = match start_incident(None(), IncidentData()) {
+        Ok(id) => id,
+        Err(e) => -1,
+    }
+    print(instance_id) // 1
+
+    // Not overdue yet -- `entered_at` is "now".
+    match list_incident_overdue() {
+        Ok(j) => print(j), // []
+        Err(e) => print("overdue query failed"),
+    }
+
+    sleep_ms(1100)
+
+    // Stand-in for an external scheduler's poll: a real stale instance,
+    // real JSON, straight from `__workflow_overdue`'s own SQLite query --
+    // not a mock.
+    let is_overdue: bool = match list_incident_overdue() {
+        Ok(j) => instance_is_overdue(j, instance_id),
+        Err(e) => false,
+    }
+    print(is_overdue) // 1 (true) -- [{"instance_id":1,"state":"Open","age_seconds":...}]
+
+    // The realistic escalation call: the scheduler already knows which
+    // instance it just found overdue (`instance_id`, above) -- it calls
+    // the exact same `advance_<workflow>` any authenticated caller would.
+    // `Err(e) => false` has to come first here, not `Ok(v) => v` --
+    // `codegen.rs::local_ty_of`'s own match-result-type inference reads
+    // `arms[0]`'s body type, and a bound-by-this-very-match identifier
+    // (`v`) isn't in scope yet at that point; a literal-typed first arm
+    // sidesteps it cleanly. Same order `52_compiled_workflow_state_machine.nir`'s
+    // own `advance_now`-consuming `match`es already use.
+    let escalated: bool = match advance_now(identity, instance_id, Escalate()) {
+        Err(e) => false,
+        Ok(v) => v,
+    }
+    print(escalated) // 1 (true) -- Open's on_exit (none declared) then Escalated's on_entry ran
+
+    // `Escalated` declares no `sla_seconds` -- even though real wall-clock
+    // time has kept passing, it's structurally never reported overdue.
+    // Proves `list_<workflow>_overdue` really is per-state, not "any
+    // instance older than N seconds."
+    match list_incident_overdue() {
+        Ok(j) => print(j), // []
+        Err(e) => print("overdue query failed"),
+    }
+
+    let resolved: bool = match advance_now(identity, instance_id, Resolve()) {
+        Err(e) => false,
+        Ok(v) => v,
+    }
+    print(resolved) // 1 (true)
+}

--- a/examples/features/README.md
+++ b/examples/features/README.md
@@ -44,7 +44,7 @@ that's the one file here meant to be read, not run, on its own.
 | 30 | `30_identity_oidc.nir` | `oidc_validate_token`/`check_role`/`extract_claim`/`identity_expired` |
 | 31 | `31_mock_identity_provider.nir` | `mock_issue_token` — the mock-IdP inverse of `oidc_validate_token` |
 | 32 | `32_sessions_and_api_keys.nir` | `create_application_session`/`session_cookie`/`new_refresh_token`/`exchange_refresh_token`/`check_revocation`/`validate_api_key` |
-| 33 | `33_privileged_functions.nir` | `requires(role:...)`/`requires(claim:...,...)` + `acquire` |
+| 33 | `33_privileged_functions.nir` | `requires(role:...)`/`requires(claim:...,...)` + `acquire` — the mechanism itself compiles now (2026-09), but this file's own worked examples route through `oidc_validate_token`/`extract_claim` (still interpreter-only-designed), so it doesn't run end to end; see `50_field_masking_and_check_role.nir` for a `check_role`-driven role-gated flow that does |
 | 34 | `34_requires_public.nir` | `requires(public)` |
 | 35 | `35_validate_contracts.nir` | `validate { pre:/post: }` Hoare contracts |
 | 36 | `36_transact.nir` | `transact { precheck?/network/verify/commit/compensate?/log? }` |
@@ -60,7 +60,7 @@ that's the one file here meant to be read, not run, on its own.
 | 46 | `46_db_schema_and_role_mapping_conventions.nir` | `serve --db` auto schema migrations + `RoleMapping` identity cache (pure convention, no new syntax) |
 | 47 | `47_external_service_boundary.nir` | plugin-backed `db`/`mq` by URL scheme (`db_connect`/`mq_connect_via`) |
 | 49 | `49_nfr.nir` | `nfr(latency_ms:/error_rate_max:/throughput_min_per_sec:/concurrency_max:)` — compiled, automatic APM tracking |
-| 50 | `50_field_masking_and_check_role.nir` | field-level `requires(role/claim:...)` masking + compiled `check_role` — the README's own hero example |
+| 50 | `50_field_masking_and_check_role.nir` | field-level `requires(role/claim:...)` masking + function-level `requires(role:...)`/`acquire` + compiled `check_role` — the README's own hero example |
 
 ## Deliberately not given their own file
 

--- a/examples/features/README.md
+++ b/examples/features/README.md
@@ -1,13 +1,19 @@
 # Nirdosha — feature catalogue
 
-One `.nir` file per language feature, each independently runnable
-(`nirdosha <file>`) and verified against `target/debug/nirdosha`. Every
-file is self-contained — no external services required, though a few
+One `.nir` file per language feature, each independently runnable and
+verified against `target/debug/nirdosha`. **2026-09: there is no
+interpreter and no bare `nirdosha <file>` run mode any more** — compile
+first, then run the binary: `nirdosha build <file>.nir -o <out> && <out>`.
+Every file is self-contained — no external services required, though a few
 (25/28/47) degrade gracefully (a real `Err`, not a crash) when Redis or
 network access isn't available.
 
 `45_module_namespacing.nir` `use`s `45_module_namespacing_helper.nir` —
 that's the one file here meant to be read, not run, on its own.
+`51_compiled_serve.nir` is the other exception: its own `main` loops
+forever accepting connections, so it's meant to be run in the background
+and driven with a real `curl` (see its own header comment), not read to
+completion by itself.
 
 | # | File | Feature |
 |---|---|---|
@@ -37,9 +43,9 @@ that's the one file here meant to be read, not run, on its own.
 | 23 | `23_tcp_listener.nir` | `tcp_listener`, `listen`, `accept` |
 | 24 | `24_file_io.nir` | `file`, `open` (`"r"`/`"w"`/`"a"`) |
 | 25 | `25_json.nir` | `json_parse`/`json_get_*`/`json_array_*`/`json_set_str` |
-| 26 | `26_http_and_https.nir` | `http_get`/`http_post`/`https_get`/`https_post` |
+| 26 | `26_http_and_https.nir` | `http_get`/`http_post`/`https_get`/`https_post` — compiled (2026-09); vendored TLS, chunked-transfer-encoding decoding |
 | 27 | `27_database.nir` | `db_connect`/`db_query`/`db_execute` (SQLite/Postgres) |
-| 28 | `28_message_queue.nir` | `mq_connect`/`mq_publish`/`mq_consume` (Redis) |
+| 28 | `28_message_queue.nir` | `mq_connect`/`mq_publish`/`mq_consume` (Redis) — the mechanism compiles (2026-09), but this file's own `Ok(m) => m` arm order hits the pre-existing `match_expr` limitation (`docs/PHASE0.md`'s "Twenty-first update"); see `crates/compiler/tests/codegen.rs`'s `mq_publish_and_consume_round_trip_a_real_message` for a working equivalent |
 | 29 | `29_crypto_hashing.nir` | `sha256_hex`, `constant_time_str_eq` |
 | 30 | `30_identity_oidc.nir` | `oidc_validate_token`/`check_role`/`extract_claim`/`identity_expired` |
 | 31 | `31_mock_identity_provider.nir` | `mock_issue_token` — the mock-IdP inverse of `oidc_validate_token` |
@@ -47,9 +53,9 @@ that's the one file here meant to be read, not run, on its own.
 | 33 | `33_privileged_functions.nir` | `requires(role:...)`/`requires(claim:...,...)` + `acquire` — the mechanism itself compiles now (2026-09), but this file's own worked examples route through `oidc_validate_token`/`extract_claim` (still interpreter-only-designed), so it doesn't run end to end; see `50_field_masking_and_check_role.nir` for a `check_role`-driven role-gated flow that does |
 | 34 | `34_requires_public.nir` | `requires(public)` |
 | 35 | `35_validate_contracts.nir` | `validate { pre:/post: }` Hoare contracts |
-| 36 | `36_transact.nir` | `transact { precheck?/network/verify/commit/compensate?/log? }` |
-| 37 | `37_transact_cross_process.nir` | `transact`'s cross-process layer + `retry`/`timeout` |
-| 38 | `38_workflow.nir` | `workflow { data/state/on_entry/on <Event> -> <State>/terminal/owner }` |
+| 36 | `36_transact.nir` | `transact { precheck?/network/verify/commit/compensate?/log? }` — compiled (2026-09, Layer 1 only) |
+| 37 | `37_transact_cross_process.nir` | `transact`'s cross-process layer + `retry`/`timeout` — `retry`/`timeout` rejected by the compiled path (architectural, `docs/TRANSACT.md`); no interpreter left to run this file any other way |
+| 38 | `38_workflow.nir` | `workflow { data/state/on_entry/on <Event> -> <State>/terminal/owner }` — the *full* design vision, still not runnable end to end (its own non-empty `data` block, and its dependency on `mock_issue_token`, which never got codegen); see `52`/`53`/`54` for the real, compiled subset |
 | 39 | `39_screen_ui.nir` | `screen <Struct> { title/field/action }` |
 | 40 | `40_dashboard.nir` | `dashboard { tile/chart }` |
 | 41 | `41_dashboard_visual.nir` | `dashboard { visual ... { render: "graph"\|"heatmap"\|"timeline" } }` |
@@ -61,6 +67,10 @@ that's the one file here meant to be read, not run, on its own.
 | 47 | `47_external_service_boundary.nir` | plugin-backed `db`/`mq` by URL scheme (`db_connect`/`mq_connect_via`) |
 | 49 | `49_nfr.nir` | `nfr(latency_ms:/error_rate_max:/throughput_min_per_sec:/concurrency_max:)` — compiled, automatic APM tracking |
 | 50 | `50_field_masking_and_check_role.nir` | field-level `requires(role/claim:...)` masking + function-level `requires(role:...)`/`acquire` + compiled `check_role` — the README's own hero example |
+| 51 | `51_compiled_serve.nir` | compiled `serve` — `str_index_of`/`str_slice`/`len(str)` hand-parse an HTTP request line over `listen`/`accept`, routing `/api/<fn>` to distinct compiled `fn`s by plain `if`/`else if` + `==`; real `curl`-drivable, no interpreter |
+| 52 | `52_compiled_workflow_state_machine.nir` | compiled `workflow` Layer 1 (2026-09) — `start_*`/`advance_*`, `on_entry`/`on_exit`, ordinary transitions, `terminal` states, `Err(NoSuchTransition)`/`Err(InstanceNotFound)` as real, non-trapping errors |
+| 53 | `53_compiled_workflow_notifications.nir` | compiled `send_email`/`send_sms`/`send_push`/`notify` fired from a workflow's `on_entry` — real authenticated HTTPS POSTs against a real, admin-editable provider row in a real SQLite table, and the real not-configured (`send_push`, no provider row) path |
+| 54 | `54_compiled_workflow_escalation.nir` | compiled `state { sla_seconds: N }` + `list_<workflow>_overdue()` (`docs/ROADMAP.md` A15) — real SLA/escalation *detection*, driving a real "external scheduler polls, then calls `advance_<workflow>`" escalation round trip; per-state, not workflow-wide (a state with no `sla_seconds` is never reported overdue) |
 
 ## Deliberately not given their own file
 

--- a/rfcs/0007-apm-runtime-kernel.md
+++ b/rfcs/0007-apm-runtime-kernel.md
@@ -132,7 +132,7 @@ outright by the correction:
 | P1 | Narrowed deadlock claims | Kept unchanged — §8. |
 | P1 | NFR governance | Kept as open work — §9, with the CLI-knob question replaced (compiled binaries have no `NIRDOSHA_{PREFIX}_POOL_*`-equivalent surface today; a new one would need designing, not migrating). |
 | P1 | Spawn-admission blocking hazard | **Reframed, not just kept**: there is no `thread_pool.rs` in the compiled path to protect from re-introduced deadlock — a compiled spawn scheduler doesn't exist yet. The hazard is real but prospective: whatever compiled thread scheduler eventually gets built (as part of B6) must have this property from its first line of code, not retrofitted. See §8. |
-| P2 | Authorization/admission error taxonomy | **Resolved as inapplicable, for now**: `acquire`/`requires(...)` don't compile (`codegen.rs:946-949` rejects `Expr::Acquire`) — there's no `PrivilegedFnNotAcquired`-equivalent in the compiled surface to conflict with `AdmissionDenied`. Reopens if `acquire` ever gains codegen. |
+| P2 | Authorization/admission error taxonomy | **Premise changed, conclusion unchanged, 2026-09**: `acquire`/`requires(...)` now compile for real (`docs/LANGUAGE.md` §6a) — the "doesn't compile" reason this row used to give is gone. Still not a live conflict: a failed `acquire` is an ordinary `Result::Err(str)` the program itself inspects, not a distinguishable runtime signal, and `AdmissionDenied` still isn't its own surfaced error kind either (§9's own "Authorization-oracle risk" entry has the fuller writeup). Reopens for real once `AdmissionDenied` becomes distinguishable. |
 | P2 | Numeric SLOs and rollout plan | Kept, re-baselined — §5, §10. |
 | P2 | Global sequencing as a serialization point | Kept — replay stays opt-in debug mode, §6. |
 
@@ -525,12 +525,26 @@ today has no natural multiple-tenant concept. This section is
 explicitly parked until B8 unblocks it, rather than force-fit onto a
 substrate that doesn't have the concept it needs.
 
-**Authorization-oracle risk — moot today, reopens later.** The
-decision document's concern (don't let `AdmissionDenied` leak
-authorization facts distinguishable from `PrivilegedFnNotAcquired`)
-doesn't apply because `acquire`/`requires(...)` don't compile
-(`codegen.rs:946-949`). Reopens exactly if/when `acquire` gains codegen
-— worth remembering rather than assuming permanently resolved.
+**Authorization-oracle risk — reopened, 2026-09, still not a live
+issue for a different reason.** `acquire`/`requires(role/claim: ...)`
+now compile for real (`docs/LANGUAGE.md` §6a, §10) — the premise this
+entry used to stand on ("doesn't apply because they don't compile") no
+longer holds, exactly as its own closing sentence anticipated. Checked
+against the real compiled behavior rather than reasoned about in the
+abstract: a failed `acquire` surfaces as an ordinary `Result::Err(str)`
+value the `.nir` program itself inspects via `match` — there is no
+`PrivilegedFnNotAcquired`-shaped *runtime* signal to leak in the first
+place (`PrivilegedFnNotAcquired` itself is `typeck.rs`'s own static
+rejection of a direct, unacquired call; a program that compiles never
+produces one at runtime). And `AdmissionDenied` still isn't a
+distinguishable signal on its own terms either — per §10's own phase
+table, a kernel denial still folds into the same generic `-1` every
+other kernel failure returns. So the concern stays moot, but now for
+the right reason (no distinguishable `AdmissionDenied` signal exists to
+correlate against anything), not the wrong one (acquire doesn't
+compile). Reopens for real if/when `AdmissionDenied` becomes its own
+distinct, surfaced error kind — that pairing is the one worth watching,
+not `acquire`'s compiled status by itself.
 
 **NFR governance — partially landed, 2026-09 — validation ranges done,
 precedence/composition/per-principal ceilings/staged rollout still

--- a/rfcs/0008-native-plugin-abi-widening.md
+++ b/rfcs/0008-native-plugin-abi-widening.md
@@ -1,0 +1,355 @@
+# RFC 0008: Native plugin ABI widening and Cargo-driven discovery — a compile-time-only path to a real plugin ecosystem
+
+> **Status.** Phase 1 (§Phase 1 below) is built and verified, on this
+> branch, not a proposal: `crate::plugin::NativePluginBuiltin::validate`
+> now accepts `str`, `handle(Kind)`, and `&handle(Kind)` in addition to
+> plain scalars; `codegen.rs::llvm_ty` gives `Ty::Handle(_)` a real `i64`
+> mapping (previously a hard `unsupported()` rejection). Two real
+> reference crates exist and are exercised end to end by a real compiled
+> binary, not just typechecked: `crates/plugin-example-native-shout`
+> (`str` both directions) and `crates/plugin-example-native-kv`
+> (`handle(Kind)` + `&handle(Kind)` borrow-to-read/move-to-close, `str`
+> params/returns). `crates/compiler/tests/native_plugin_codegen.rs` (new:
+> `a_str_typed_native_plugin_crosses_the_boundary_in_both_directions`,
+> `a_handle_typed_native_plugin_crosses_the_boundary_as_a_plain_i64`,
+> `a_native_plugin_handle_used_twice_is_a_compile_time_ownership_error`,
+> `a_borrowed_native_plugin_handle_can_be_read_any_number_of_times_
+> before_one_final_close`) and `crates/compiler/tests/
+> native_plugin_examples.rs` (new file: builds both example crates for
+> real via `cargo build --release`, links them into one compiled binary,
+> runs it) are the evidence — `cargo test -p nirdosha --no-fail-fast`
+> stays 100% green throughout, no existing behavior changed. Phases 2
+> (authoring macro), 3 (Cargo-driven `nirdosha build` auto-discovery),
+> and 4 (a real external-I/O plugin, e.g. `mysql`, ported onto this ABI
+> against a live service) remain open — Phase 1 makes them possible, it
+> doesn't do them. The rest of this document is the original design
+> capture, kept as written below; this box is the only part updated
+> after the fact.
+
+> **Provenance note.** This RFC responds directly to an external
+> assessment of this repo ("ecosystem is essentially zero outside the
+> language itself... adoption will depend heavily on how quickly the
+> missing I/O and data layers land") that turned out to be accurate,
+> not stale: `crates/plugin-example-{mysql,activemq,cassandra,neo4j,
+> hbase}/` and `crates/plugin-support/` — the only plugin ecosystem
+> that ever existed, giving real I/O to SQL/MQ/Cassandra/HBase/Neo4j —
+> were deleted in `c82fa1f` ("refactor: remove native plugin
+> ecosystem") because they depended entirely on the tree-walking
+> interpreter's `PluginBuiltin`/`PluginFn` dispatch, which no longer
+> exists on `remove-interpreter`. What survived,
+> `crates/compiler/src/plugin.rs`'s `NativePluginBuiltin`
+> (rfcs/0005 §3), is a real, shipped, compile-time-only calling
+> mechanism — but a scalar-only one, with no plugin built on it and no
+> way to discover one automatically. This RFC is explicitly scoped to
+> **not** reopen interpreter dispatch or any form of dynamic/WASM
+> loading (rfcs/0004's Kind C) — every mechanism proposed here resolves
+> at `nirdosha build` time and links statically, the same posture
+> `NativePluginBuiltin` already has.
+
+## Motivation
+
+`NativePluginBuiltin` (`crates/compiler/src/plugin.rs`) proved the hard
+part of the compiled-path plugin question in rfcs/0005 §3: a plugin
+author's `#[no_mangle] extern "C"` symbol, precompiled into a
+`staticlib`, can be declared and called directly from generated LLVM
+IR (`emit_llvm_ir_impl`, `codegen.rs:1307`, inserts the plugin's
+signature into the same `sigs` table an ordinary `fn` uses, so
+`Codegen::call`'s existing dispatch needs zero changes) and linked into
+the final `clang` invocation alongside `RUNTIME_KERNELS_LIB`
+(`build_impl`, `codegen.rs:6771`). `crates/compiler/tests/
+native_plugin_codegen.rs` proves this end to end: a real, separately
+`rustc`-compiled function, called from a real compiled binary, no
+interpreter anywhere in the path.
+
+Two things stop that proof from being an ecosystem:
+
+1. **`NativePluginBuiltin::validate()` accepted only scalars, as of the
+   state this RFC opens against** — `i8..usize`/`f64`/`bool`/`void`.
+   Every real I/O plugin the deleted gallery had (a SQL row, a
+   Cassandra query result, a DB connection handle) needs at least a
+   string or an opaque handle to cross the boundary; none of that
+   compiled at the time this RFC was opened (see the Status box above
+   for what §Phase 1 below has since changed).
+2. **There is no discovery mechanism at all.** Every existing native
+   plugin test hand-assembles a `&[NativePluginBuiltin]` slice in Rust
+   source (`native_plugin_codegen.rs:88`) and passes it to
+   `typecheck_with_native_plugins`/`build_with_native_plugins`
+   directly. The bare `nirdosha build` CLI has no way to *find* a
+   plugin crate on its own (`emit_llvm_ir_with_native_plugins`'s own
+   doc comment, `codegen.rs:1281-1292`, says exactly this). The Cargo-
+   based discovery design that once existed for the interpreter path
+   (`docs/ECOSYSTEM.md` §G1, "Stage 1", built 2026-09-04) was deleted
+   with the interpreter along with the plugins that used it.
+
+Neither gap is a request to relax "compile-time only, nothing
+interpreted" — both are asking that constraint to do more work than a
+scalar-only ABI and a hand-written Rust slice currently let it.
+
+## Design
+
+### Phase 1 — Widen the native ABI past scalars
+
+**1a. `Ty::Handle` costs nothing new and should be accepted immediately.**
+A `Ty::Handle(String)` value's runtime representation is already a
+plain `i64` (`HandleRegistry::insert`'s return, rfcs/0005 §1) with all
+of its safety coming from `ownership.rs`'s affine tracking at the
+*type* level, not from anything special in codegen. `codegen.rs`'s
+`llvm_ty` currently rejects `Handle` for the compiled path only because
+"plugins are already interpreter-only for the compiled path" (rfcs/0005
+§1) — a precondition this RFC removes. Concretely:
+`NativePluginBuiltin::validate`'s scalar check (`plugin.rs`) gains
+`Ty::Handle(_)`, and `codegen.rs::llvm_ty` emits `i64` for it exactly as
+it does for `Ty::Thread`/`Ty::Channel`/`Ty::File` today. **Built and
+verified** (see this document's Status box) — this really was as cheap
+as predicted, a one-line change in each of the two files.
+
+**1b. `str` crossing, using the representation that already exists —
+turned out to need even less new machinery than planned.** `codegen.rs`
+already defines `Ty::Str => "{ptr, i64}"` — Nirdosha's compiled string
+representation is *already* a pointer+length pair — and, load-bearing
+for this RFC, `Ty::is_aggregate()` **deliberately excludes** `Ty::Str`:
+a `str` value already passes and returns *by value*, in registers, the
+same way `f64` and `runtime-kernels/src/lib.rs`'s own two-word
+`Dec128Bits` do, never through the `sret`/by-pointer convention
+`Vector`/`Matrix`/`Ty::Named` need. Practical effect: `Codegen::call`'s
+existing generic `sigs`-driven dispatch already declares and calls a
+`str`-typed native symbol correctly with **zero codegen changes** — the
+original plan below (decompose into two separate scalar arguments, plus
+an explicit `<name>_free` convention for owned returns) turned out to
+be solving a problem codegen didn't have. What actually shipped is
+simpler: a plugin author's own `#[repr(C)]` struct of exactly `(ptr:
+*const u8, len: i64)`, passed **by value** (matching `Dec128Bits`'s own
+precedent exactly), in both directions. A `str`-typed return is never
+freed by Nirdosha at all — no `owns_returned_str` field, no free-symbol
+convention — matching the *existing*, already-shipped posture
+`codegen.rs`'s own `sha256_hex` builtin already has (`Ty::Str` isn't
+affine, so there is no scope-closing point to hook a free onto); a
+plugin author who wants a real free path can still add one to their own
+public API, but nothing about this ABI requires or invokes it. The
+original two-scalar-decomposition and `<name>_free` design below is
+kept struck through in spirit (not deleted from this document — this
+RFC's own convention, matching rfcs/0005's revision style, is to record
+what was tried and superseded, not silently rewrite history) by this
+paragraph; see `crates/plugin-example-native-shout` for the real,
+shipped shape.
+
+**1c. A real finding this RFC's original draft missed: reads must
+borrow, not just widen the type.** Building `crates/plugin-example-
+native-kv` (Phase 4-lite, done alongside Phase 1 — see Status box)
+surfaced a genuine gap the plan below didn't anticipate: `Ty::Handle`
+being affine (rfcs/0005 §1) means a bare `handle(Kind)`-typed parameter
+is **consumed** on its first use, exactly like any other affine value —
+so a native `kv_set`/`kv_get` declared as taking a plain `handle(Kind)`
+would make the handle unusable after the very first call, permanently
+blocking any real "connect once, query N times, close" plugin (which is
+most of them). The deleted interpreter-path test suite had already
+solved this once (`widget_query(&handle(Widget))`, rfcs/0005 §1's own
+evidence) and this RFC's Phase 1 rediscovers and ports the identical
+answer to the compiled path: `&handle(Kind)` — `Ty::Ref(Box::new(Ty::
+Handle(_)))` — **borrows** rather than consumes, and needed no new
+codegen either, because `codegen.rs::llvm_ty` already renders any
+`Ty::Ref(_)` as a plain one-word `ptr` (the address of the caller's
+`i64` handle slot). `NativePluginBuiltin::validate` accepts this one
+specific shape (not `Ty::Ref` in general — a `&str`/`&i64` native param
+would be redundant, since those already cross by value); the plugin's
+own Rust signature takes a `*const i64` and dereferences it once. Only
+the one real, final, resource-closing call (`kv_close(h)`, no `&`)
+consumes the handle. `crates/compiler/tests/native_plugin_codegen.rs`'s
+`a_borrowed_native_plugin_handle_can_be_read_any_number_of_times_
+before_one_final_close` is the proof.
+
+**1d. JSON as a str-boundary convenience, not a new ABI.** `Ty::Json`
+does **not** gain a native representation of its own. A native plugin
+that needs structured data declares its native signature as `str` in
+and/or out; a thin `.nir`-side or generated-shim `json_encode`/
+`json_decode` pair (already real builtins per `docs/ECOSYSTEM.md`'s
+own builtin registry, `[DONE]`) sits on the `.nir` side of the call.
+This is exactly what the deleted `cassandra_query` plugin did for row
+results in the interpreter world (`cql_value_to_json`) — moved to the
+`.nir` side of a str boundary instead of the Rust side, same shape.
+
+**Deliberately not attempted here**: raw `struct`/`enum` crossing,
+generics, trait objects, `async` — none of these have a compiled-path
+answer this RFC proposes, and rfcs/0005 §3's own "harder, still-open
+question" framing is correct that this is separate, larger design work
+than an ABI widening. A plugin author works around this the same way
+Rust FFI authors always have: flatten to scalars/strings/handles at
+the boundary, keep the rich type on the Rust side of it.
+
+### Phase 2 — An authoring convention (a macro + a manifest, not new tooling)
+
+A plugin author applies a proc-macro, e.g. `#[nirdosha_native_fn]`, to
+a function whose signature is already restricted to the Phase 1 surface
+(scalar | `Ty::Handle`-shaped `i64` | `&handle(Kind)`-shaped `*const
+i64` | `str`-shaped `#[repr(C)] { ptr, len }` by value). The macro:
+
+- Generates the `#[unsafe(no_mangle)] extern "C"` shim performing the
+  `NirStr`/handle-pointer marshaling (Rust `&str`/`String` in and out,
+  a dereferenced `*const i64` for a borrowed handle) — the same
+  mechanical translation `crates/plugin-example-native-shout` and
+  `crates/plugin-example-native-kv` currently hand-write (see each
+  crate's own `src/lib.rs`).
+- Registers the function's Nirdosha-facing signature (name, `Ty` for
+  each param, `Ty` for the return) into a `build.rs`-run collector.
+
+The plugin crate's `build.rs` dumps that collected signature list as a
+manifest file (plain TOML, one file per crate, sitting next to the
+compiled `.a` the same way `NativePluginBuiltin::static_lib`'s own doc
+comment already describes a plugin crate producing via
+`include_bytes!`) — **data written to disk by a build script the
+plugin author's own `cargo build` already runs**, not code the
+Nirdosha compiler ever executes. This preserves "everything happens at
+compile time, nothing interpreted" precisely: `nirdosha build` reads a
+TOML file, it never loads or runs a byte of the plugin crate's own
+logic to learn its shape.
+
+### Phase 3 — `nirdosha build` does the discovery and linking automatically
+
+Revives the `[package.metadata.nirdosha]` convention `docs/ECOSYSTEM.md`
+§G1 designed and partially shipped for the interpreter path (Stage 1,
+2026-09-04), re-targeted at `NativePluginBuiltin` instead of the
+deleted `PluginBuiltin`/`NirdoshaPlugin` trait:
+
+1. A project's own `Cargo.toml` lists native plugin crates as ordinary
+   `[dependencies]`, tagged `kind = "nir-native"` in that crate's own
+   `[package.metadata.nirdosha]` block so `nirdosha build` can tell a
+   plugin crate from an ordinary Rust dependency without guessing.
+2. `nirdosha build` (or a `nirdosha plugin fetch` prep step) shells out
+   to `cargo build --release -p <plugin-crate>` for each declared
+   plugin — a build-time subprocess invocation, the same posture
+   `codegen.rs::build_impl` already takes toward `clang` (`codegen.
+   rs:6815`), not runtime interpretation of anything.
+3. Reads each plugin's Phase-2 manifest, constructs the
+   `NativePluginBuiltin` roster in-process (replacing today's
+   hand-written Rust slice), and passes it to
+   `typecheck_with_native_plugins`/`build_with_native_plugins`/
+   `emit_llvm_ir_with_native_plugins` exactly as `native_plugin_codegen.
+   rs`'s test already does manually.
+4. Reads the compiled `.a` bytes from each plugin crate's own target
+   directory into `NativePluginBuiltin::static_lib`, replacing the
+   test's `include_bytes!`/manual-read stand-in with a real discovered
+   path.
+
+None of steps 1-4 introduce a new registry, a new file format nobody
+already reads (TOML via `[package.metadata.*]` is exactly what Cargo
+itself already supports for third-party tool metadata), or any load of
+the plugin's logic ahead of static linking.
+
+### Phase 4 — Prove it on one real crate before calling it done
+
+Port `mysql` — the most complete of the five deleted plugins — onto
+this ABI end to end: `connect`/`query`/`execute`/`close` as
+`Ty::Handle`+`Ty::Str` native functions, a real `nirdosha build`
+producing a native binary, run against a live MySQL container, the
+same live-verification bar `docs/ECOSYSTEM.md` §G1's Stage 1 gap-
+closing pass and rfcs/0005 §3 both already held themselves to. Only
+after this lands does "a real, compile-time plugin ecosystem" stop
+being a claim about a mechanism and start being a claim about
+something a `.nir` program can actually do.
+
+## Effect on the permission model
+
+`NativePluginBuiltin` today carries no effect classification at all —
+unlike the interpreter's `PluginBuiltin`, which gained a required
+`effects: BTreeSet<Effect>` field in rfcs/0003 specifically because an
+untagged plugin call was invisible to `effects.rs`'s `Expr::Call`
+walk and let a function declaring `effect(pure)` call a real
+network-backed plugin undetected. The compiled path doesn't run
+`effects::infer_effects` as part of `nirdosha build` today (only
+`emit-ui`, `main.rs:475`, does, for its own unrelated reason) — so this
+RFC introduces no *regression* — but the instant effect-purity checking
+is extended to the compiled path (a real, separately-tracked need),
+`NativePluginBuiltin` will need the identical `effects` field rfcs/0003
+already added to its interpreter counterpart, or the exact
+same unsoundness reappears on the compiled side. Tracked as an open
+question below rather than solved here, since it's speculative against
+work that hasn't landed.
+
+`requires(role/claim: ...)`/`acquire`/`screen` gates are unaffected: a
+native plugin call is an ordinary function call in `sigs` as far as
+`typeck.rs` is concerned (`codegen.rs:1328`'s comment is explicit about
+this), so anything gating a call today gates a native plugin call
+identically.
+
+## Compatibility
+
+Fully additive, and turned out even more so than planned: `NativePluginBuiltin`'s
+own shape (`name`/`params`/`ret`/`static_lib`) is unchanged — no new
+field, since the simpler by-value `str`/leak-always convention (§Phase
+1b) needed none. `validate()`'s internal check gained `Ty::Str`,
+`Ty::Handle(_)`, and `Ty::Ref(Box<Ty::Handle(_)>)` as accepted shapes;
+`codegen.rs::llvm_ty` gained one new match arm (`Ty::Handle(_) =>
+"i64"`, previously a hard rejection). No `.nir` grammar changes — `&h`
+and `handle(Kind)` were already real, parseable syntax (rfcs/0005).
+No existing `.nir` program's compiled output changes, because none
+shipped anywhere already calls a native plugin (every caller is a
+Rust-side test harness — `native_plugin_codegen.rs`,
+`native_plugin_examples.rs` — not a `.nir` program distributed on its
+own). `cargo test -p nirdosha --no-fail-fast` stayed 100% green
+throughout this change, confirming no existing behavior moved.
+
+## Rejected alternatives
+
+**WASM/dynamic loading (rfcs/0004's Kind C) as the ecosystem answer.**
+Explicitly out of scope by the requirement that motivated this RFC:
+"nothing should be interpreted, everything should happen at compile
+time." `wasmtime`-hosted plugins, even AOT-compiled, still load and
+instantiate a module at the target program's runtime, not at
+`nirdosha build` time — a different trust/performance trade rfcs/0004
+already spiked (real numbers, rot13-to-WASM) for a genuinely different
+goal (isolating an *untrusted* plugin author). This RFC's plugins are
+exactly as trusted as `RUNTIME_KERNELS_LIB` already is: statically
+linked into the same binary, checked by the same `rustc`/`clang`.
+
+**A bespoke Nirdosha plugin registry instead of Cargo.** Rejected for
+the same reason `docs/ECOSYSTEM.md` §G1 already rejected it for the
+interpreter path: hosting a service, a publish CLI, and its own
+uptime/abuse-moderation is the expensive option for a project this RFC
+itself is trying to make *more* self-sustaining, not less
+(`docs/ECOSYSTEM.md` §G5's solo-maintainer note). Cargo/crates.io
+already solve resolution, semver, lockfiles, and hosting; the only
+missing piece is the metadata convention Phase 2/3 define.
+
+**A generic (non-scalar) FFI ABI via serialization of arbitrary Rust
+types (e.g. `serde`-derived binary encoding for any `T`).** Rejected as
+solving a bigger problem than the evidence justifies: every real
+plugin in the deleted gallery needed at most scalars, one connection
+handle, and JSON-shaped query results — str+Handle+JSON-over-str covers
+that whole surface without inventing a general cross-language type
+encoding, which is genuinely open research (rfcs/0005 §3's own framing)
+rather than a bounded engineering task.
+
+## Open questions
+
+- **Effect classification for native plugins**, deferred above pending
+  compiled-path effect-purity checking actually existing to protect.
+- **`str`-return memory growth is a real, disclosed, unsolved cost, not
+  just a rot13-scale curiosity.** Every native-plugin-returned string is
+  leaked for the life of the process (§Phase 1b) — fine for
+  `plugin_shout`'s scale, a real concern for a plugin returning large or
+  frequent query results (`kv_get` included) in a long-running server
+  process. A real free-path convention (plugin-exported
+  `<name>_free(ptr, len)`, called once Nirdosha's own use of the string
+  provably ends) was in this RFC's first draft and was cut for being
+  unjustified by the evidence *so far* — Phase 4's `mysql` port, under
+  real sustained load, is what would actually justify designing it for
+  real instead of guessing.
+- **Should `&T` crossing generalize past `handle(Kind)`?** `Ty::Ref` is
+  accepted narrowly (`Ty::Ref(Box<Ty::Handle(_)>)` only) because that's
+  the one case with a proven need (§Phase 1c). `Ty::Db`/`Ty::Mq` are
+  also affine (rfcs/0005 §1) and would hit the identical "reads must
+  borrow" problem the moment either gets a compiled-path story — worth
+  widening then, not speculatively now.
+- **Versioning across `nirdosha` releases**: rfcs/0003 raised "what
+  does plugin ABI compatibility mean given static linking" for the
+  interpreter path and left it a policy question; static linking makes
+  it arguably simpler here (a plugin is always rebuilt against the
+  `nirdosha` version compiling it, never loaded against a mismatched
+  one at runtime) but that argument hasn't been written down formally
+  yet.
+- **Windows.** `build_impl`'s existing native-plugin linking already
+  has a real Unix/Windows split for system libraries (`codegen.
+  rs:6829-6834`); a plugin crate's own staticlib crossing that same
+  split (calling convention, `.lib` vs `.a`) isn't addressed here and
+  needs its own pass before Phase 4's `mysql` port is called done on
+  more than one platform.

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -19,6 +19,7 @@ this list.
 | [0005](./0005-plugin-boundary-safety-and-performance.md) | The Nirdosha↔Rust plugin boundary — safety and performance |
 | [0006](./0006-structured-concurrency.md) | Structured concurrency for native threads — Pillars 1-4 |
 | [0007](./0007-apm-runtime-kernel.md) | A compiled-path resource-control kernel — boundary-leased admission, fail-open telemetry, and NFRs-as-language |
+| [0008](./0008-native-plugin-abi-widening.md) | Native plugin ABI widening and Cargo-driven discovery — a compile-time-only path to a real plugin ecosystem |
 
 A decision made in the course of implementing something, not designed
 up front, goes in [`docs/adr/`](../docs/adr/README.md) instead — a


### PR DESCRIPTION
## Summary

- Compiles `workflow_lower.rs`'s synthesized functions for real: `start_*`/`advance_*`, `on_entry`/`on_exit` actions, ordinary transitions, `terminal` states, and `Err(NoSuchTransition)`/`Err(InstanceNotFound)` as real, non-trapping results.
- `send_email`/`send_sms`/`send_push`/`notify` compile to real authenticated HTTPS POSTs against an admin-editable provider row.
- `state { sla_seconds: N }` + `list_<workflow>_overdue()` (`docs/ROADMAP.md` A15) compile as real SLA/escalation *detection* (no automatic firing — an external scheduler still has to poll and call `advance_<workflow>` itself).
- Two general (non-workflow-specific) compiler bugs found and fixed along the way:
  - `match_enum`/`match_literal`: aggregate-result arms now route through `expr_ptr_expected` instead of plain `expr_ptr`.
  - `print()` now handles `Ty::Json` instead of silently falling through to a broken `i64`-typed printf call.
  - `ownership.rs`: `notify(conn, mq, ...)` has two connection-shaped arguments, but the "leading db/mq arg is read, not consumed" exemption only checked index 0 — fixed to also exempt index 1 for `notify`.
- Three new example files (`52`/`53`/`54`), all built and run for real, output inspected. 5 new `crates/compiler/tests/codegen.rs` tests.
- Docs synced: `docs/WORKFLOW.md`, `docs/LANGUAGE.md`, `docs/ROADMAP.md`, `docs/PUBLIC_ROADMAP.md`, `docs/PHASE0.md`.
- `sandbox` (Phase 6) explicitly descoped from the first production release per direct user decision — recorded in `docs/ROADMAP.md`/`docs/PUBLIC_ROADMAP.md`/`docs/SANDBOXING.md`, not silently dropped.

## Test plan

- `cargo test -p nirdosha` — every test file green, 108/108 in `tests/codegen.rs`.
- `cargo test` from `crates/runtime-kernels`'s own separate workspace — 84/84 (`--skip kernel::recorder`).
- `examples/features/52_compiled_workflow_state_machine.nir`, `53_compiled_workflow_notifications.nir`, `54_compiled_workflow_escalation.nir` — each built with `nirdosha build` and run as a real binary, stdout inspected against inline comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)