### PR TITLE
docs: sync docs/comments with the interpreter-removal and RFC 0007 reality

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,9 +12,12 @@ A clear description of what went wrong.
 
 **Diagnostic output**
 
-Run the failing case with `nirdosha <file.nir> --format=json` and paste
-the `Diagnostic` JSON here — it's the fastest way to pin down exactly
-where things went wrong.
+Run the failing case with `nirdosha emit-ui <file.nir> -o /tmp/out.html`
+(typecheck/ownership errors) or `nirdosha build <file.nir> -o /tmp/out`
+(codegen "unsupported" errors) and paste the error output here — it's
+the fastest way to pin down exactly where things went wrong. (There is
+no interpreter and no `--format=json` flag anymore — see
+[`SECURITY.md`](../../SECURITY.md) / `docs/API_TRUST_MODEL.md` §4a.)
 
 ```json
 paste here

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,8 @@
 
 Nirdosha is a security/systems-focused DSL (structs/enums, affine
 `box`/`db`/`tcp`/`file`/`mq`/`sandbox` handles, Row 12 identity) with a
-Rust compiler (interpreter + LLVM codegen) at `crates/compiler/`. This
+Rust compiler (LLVM codegen only — the tree-walking interpreter was
+deleted) at `crates/compiler/`. This
 file is the minimum needed to orient — everything else loads on demand
 from the table below. Don't read `docs/GRAMMAR.md`/`docs/LANGUAGE.md`/etc.
 up front; load the one row you actually need.
@@ -14,12 +15,17 @@ cd crates/compiler
 cargo build                              # build the nirdosha CLI
 cargo test                                # full suite (unit + crates/compiler/tests/*.rs)
 cargo test --test <name>                  # one integration test file
-cargo run -- <file.nir>                   # interpret
 cargo run -- build <file.nir> -o <out>    # compile to a native binary (LLVM, -O2)
 cargo run -- emit-ast <file.nir>          # parsed AST as JSON -- lex+parse ONLY, does NOT typecheck (by design: an ill-typed program is still inspectable)
-cargo run -- emit-ui <file.nir> -o out.html   # derive a web UI from struct/fn conventions -- full typecheck+ownership pass, no side effects; the actual fastest typecheck-only smoke test
-cargo run -- serve <file.nir> --port 8080     # run as a real HTTP service
+cargo run -- emit-ui <file.nir> -o out.html   # derive a static-HTML web UI from struct/fn conventions -- full typecheck+ownership pass, no side effects; the actual fastest typecheck-only smoke test
+cargo run -- emit-catalog [-o out.json]   # dump the resolved UI catalog (std + linked UI-plugin components) as JSON
+cargo run -- gen-crud <file.nir>          # scaffold CRUD fns for a struct
 ```
+
+There is no `run`/`serve` subcommand — the tree-walking interpreter and
+its HTTP server (`interpreter.rs`/`serve.rs`) were deleted; `codegen.rs`
+is the only backend, and `emit-ui`'s output is a static, self-contained
+HTML file with no server behind it.
 
 ## Facts that will cost you real time to rediscover — read these once
 
@@ -67,7 +73,7 @@ All of the following live under `docs/`.
 |---|---|
 | Current status of everything, what's shipped, what's pending, sequencing | `docs/ROADMAP.md` |
 | EBNF grammar, LL(1)/parser disambiguation rules | `docs/GRAMMAR.md` |
-| Type system, operators, builtins list, what's compiled vs. interpreter-only (verify against `codegen.rs::check_supported` directly, not just this doc) | `docs/LANGUAGE.md` |
+| Type system, operators, builtins list, what's still not compiled (verify against `codegen.rs::check_supported` directly, not just this doc) | `docs/LANGUAGE.md` |
 | Design philosophy / the "rows" (no-GC, no-races, determinism, LLM-friendliness, ...) | `docs/goal.md` |
 | Phase-by-phase build plan (0.5 → 5) | `docs/Nirdosha_Unified_Plan.md` |
 | `transact` durability protocol (WAL, crash replay, `txn_id`, retry/timeout) | `docs/TRANSACT.md` |
@@ -92,11 +98,14 @@ packages or tooling.
 
 ## Load on demand — large source files
 
-`crates/compiler/src/INDEX.md` maps every file over ~500 lines
-(`codegen.rs`/`interpreter.rs`/`typeck.rs`/`ast.rs`/`parser.rs`/
-`ui_gen.rs`/`serve.rs`/`ownership.rs`/`runtime_kernels.rs`/`smt.rs`/
-`refine.rs`/`main.rs`) to its structural pieces by name, with an
-approximate line number as a fast-path hint — check that before reading
-one of these files in full. The names are the durable part; a line
-number will drift as the file is edited, `grep -n` the name if it looks
-off rather than trusting a stale offset.
+`crates/compiler/src/INDEX.md` maps every `crates/compiler/src/` file
+over ~500 lines (`codegen.rs`/`typeck.rs`/`ast.rs`/`ui_gen.rs`/
+`parser.rs`/`contract_check.rs`/`ownership.rs`/`smt.rs`/`refine.rs`/
+`main.rs`/`token.rs`/`effects.rs`) to its structural pieces by name,
+with an approximate line number as a fast-path hint — check that before
+reading one of these files in full. The names are the durable part; a
+line number will drift as the file is edited, `grep -n` the name if it
+looks off rather than trusting a stale offset. The compiled-path
+runtime kernels (`det`/`inv`/`kf_update`/`tcp`/`file`, ...) live in
+their own crate now, `crates/runtime-kernels/`, not
+`crates/compiler/src/` — see `docs/adr/0003-runtime-kernels-cargo-dependency.md`.

--- a/AREAS.md
+++ b/AREAS.md
@@ -18,10 +18,10 @@ nobody may touch.
 | Area | Path(s) | Owner | Notes |
 |---|---|---|---|
 | Compiler core (parser, typeck, ownership, SMT/refine) | `crates/compiler/src/{parser,typeck,ast,ownership,smt,refine}.rs` | `arunsoman` | Static-checking pipeline. See `crates/compiler/src/INDEX.md` for the per-function map. |
-| Interpreter | `crates/compiler/src/interpreter.rs` | `arunsoman` | The reference execution semantics — anything the native backend doesn't yet cover falls back here. |
-| Native codegen (LLVM) | `crates/compiler/src/codegen.rs`, `runtime_kernels.rs` | `arunsoman` | Narrower than the interpreter by design (`check_supported`'s explicit reject list); help wanted closing Track B gaps, `docs/ROADMAP.md`. |
-| UI/screen DSL | `crates/compiler/src/{ui_gen,serve}.rs` | `arunsoman` | Manifest derivation + the server that enforces its gates; see `docs/LANGUAGE.md` §11–13. |
-| Plugin/extension system | `crates/compiler/src/plugin.rs`, `crates/plugin-example-rot13/` | `arunsoman` | New, Track G1 Kind A (native builtin extension via Cargo) — actively in progress; see `rfcs/0001-package-manifest-format.md`. |
+| Native codegen (LLVM) | `crates/compiler/src/codegen.rs`, `runtime_kernels.rs` | `arunsoman` | The only backend now — the tree-walking interpreter (`interpreter.rs`) was deleted; `check_supported`'s explicit reject list is the ground truth for what still isn't compiled. Help wanted closing those gaps, `docs/ROADMAP.md`. |
+| UI/screen DSL | `crates/compiler/src/ui_gen.rs` | `arunsoman` | Manifest + static HTML derivation (`emit-ui`). `serve.rs` (the HTTP server that enforced gates server-side) was deleted along with the interpreter — gating today is client-side only in the emitted HTML; see `docs/LANGUAGE.md` §11–13 and `docs/API_TRUST_MODEL.md`. |
+| UI-plugin components | `crates/compiler/src/ui_plugin.rs`, `crates/ui-plugin-example-sparkline/` | `arunsoman` | Compile-time `layout` widget extension + Cargo-metadata auto-discovery; see `rfcs/0009-ui-catalog-extensibility.md`. |
+| Plugin/extension system | `crates/compiler/src/plugin.rs`, `crates/plugin-example-native-shout/`, `crates/plugin-example-native-kv/` | `arunsoman` | Native builtin extension via Cargo, Phase 1 built and verified; see `rfcs/0008-native-plugin-abi-widening.md`. |
 | Grammar / GBNF / constrained decoding | `crates/grammar_check/`, `crates/grammar_export/`, `crates/compiler/nirdosha.gbnf` | `arunsoman` | LALR(1) cross-check against the hand-written LL(1) parser; corpus entries are a **help wanted** / good-first-issue source (see open issue #3). |
 | LLM eval harness | `crates/bench/` | `arunsoman` | Real pass@1/self-repair scaffold, mock models only today — **help wanted** wiring a real provider (open issue #2, `docs/ECOSYSTEM.md` §G3). |
 | Presence gateway | `crates/presence-gateway/` | `arunsoman` | `docs/ROADMAP.md` Track A5. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,10 @@ triage, or design feedback — helps.
 
 - **Try it and report what breaks.** Build from source (below) or grab
   a [prebuilt binary](https://github.com/kannamma-labs/nirdosha/releases/latest),
-  run a few `examples/*.nir`
-  files, open an issue for anything confusing or wrong.
+  try a few `examples/features/*.nir`/`examples/syntax/*.nir` files
+  through `nirdosha emit-ui`/`build` (there is no interpreter anymore —
+  see `examples/features/README.md`'s 2026-09 note on what still
+  actually runs), open an issue for anything confusing or wrong.
 - **Improve docs.** Typos, unclear explanations, and missing examples
   are all welcome fixes.
 - **Add `.nir` examples**, especially ones exercising a feature that
@@ -60,9 +62,9 @@ sudo pacman -S clang z3
 ```
 
 `clang` is only invoked at runtime by `nirdosha build`/`emit-llvm`
-(native codegen) — you don't need it just to interpret a program or run
-the test suite. `z3` is linked at compile time and is required to build
-the compiler at all.
+(native codegen) — you don't need it just to run the test suite or use
+`emit-ui`/`emit-ast`/`emit-catalog`. `z3` is linked at compile time and
+is required to build the compiler at all.
 
 Read [`AGENTS.md`](./AGENTS.md) first if you're going to touch the
 compiler itself — it has the hard gotchas (no `::` token, `str` banned

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,11 +11,14 @@ resolved.
 Please include:
 
 - What you found and why it's a security issue, not just a bug
-- A minimal `.nir` file or request that reproduces it
+- A minimal `.nir` file that reproduces it
 - The affected area if you know it (parser/typeck/ownership, `smt.rs`
-  refinement checking, `serve.rs`'s HTTP/auth boundary, `sandbox`
-  process isolation, `transact`/`workflow` durability, or the
-  generated UI client)
+  refinement checking, the compiled `requires(role/claim:...)`/
+  `acquire`/`check_role` enforcement path (`codegen.rs`), or the
+  `emit-ui`-generated static client). `sandbox` process isolation and a
+  `serve.rs` HTTP/auth boundary are historical — the interpreter and
+  `serve.rs` were deleted entirely and neither exists on any current
+  branch; see [`docs/API_TRUST_MODEL.md`](./docs/API_TRUST_MODEL.md) §4a.
 
 You should get an initial response within a week. This is a small team
 (see [`MAINTAINERS.md`](./MAINTAINERS.md)), not a funded security team —
@@ -31,24 +34,37 @@ A report that a *documented, disclosed* limitation is exploitable is
 still useful — please file it — but it's triaged differently from a
 violation of a claim the project actually makes.
 
-Areas most worth scrutiny, since they're the actual security
-boundary in a real deployment:
+**2026-09 — there is no compiled serving mode.** The interpreter and
+`serve.rs` were deleted entirely (`docs/API_TRUST_MODEL.md` §4a); there
+is no `nirdosha serve` subcommand. `db`/`json`/`mq`/`transact`/`sandbox`
+and most Row 12 identity builtins (`oidc_validate_token`,
+`extract_claim`) don't run in any form today — `codegen.rs::
+check_supported` rejects them and there's no interpreter left to fall
+back to. What does compile and run for real, and is the actual
+security boundary in a compiled binary today: `requires(role/claim:
+...)`/`acquire`/`check_role` enforcement (`docs/API_TRUST_MODEL.md`
+§4a's own 2026-09 update).
 
-- `serve.rs` — the HTTP/auth boundary: token validation
-  (`oidc_validate_token`), role/claim gate enforcement, field-level
-  RBAC redaction, request-size/rate limits
-- `sandbox`/`stop` — real OS-process isolation (`docs/SANDBOXING.md`)
+Areas most worth scrutiny:
+
+- `codegen.rs`'s compiled `requires`/`acquire`/`check_role`
+  enforcement and field-masking lowering — the actual security
+  boundary in a compiled binary today, now that it's the only path
+  that runs at all
 - `ownership.rs`/`typeck.rs` — the static guarantees the whole project
   is built around; a real counterexample to "the type checker accepts
   it, therefore it's memory/race-safe" is a serious finding
+- `emit-ui`'s generated static client — its field-level `view`/`edit`
+  gate rendering is cosmetic only, with no server left to enforce it
+  independently, since none exists
 - Anything that would let untrusted `.nir` source (e.g. LLM-generated
-  code fed through the agent-facing tooling) escape a declared
-  `sandbox` or bypass a `requires(role: ...)` gate
+  code fed through the agent-facing tooling) bypass a `requires(role:
+  ...)`/`acquire` gate in a compiled binary
 
 Out of scope: findings that require local code execution with the same
-privileges as the `nirdosha` process itself, or that only affect a
-locally-run `nirdosha serve` instance with no authentication configured
-(that's a documented development mode, not a deployment posture).
+privileges as the `nirdosha` process itself, or that target the
+deleted interpreter/`serve.rs`/`sandbox` runtime path (historical, not
+present on any current branch).
 
 ## Supported versions
 

--- a/TRUSTED_PLUGINS.md
+++ b/TRUSTED_PLUGINS.md
@@ -43,14 +43,19 @@ list (`nirdosha-plugin-rot13`/`-mysql`/`-activemq`/`-cassandra`/
 depended on the tree-walking interpreter's own `PluginBuiltin`/
 `PluginFn` dispatch, which no longer exists (the interpreter was
 deleted in a separate pass the same session). `NativePluginBuiltin`
-(the compiled-path plugin ABI these examples never targeted, a
-different and narrower scalar-only shape) survives and is real —
-`crates/compiler/tests/native_plugin_codegen.rs` exercises it directly
-— but nothing currently plugs into it: no reference plugin crate
-implements it, and `nirdosha build`'s own CLI has no flag to load a
-native plugin at all yet (`build_with_native_plugins` is a library
-entry point with no wired-up caller). This table's real purpose is
-unchanged — the template a genuine plugin's listing follows, and the
+(the compiled-path plugin ABI these examples never targeted, since
+widened past scalars to `str`/`handle(Kind)` by
+rfcs/0008-native-plugin-abi-widening.md Phase 1) survives and is real —
+`crates/compiler/tests/native_plugin_codegen.rs` exercises it directly,
+and two in-repo reference crates now implement it end to end
+(`crates/plugin-example-native-shout`, `crates/plugin-example-native-kv`,
+proven via `crates/compiler/tests/native_plugin_examples.rs`) — but
+`nirdosha build`'s own CLI still has no flag to load a native plugin at
+all (`build_with_native_plugins` is a library entry point with no
+wired-up CLI caller; Cargo-driven auto-discovery is rfcs/0008's own
+still-open Phase 3), so neither reference crate is a candidate for this
+table yet — there's no app-facing way to depend on one. This table's
+real purpose is unchanged — the template a genuine plugin's listing follows, and the
 day-one gate a future auto-discovery step (RFC 0001) requires — it
 just currently has zero rows to show for it.
 

--- a/agent-skills/nirdosha/AGENTS.md
+++ b/agent-skills/nirdosha/AGENTS.md
@@ -593,9 +593,10 @@ fn main() {
 ```
 
 Naming `list_<struct>`/`create_<struct>`/`update_<struct>`/
-`delete_<struct>` functions like this is also what `nirdosha emit-ui`/
-`nirdosha serve` use to auto-generate a full CRUD web UI with zero
-extra syntax — see the `screen`/`dashboard` DSL in `docs/LANGUAGE.md` §11 if
+`delete_<struct>` functions like this is also what `nirdosha emit-ui`
+uses to auto-generate a full CRUD web UI with zero extra syntax (a
+static HTML file — there is no `nirdosha serve`/compiled serving mode
+anymore, the interpreter it depended on was deleted) — see the `screen`/`dashboard` DSL in `docs/LANGUAGE.md` §11 if
 you need to customize that generated UI (custom labels, field
 validation, role-gated visibility, dashboard tiles/charts).
 
@@ -606,8 +607,8 @@ Target } ... }` — durable, named states with `on <Event> -> <Target>`
 transitions, desugared into ordinary `fn`s (`start_<name>`,
 `advance_<name>`, etc.), so it needs no new runtime. `state { owner:
 role("...") }` names who may fire that state's outgoing events —
-checked live, per instance, not statically — and `nirdosha serve`/
-`emit-ui` generate a "Workflows" queue screen from it automatically
+checked live, per instance, not statically — and `nirdosha emit-ui`
+generates a "Workflows" queue screen from it automatically
 (each role sees only what's waiting on them, plus a "my requests" tab
 for whoever started an instance and an audit-trail "history" view), no
 extra syntax needed. See `docs/WORKFLOW.md` for the full construct.
@@ -629,23 +630,35 @@ verify before presenting code as final:
 
 ```sh
 nirdosha emit-ui file.nir -o /tmp/out.html   # full typecheck + ownership check, no side effects (doesn't run main())
-nirdosha file.nir --format=json              # actually runs it; structured Diagnostic JSON on any failure
+nirdosha build file.nir -o /tmp/out && /tmp/out   # actually compiles and runs it -- native binary, no interpreter
 ```
+
+**There is no interpreter anymore, and no `--format=json` flag.** An
+older workflow ran `nirdosha file.nir --format=json` to execute a
+program directly; that mode was deleted along with the tree-walking
+interpreter, and there is no fallback for it. `nirdosha build` only
+compiles what `codegen.rs::check_supported` accepts — `db`/`json`/`mq`/
+`transact`/`sandbox` and most Row 12 identity builtins
+(`oidc_validate_token`, `extract_claim`, ...) aren't in that set yet, so
+a program using any of them will fail `build`/`emit-llvm` with a named
+"unsupported" reason (`docs/LANGUAGE.md` §10's compiled-vs-not table) —
+that's not a bug to work around, it's today's real, disclosed boundary
+of what actually runs. `requires(role/claim:...)`/`acquire`/
+`check_role` **do** compile and run for real.
 
 **`nirdosha emit-ast file.nir` does *not* typecheck** — it only
 lexes/parses, by deliberate design (so a program that doesn't yet
 typecheck can still be inspected). A file that passes `emit-ast` can
 still be full of type errors — don't treat a clean `emit-ast` as "this
-compiles." Use `emit-ui` for a real typecheck-only pass, or just run it
-with `--format=json` if side effects (a real DB write, a real HTTP
-call) are acceptable for this check.
+compiles." Use `emit-ui` for a real typecheck-only pass that also
+accepts programs `build` can't yet run end to end.
 
-A `Diagnostic` (from `--format=json`) or a `type error: ...` line (from
-`emit-ui`) names the exact rule violated — read it and fix the named
-issue rather than guessing. If you don't have shell access (a plain
-chat interface), self-check your output line-by-line against the 9
-rules above before presenting it, and say plainly that it hasn't been
-run through the real compiler.
+A `type error: ...`/`ownership error: ...` line (from `emit-ui`) or an
+`unsupported: ...` line (from `build`/`emit-llvm`) names the exact rule
+violated — read it and fix the named issue rather than guessing. If you
+don't have shell access (a plain chat interface), self-check your
+output line-by-line against the 9 rules above before presenting it, and
+say plainly that it hasn't been run through the real compiler.
 
 ## Where to go deeper
 
@@ -658,7 +671,9 @@ Worked examples: `examples/*.nir` in the main repo
 
 Before telling the user code is finished, actually run it through the
 compiler (`nirdosha emit-ui file.nir -o /tmp/out.html` for a
-typecheck-only pass, then `nirdosha file.nir --format=json` to run it)
-if you have shell access. A `Diagnostic`/`type error` names the exact
-rule violated — fix that, don't guess. Do not rely on `nirdosha
+typecheck-only pass, then `nirdosha build file.nir -o /tmp/out &&
+/tmp/out` to actually run it — there is no interpreter and no
+`--format=json` flag anymore, see above) if you have shell access. A
+`type error`/`ownership error`/`unsupported` line names the exact rule
+violated — fix that, don't guess. Do not rely on `nirdosha
 emit-ast` as a typecheck signal — it only parses (see above).

--- a/agent-skills/nirdosha/claude-code/SKILL.md
+++ b/agent-skills/nirdosha/claude-code/SKILL.md
@@ -591,9 +591,10 @@ fn main() {
 ```
 
 Naming `list_<struct>`/`create_<struct>`/`update_<struct>`/
-`delete_<struct>` functions like this is also what `nirdosha emit-ui`/
-`nirdosha serve` use to auto-generate a full CRUD web UI with zero
-extra syntax — see the `screen`/`dashboard` DSL in `docs/LANGUAGE.md` §11 if
+`delete_<struct>` functions like this is also what `nirdosha emit-ui`
+uses to auto-generate a full CRUD web UI with zero extra syntax (a
+static HTML file — there is no `nirdosha serve`/compiled serving mode
+anymore, the interpreter it depended on was deleted) — see the `screen`/`dashboard` DSL in `docs/LANGUAGE.md` §11 if
 you need to customize that generated UI (custom labels, field
 validation, role-gated visibility, dashboard tiles/charts).
 
@@ -604,8 +605,8 @@ Target } ... }` — durable, named states with `on <Event> -> <Target>`
 transitions, desugared into ordinary `fn`s (`start_<name>`,
 `advance_<name>`, etc.), so it needs no new runtime. `state { owner:
 role("...") }` names who may fire that state's outgoing events —
-checked live, per instance, not statically — and `nirdosha serve`/
-`emit-ui` generate a "Workflows" queue screen from it automatically
+checked live, per instance, not statically — and `nirdosha emit-ui`
+generates a "Workflows" queue screen from it automatically
 (each role sees only what's waiting on them, plus a "my requests" tab
 for whoever started an instance and an audit-trail "history" view), no
 extra syntax needed. See `docs/WORKFLOW.md` for the full construct.
@@ -627,23 +628,35 @@ verify before presenting code as final:
 
 ```sh
 nirdosha emit-ui file.nir -o /tmp/out.html   # full typecheck + ownership check, no side effects (doesn't run main())
-nirdosha file.nir --format=json              # actually runs it; structured Diagnostic JSON on any failure
+nirdosha build file.nir -o /tmp/out && /tmp/out   # actually compiles and runs it -- native binary, no interpreter
 ```
+
+**There is no interpreter anymore, and no `--format=json` flag.** An
+older workflow ran `nirdosha file.nir --format=json` to execute a
+program directly; that mode was deleted along with the tree-walking
+interpreter, and there is no fallback for it. `nirdosha build` only
+compiles what `codegen.rs::check_supported` accepts — `db`/`json`/`mq`/
+`transact`/`sandbox` and most Row 12 identity builtins
+(`oidc_validate_token`, `extract_claim`, ...) aren't in that set yet, so
+a program using any of them will fail `build`/`emit-llvm` with a named
+"unsupported" reason (`docs/LANGUAGE.md` §10's compiled-vs-not table) —
+that's not a bug to work around, it's today's real, disclosed boundary
+of what actually runs. `requires(role/claim:...)`/`acquire`/
+`check_role` **do** compile and run for real.
 
 **`nirdosha emit-ast file.nir` does *not* typecheck** — it only
 lexes/parses, by deliberate design (so a program that doesn't yet
 typecheck can still be inspected). A file that passes `emit-ast` can
 still be full of type errors — don't treat a clean `emit-ast` as "this
-compiles." Use `emit-ui` for a real typecheck-only pass, or just run it
-with `--format=json` if side effects (a real DB write, a real HTTP
-call) are acceptable for this check.
+compiles." Use `emit-ui` for a real typecheck-only pass that also
+accepts programs `build` can't yet run end to end.
 
-A `Diagnostic` (from `--format=json`) or a `type error: ...` line (from
-`emit-ui`) names the exact rule violated — read it and fix the named
-issue rather than guessing. If you don't have shell access (a plain
-chat interface), self-check your output line-by-line against the 9
-rules above before presenting it, and say plainly that it hasn't been
-run through the real compiler.
+A `type error: ...`/`ownership error: ...` line (from `emit-ui`) or an
+`unsupported: ...` line (from `build`/`emit-llvm`) names the exact rule
+violated — read it and fix the named issue rather than guessing. If you
+don't have shell access (a plain chat interface), self-check your
+output line-by-line against the 9 rules above before presenting it, and
+say plainly that it hasn't been run through the real compiler.
 
 ## Where to go deeper
 
@@ -655,10 +668,11 @@ Worked examples: `examples/*.nir` in the main repo
 ## After writing or editing a `.nir` file
 
 Always run the verification loop above (`nirdosha emit-ui`, then
-`nirdosha <file> --format=json`) before telling the user the code is
-done — don't just claim it typechecks, and don't rely on `emit-ast`
-for that (see above — it doesn't typecheck). If `nirdosha` isn't
-installed yet, install it first:
+`nirdosha build <file> -o /tmp/out && /tmp/out` — there is no
+interpreter and no `--format=json` flag anymore, see above) before
+telling the user the code is done — don't just claim it typechecks, and
+don't rely on `emit-ast` for that (see above — it doesn't typecheck).
+If `nirdosha` isn't installed yet, install it first:
 
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/kannamma-labs/nirdosha/main/scripts/install.sh | sh

--- a/agent-skills/nirdosha/core.md
+++ b/agent-skills/nirdosha/core.md
@@ -596,9 +596,10 @@ fn main() {
 ```
 
 Naming `list_<struct>`/`create_<struct>`/`update_<struct>`/
-`delete_<struct>` functions like this is also what `nirdosha emit-ui`/
-`nirdosha serve` use to auto-generate a full CRUD web UI with zero
-extra syntax — see the `screen`/`dashboard` DSL in `docs/LANGUAGE.md` §11 if
+`delete_<struct>` functions like this is also what `nirdosha emit-ui`
+uses to auto-generate a full CRUD web UI with zero extra syntax (a
+static HTML file — there is no `nirdosha serve`/compiled serving mode
+anymore, the interpreter it depended on was deleted) — see the `screen`/`dashboard` DSL in `docs/LANGUAGE.md` §11 if
 you need to customize that generated UI (custom labels, field
 validation, role-gated visibility, dashboard tiles/charts).
 
@@ -609,8 +610,8 @@ Target } ... }` — durable, named states with `on <Event> -> <Target>`
 transitions, desugared into ordinary `fn`s (`start_<name>`,
 `advance_<name>`, etc.), so it needs no new runtime. `state { owner:
 role("...") }` names who may fire that state's outgoing events —
-checked live, per instance, not statically — and `nirdosha serve`/
-`emit-ui` generate a "Workflows" queue screen from it automatically
+checked live, per instance, not statically — and `nirdosha emit-ui`
+generates a "Workflows" queue screen from it automatically
 (each role sees only what's waiting on them, plus a "my requests" tab
 for whoever started an instance and an audit-trail "history" view), no
 extra syntax needed. See `docs/WORKFLOW.md` for the full construct.
@@ -632,23 +633,35 @@ verify before presenting code as final:
 
 ```sh
 nirdosha emit-ui file.nir -o /tmp/out.html   # full typecheck + ownership check, no side effects (doesn't run main())
-nirdosha file.nir --format=json              # actually runs it; structured Diagnostic JSON on any failure
+nirdosha build file.nir -o /tmp/out && /tmp/out   # actually compiles and runs it -- native binary, no interpreter
 ```
+
+**There is no interpreter anymore, and no `--format=json` flag.** An
+older workflow ran `nirdosha file.nir --format=json` to execute a
+program directly; that mode was deleted along with the tree-walking
+interpreter, and there is no fallback for it. `nirdosha build` only
+compiles what `codegen.rs::check_supported` accepts — `db`/`json`/`mq`/
+`transact`/`sandbox` and most Row 12 identity builtins
+(`oidc_validate_token`, `extract_claim`, ...) aren't in that set yet, so
+a program using any of them will fail `build`/`emit-llvm` with a named
+"unsupported" reason (`docs/LANGUAGE.md` §10's compiled-vs-not table) —
+that's not a bug to work around, it's today's real, disclosed boundary
+of what actually runs. `requires(role/claim:...)`/`acquire`/
+`check_role` **do** compile and run for real.
 
 **`nirdosha emit-ast file.nir` does *not* typecheck** — it only
 lexes/parses, by deliberate design (so a program that doesn't yet
 typecheck can still be inspected). A file that passes `emit-ast` can
 still be full of type errors — don't treat a clean `emit-ast` as "this
-compiles." Use `emit-ui` for a real typecheck-only pass, or just run it
-with `--format=json` if side effects (a real DB write, a real HTTP
-call) are acceptable for this check.
+compiles." Use `emit-ui` for a real typecheck-only pass that also
+accepts programs `build` can't yet run end to end.
 
-A `Diagnostic` (from `--format=json`) or a `type error: ...` line (from
-`emit-ui`) names the exact rule violated — read it and fix the named
-issue rather than guessing. If you don't have shell access (a plain
-chat interface), self-check your output line-by-line against the 9
-rules above before presenting it, and say plainly that it hasn't been
-run through the real compiler.
+A `type error: ...`/`ownership error: ...` line (from `emit-ui`) or an
+`unsupported: ...` line (from `build`/`emit-llvm`) names the exact rule
+violated — read it and fix the named issue rather than guessing. If you
+don't have shell access (a plain chat interface), self-check your
+output line-by-line against the 9 rules above before presenting it, and
+say plainly that it hasn't been run through the real compiler.
 
 ## Where to go deeper
 

--- a/agent-skills/nirdosha/github/copilot-instructions.md
+++ b/agent-skills/nirdosha/github/copilot-instructions.md
@@ -588,9 +588,10 @@ fn main() {
 ```
 
 Naming `list_<struct>`/`create_<struct>`/`update_<struct>`/
-`delete_<struct>` functions like this is also what `nirdosha emit-ui`/
-`nirdosha serve` use to auto-generate a full CRUD web UI with zero
-extra syntax — see the `screen`/`dashboard` DSL in `docs/LANGUAGE.md` §11 if
+`delete_<struct>` functions like this is also what `nirdosha emit-ui`
+uses to auto-generate a full CRUD web UI with zero extra syntax (a
+static HTML file — there is no `nirdosha serve`/compiled serving mode
+anymore, the interpreter it depended on was deleted) — see the `screen`/`dashboard` DSL in `docs/LANGUAGE.md` §11 if
 you need to customize that generated UI (custom labels, field
 validation, role-gated visibility, dashboard tiles/charts).
 
@@ -601,8 +602,8 @@ Target } ... }` — durable, named states with `on <Event> -> <Target>`
 transitions, desugared into ordinary `fn`s (`start_<name>`,
 `advance_<name>`, etc.), so it needs no new runtime. `state { owner:
 role("...") }` names who may fire that state's outgoing events —
-checked live, per instance, not statically — and `nirdosha serve`/
-`emit-ui` generate a "Workflows" queue screen from it automatically
+checked live, per instance, not statically — and `nirdosha emit-ui`
+generates a "Workflows" queue screen from it automatically
 (each role sees only what's waiting on them, plus a "my requests" tab
 for whoever started an instance and an audit-trail "history" view), no
 extra syntax needed. See `docs/WORKFLOW.md` for the full construct.
@@ -624,23 +625,35 @@ verify before presenting code as final:
 
 ```sh
 nirdosha emit-ui file.nir -o /tmp/out.html   # full typecheck + ownership check, no side effects (doesn't run main())
-nirdosha file.nir --format=json              # actually runs it; structured Diagnostic JSON on any failure
+nirdosha build file.nir -o /tmp/out && /tmp/out   # actually compiles and runs it -- native binary, no interpreter
 ```
+
+**There is no interpreter anymore, and no `--format=json` flag.** An
+older workflow ran `nirdosha file.nir --format=json` to execute a
+program directly; that mode was deleted along with the tree-walking
+interpreter, and there is no fallback for it. `nirdosha build` only
+compiles what `codegen.rs::check_supported` accepts — `db`/`json`/`mq`/
+`transact`/`sandbox` and most Row 12 identity builtins
+(`oidc_validate_token`, `extract_claim`, ...) aren't in that set yet, so
+a program using any of them will fail `build`/`emit-llvm` with a named
+"unsupported" reason (`docs/LANGUAGE.md` §10's compiled-vs-not table) —
+that's not a bug to work around, it's today's real, disclosed boundary
+of what actually runs. `requires(role/claim:...)`/`acquire`/
+`check_role` **do** compile and run for real.
 
 **`nirdosha emit-ast file.nir` does *not* typecheck** — it only
 lexes/parses, by deliberate design (so a program that doesn't yet
 typecheck can still be inspected). A file that passes `emit-ast` can
 still be full of type errors — don't treat a clean `emit-ast` as "this
-compiles." Use `emit-ui` for a real typecheck-only pass, or just run it
-with `--format=json` if side effects (a real DB write, a real HTTP
-call) are acceptable for this check.
+compiles." Use `emit-ui` for a real typecheck-only pass that also
+accepts programs `build` can't yet run end to end.
 
-A `Diagnostic` (from `--format=json`) or a `type error: ...` line (from
-`emit-ui`) names the exact rule violated — read it and fix the named
-issue rather than guessing. If you don't have shell access (a plain
-chat interface), self-check your output line-by-line against the 9
-rules above before presenting it, and say plainly that it hasn't been
-run through the real compiler.
+A `type error: ...`/`ownership error: ...` line (from `emit-ui`) or an
+`unsupported: ...` line (from `build`/`emit-llvm`) names the exact rule
+violated — read it and fix the named issue rather than guessing. If you
+don't have shell access (a plain chat interface), self-check your
+output line-by-line against the 9 rules above before presenting it, and
+say plainly that it hasn't been run through the real compiler.
 
 ## Where to go deeper
 

--- a/agent-skills/nirdosha/paste-anywhere-prompt.md
+++ b/agent-skills/nirdosha/paste-anywhere-prompt.md
@@ -737,9 +737,10 @@ fn main() requires(public) {
 ```
 
 Naming `list_<struct>`/`create_<struct>`/`update_<struct>`/
-`delete_<struct>` functions like this is also what `nirdosha emit-ui`/
-`nirdosha serve` use to auto-generate a full CRUD web UI with zero
-extra syntax — see the `screen`/`dashboard` DSL in `docs/LANGUAGE.md` §11 if
+`delete_<struct>` functions like this is also what `nirdosha emit-ui`
+uses to auto-generate a full CRUD web UI with zero extra syntax (a
+static HTML file — there is no `nirdosha serve`/compiled serving mode
+anymore, the interpreter it depended on was deleted) — see the `screen`/`dashboard` DSL in `docs/LANGUAGE.md` §11 if
 you need to customize that generated UI (custom labels, field
 validation, role-gated visibility, dashboard tiles/charts).
 
@@ -760,7 +761,7 @@ no warning** — nothing points at the missing screen; it's simply absent
 from the nav rail. This is the exact same "compiles clean, wrong at
 runtime" hazard class as `db_query`'s array-result footgun above, just
 one layer up (UI generation, not the interpreter) — if a struct you
-expect to see a screen for doesn't show up in `nirdosha serve`'s nav,
+expect to see a screen for doesn't show up in `nirdosha emit-ui`'s nav,
 check every one of its CRUD function names against this convention
 before assuming something else is wrong.
 
@@ -784,8 +785,8 @@ Target } ... }` — durable, named states with `on <Event> -> <Target>`
 transitions, desugared into ordinary `fn`s (`start_<name>`,
 `advance_<name>`, etc.), so it needs no new runtime. `state { owner:
 role("...") }` names who may fire that state's outgoing events —
-checked live, per instance, not statically — and `nirdosha serve`/
-`emit-ui` generate a "Workflows" queue screen from it automatically
+checked live, per instance, not statically — and `nirdosha emit-ui`
+generates a "Workflows" queue screen from it automatically
 (each role sees only what's waiting on them, plus a "my requests" tab
 for whoever started an instance and an audit-trail "history" view), no
 extra syntax needed. See `docs/WORKFLOW.md` for the full construct.
@@ -807,30 +808,37 @@ verify before presenting code as final:
 
 ```sh
 nirdosha emit-ui file.nir -o /tmp/out.html   # full typecheck + ownership check, no side effects (doesn't run main())
-nirdosha file.nir --format=json              # actually runs it; structured Diagnostic JSON on any failure
+nirdosha build file.nir -o /tmp/out && /tmp/out   # actually compiles and runs it -- native binary, no interpreter
 ```
+
+**There is no interpreter anymore, and no `--format=json` flag.** An
+older workflow ran `nirdosha file.nir --format=json` to execute a
+program directly; that mode was deleted along with the tree-walking
+interpreter, and there is no fallback for it (the panic-on-
+`DuplicateConstructor` gap this section used to warn about was specific
+to that deleted flag, and no longer applies to anything reachable).
+`nirdosha build` only compiles what `codegen.rs::check_supported`
+accepts — `db`/`json`/`mq`/`transact`/`sandbox` and most Row 12 identity
+builtins (`oidc_validate_token`, `extract_claim`, ...) aren't in that
+set yet, so a program using any of them will fail `build`/`emit-llvm`
+with a named "unsupported" reason (`docs/LANGUAGE.md` §10's
+compiled-vs-not table) — that's not a bug to work around, it's today's
+real, disclosed boundary of what actually runs. `requires(role/claim:
+...)`/`acquire`/`check_role` **do** compile and run for real.
 
 **`nirdosha emit-ast file.nir` does *not* typecheck** — it only
 lexes/parses, by deliberate design (so a program that doesn't yet
 typecheck can still be inspected). A file that passes `emit-ast` can
 still be full of type errors — don't treat a clean `emit-ast` as "this
-compiles." Use `emit-ui` for a real typecheck-only pass, or just run it
-with `--format=json` if side effects (a real DB write, a real HTTP
-call) are acceptable for this check.
+compiles." Use `emit-ui` for a real typecheck-only pass that also
+accepts programs `build` can't yet run end to end.
 
-A `Diagnostic` (from `--format=json`) or a `type error: ...` line (from
-`emit-ui`) names the exact rule violated — read it and fix the named
-issue rather than guessing. **Known gap:** on at least one type error
-kind (`DuplicateConstructor` — two enums, or an enum and the prelude's
-`CurrencyCode`/`UnitCode`, declaring the same variant name — rule 1's
-last paragraph), `--format=json` itself panics instead of emitting the
-`Diagnostic`, instead of the failure it's supposed to report cleanly.
-If `--format=json` produces no JSON at all and dies with a Rust panic,
-re-run plain `nirdosha emit-ui file.nir` (no `--format=json`) — the
-same error still reports fine there. If you don't have shell access (a
-plain chat interface), self-check your output line-by-line against the
-15 rules above before presenting it, and say plainly that it hasn't
-been run through the real compiler.
+A `type error: ...`/`ownership error: ...` line (from `emit-ui`) or an
+`unsupported: ...` line (from `build`/`emit-llvm`) names the exact rule
+violated — read it and fix the named issue rather than guessing. If you
+don't have shell access (a plain chat interface), self-check your
+output line-by-line against the 15 rules above before presenting it,
+and say plainly that it hasn't been run through the real compiler.
 
 ## Where to go deeper
 

--- a/crates/compiler/UI_DSL_TODO.md
+++ b/crates/compiler/UI_DSL_TODO.md
@@ -486,7 +486,19 @@ DSL, not a bug report against this one.
   "graph" | "heatmap" | "timeline" }` (`docs/LANGUAGE.md` §11c) — three more
   inline-SVG shapes, still zero external dependency, still no line/
   scatter/treemap/3D and no real physics/basemap (disclosed there, not
-  restated here).
+  restated here). **Superseded 2026-09-07 (`rfcs/0009` Phase A)**: that
+  same `visual`/`panel` slot also accepts a fifth, additive `render:
+  "chart"` kind — a bounded mark (`bar`/`line`/`area`/`point`/`arc`/
+  `rule`) × `encode <channel> { ... }` composition, one generalized
+  `renderGraphicsChart` renderer, still no external charting library —
+  covering the line/scatter/treemap gap this bullet names, though still
+  not 3D or a real basemap. `chart_<name>`/`dashboard { chart "..." }`
+  itself is untouched and still permanently the one bar-chart shape.
+  `rfcs/0009` Phase B further adds compile-time UI-plugin `layout { ... }`
+  widget kinds (`crates/compiler/src/ui_plugin.rs`), including
+  Cargo-metadata auto-discovery of a `nir-ui-component` crate — a
+  different extension point (a `layout` widget, not a chart/form
+  control), not a narrowing of this bullet's own closed sets.
 - **Four built-in animations, fixed, nothing else.** `fade-in`/
   `slide-up`/`scale-in`/`pop` (docs/LANGUAGE.md §11b) are the entire
   `@keyframes` vocabulary `ui_gen_template.html` ships — a screen's

--- a/crates/compiler/src/INDEX.md
+++ b/crates/compiler/src/INDEX.md
@@ -6,310 +6,431 @@ number looks wrong, `grep -n '<the name>' crates/compiler/src/<file>.rs` to
 find the current location; the names in this index are the durable
 part.
 
-## codegen.rs (5086 lines, as of 2026-08-23)
+**2026-09-07 regeneration note.** This index was badly stale (last
+dated 2026-08-23): it listed `interpreter.rs` and `serve.rs` as
+current, large files with live line-by-line structure, but both were
+deleted entirely in the interpreter-removal pass (`05a747c`) — their
+sections are gone below, not just renumbered. Every remaining file
+grew substantially in the two weeks since (codegen.rs alone gained
+~1800 lines) and every section below was re-verified against the
+current source rather than hand-patched. `runtime_kernels.rs` is also
+gone from this list, but for a different reason: it moved out of
+`crates/compiler/src/` entirely, into its own `crates/runtime-kernels/`
+crate (`docs/adr/0003-runtime-kernels-cargo-dependency.md`) — out of
+this index's own stated scope, not deleted. Newly added sections below
+(`contract_check.rs`, `ownership.rs`, `smt.rs`, `refine.rs`, `main.rs`,
+`token.rs`, `effects.rs`) either grew past this index's original
+threshold or simply weren't covered before.
 
-- `1` — module doc: LLVM codegen strategy overview (docs/goal.md row 5, "native, hardware-speed codegen")
+## codegen.rs (6886 lines, as of 2026-09-07)
+
+- `1` — module doc: LLVM codegen strategy overview (docs/goal.md row 5, "native, hardware-speed codegen"); its own "what's supported" summary is disclosed as lossy — `check_supported`'s `unsupported(...)` call sites are the actual source of truth, not this comment (caught drifting once already re: `box`/`&`/`*`)
 - `79` `struct CodegenError` — the one error type every codegen fallibility collapses into
 - `89` `fn unsupported<T>` — the "reject, don't mis-compile" helper every not-yet-compiled construct calls
-- `208` `fn affine_codegen_supported` — whether an affine-containing `Ty::Named` (Phase 4b) can compile
-- `244` `fn llvm_ty` — maps a `Ty` to its LLVM type string (free-function form, used pre-`Codegen` construction)
-- `386` `fn mangle_ty` — generic instantiation name mangling (`%Result$i64$str`-style)
-- `430` `fn conservative_word_count` — over-allocated word count for a tagged-union enum payload
-- `589` `pub fn check_supported` — the real gate: walks the whole program, rejects everything `codegen.rs` doesn't yet compile with a named reason (grep this for the ground-truth "what's compiled vs interpreter-only" list, don't trust docs)
-- `601`/`608`/`629` `fn check_stmts`/`check_stmt`/`check_expr` — `check_supported`'s recursive walk
-- `799` `struct Scopes` / `impl Scopes` — codegen's own variable-name→(Ty, LLVM-pointer) environment
-- `833` `struct Codegen<'a>` — the main codegen driver: LLVM context/module/builder-equivalent state, register/label/global counters
-- `928` `pub fn emit_llvm_ir` — top-level entry point: program → full LLVM IR text
-- `1085` `fn bind_type_params_owned` — resolves a generic decl's type params against a concrete instantiation
-- `1106` `impl Codegen<'_>` — the big impl block (through ~5010), methods below are inside it
-- `1143` `fn llvm_ty` (method) — pure delegation to the free function, but through `&mut self`
-- `1184` `fn declare_named_type` — emits a `struct`/`enum`'s LLVM named type declaration (struct: real fields; enum: hand-rolled `{i64 tag, [N x i64] payload}`)
-- `1247` `fn ctor_ty` — resolves a struct/enum constructor call's target type
-- `1323`/`1352`/`1385` `fn construct`/`construct_struct`/`construct_variant` — lowering `Expr::Call` as a struct/enum constructor
-- `1484` `fn function` — lowers one `FnDecl` to an LLVM function definition
-- `1581`/`1591` `fn stmts`/`fn stmt` — statement-sequence and single-statement lowering
-- `1719` `fn local_ty_of` — recovers an already-typechecked expr's `Ty` without a full inference pass (trusts typeck already ran)
-- `1868` `fn builtin_result_ty` — a builtin call's result type, needed before its args are known (for aggregate dest allocation)
-- `1946` `fn widen_to_i64` — the one real signed/unsigned instruction choice (`zext` vs `sext`) this backend needs
-- `2001` `fn guard_in_range` — Tier-1/2 bounds check emission, elided where SMT already proved it safe
-- `2028` `fn emit_affine_free` — real `nir_free` call driven by `ownership.rs`'s `FreeMap`
-- `2154` `fn guard_index_in_bounds` — `Vector`/`Matrix` dynamic-index bounds check
-- `2174` `fn while_loop`
-- `2213` `fn expr` — **the** scalar-value lowering entry point: `Expr` → one LLVM register/literal operand
-- `2582` `fn call` — scalar-returning call dispatch (builtins + user fns)
-- `2870` `fn call_builtin_scalar` — the huge per-builtin-name match for scalar-shaped builtins
-- `3116` `fn call_builtin_agg` — same, for aggregate-shaped (`Vector`/`Matrix`-returning) builtins
-- `3336`–`3529` geometry/linalg helper cluster: `lla_to_ecef_vals`, `ecef_to_lla_vals`, `enu_rotation_vals`, `mat_mul_ptr_vals`, `mat_mul_a_bt_vals`, `mat_vec_mul_ptr_vals`, `vec_add_vals`, `load_all_f64_vals`, `store_all_f64_vals` — the fully-unrolled-at-compile-time linalg codegen
-- `3547` `fn expr_ptr` — **the** aggregate-value lowering entry point: `Expr` → pointer to a stack-allocated value (the `struct`/`enum`/`Vector`/`Matrix` counterpart to `expr`)
-- `3654` `fn array_lit`
-- `3691` `fn call_ptr` — aggregate-returning call dispatch (mirrors `call`)
-- `3710` `fn binary` — the main `BinOp` lowering entry point, dispatches to the specialized helpers below for non-scalar cases
-- `3910`–`3966` low-level emit helpers: `str_parts`, `icmp`, `fcmp`, `agg_elem_ptr`, `agg_load_elem`, `agg_store_elem`
-- `4043` `fn agg_eq` — `struct`/`enum`/`Vector`/`Matrix` structural `==`/`!=`
-- `4082` `fn str_eq` — `str` `==`/`!=` via a native-runtime `nir_str_eq` call, not hand-emitted IR
-- `4107` `fn agg_binary` / `4120` `fn agg_elementwise` / `4174` `fn agg_mul` / `4247` `fn agg_scale` — `Vector`/`Matrix` `+`/`-`/`.*`/`./`/`*` lowering, fully unrolled
-- `4261` `fn short_circuit` — `&&`/`||` as real branches, not eager and/or
-- `4307` `fn if_expr` — `if`/`else` as a value-producing expression (the block-value-then-merge pattern `match_expr` reuses)
-- `4479` `fn match_expr` — top-level `match` lowering, delegates to `match_enum`/`match_literal`
-- `4540` `fn match_enum` — real LLVM `switch` on the tag word, one case per declaration-order variant
-- `4665` `fn match_literal` — `str`/`i64`/`bool` literal-pattern match; `str` as a sequential `nir_str_eq`-then-branch chain
-- `4834` `fn block_side_effects` — runs a block for side effects only (unit-valued `if`/`match` arms)
-- `4857` `fn block_value_to_slot`
-- `4902` `fn emit_c_main` — synthesizes the real C-ABI `main` wrapping the program's own `main` (return-value-as-exit-code / str-prints-and-exits convention)
-- `5011` `pub enum OptLevel` — `-O0`/`-O2` (the whole point of the doc comment above it: `-O2`'s aggressive optimization is what actually stresses a subtly-wrong `unreachable`)
-- `5033` `static RUNTIME_KERNELS_LIB` — the statically-embedded `runtime_kernels.rs` static-lib bytes (`include_bytes!`), so a compiled binary has no runtime dependency on this compiler's own installation
-- `5033` `pub fn build` — the actual `clang`/linker invocation producing a native binary from emitted IR
+- `267`/`289` `fn affine_codegen_supported`/`affine_codegen_supported_visiting` — whether an affine-containing `Ty::Named` (Phase 4b) can compile
+- `334` `fn llvm_ty` — maps a `Ty` to its LLVM type string (free-function form, used pre-`Codegen` construction)
+- `515` `fn mangle_ty` — generic instantiation name mangling (`%Result$i64$str`-style)
+- `570` `fn conservative_word_count` — over-allocated word count for a tagged-union enum payload
+- `606`/`625`/`662`/`679`/`699`/`744` `fn agg_elem_and_len`/`elem_byte_size`/`ty_byte_size`/`agg_layout`/`agg_byte_size_operand`/`has_cyclic_layout` — `Vector`/`Matrix`/struct layout-size helpers feeding heap-alloc sizing
+- `779` `pub fn check_supported` — thin wrapper over `check_supported_with_plugins` with an empty plugin set; the real gate: walks the whole program, rejects everything `codegen.rs` doesn't yet compile with a named reason (grep this for the ground-truth "what's compiled vs interpreter-only" list, don't trust docs)
+- `799` `pub fn check_supported_with_plugins` — same gate, plus a plugin-builtin-name set to reject explicitly (rather than falling through to an untested "unknown function" path) once a plugin call passes `typecheck_with_plugins` — rfcs/0003's plugin gallery, `docs/ROADMAP.md` Track G/G1
+- `883`/`890`/`911` `fn check_stmts`/`check_stmt`/`check_expr` — `check_supported`'s recursive walk
+- `1108` `struct Scopes` / `impl Scopes` — codegen's own variable-name→(Ty, LLVM-pointer) environment
+- `1139` `struct FnSig`
+- `1154` `struct Codegen<'a>` — the main codegen driver: LLVM context/module/builder-equivalent state, register/label/global counters
+- `1284` `pub fn emit_llvm_ir` — top-level entry point: program → full LLVM IR text
+- `1300` `pub fn emit_llvm_ir_with_native_plugins` — the compiled-path counterpart for a project entrypoint with a native-callable plugin roster ready to link (rfcs/0005 §3), not the bare CLI (which can't discover a plugin crate on its own yet); validates each `NativePluginBuiltin` before delegating to `emit_llvm_ir_impl`
+- `1314` `fn emit_llvm_ir_impl` — the shared body both `emit_llvm_ir` and `emit_llvm_ir_with_native_plugins` funnel through
+- `1568` `fn bind_type_params_owned` — resolves a generic decl's type params against a concrete instantiation
+- `1590` `impl Codegen<'_>` — the big impl block (through ~6710), methods below are inside it
+- `1591`/`1595`/`1603` `fn fresh_reg`/`fresh_label`/`fresh_global` — the SSA-register/label/global-name counters
+- `1611` `fn emit_alloca`
+- `1627` `fn llvm_ty` (method) — pure delegation to the free function, but through `&mut self`
+- `1668` `fn declare_named_type` — emits a `struct`/`enum`'s LLVM named type declaration (struct: real fields; enum: hand-rolled `{i64 tag, [N x i64] payload}`)
+- `1731` `fn ctor_ty` — resolves a struct/enum constructor call's target type
+- `1754` `fn infer_type_args`
+- `1775` `fn field_index_and_ty`
+- `1807`/`1836`/`1869` `fn construct`/`construct_struct`/`construct_variant` — lowering `Expr::Call` as a struct/enum constructor
+- `1914` `fn store_value_into` / `1954` `fn expr_ptr_expected`
+- `1968` `fn function` — lowers one `FnDecl` to an LLVM function definition
+- `2096`/`2106` `fn stmts`/`fn stmt` — statement-sequence and single-statement lowering
+- `2274` `fn local_ty_of` — recovers an already-typechecked expr's `Ty` without a full inference pass (trusts typeck already ran)
+- `2434`/`2452` `fn array_lit_ty`/`mul_result_ty`
+- `2473` `fn builtin_result_ty` — a builtin call's result type, needed before its args are known (for aggregate dest allocation)
+- `2551` `fn widen_to_i64` — the one real signed/unsigned instruction choice (`zext` vs `sext`) this backend needs
+- `2572`/`2589`/`2612`/`2642` `fn narrow_from_i64`/`to_i64_word`/`from_i64_word`/`is_word_sized` — the word-sized-value marshaling `spawn`/`chan` need to move an arbitrary scalar through one `i64`-wide kernel slot
+- `2656` `fn spawn_thread` — `spawn name(args)`'s real codegen (`runtime-kernels/src/lib.rs`'s chan/spawn/join kernels); every param and the return type must be word-sized, checked here (no signature info in `check_supported`'s structural pre-pass)
+- `2728` `fn emit_spawn_trampoline`
+- `2796` `fn guard_in_range` — Tier-1/2 bounds check emission, elided where SMT already proved it safe
+- `2830` `fn emit_affine_free` — real `nir_free` call driven by `ownership.rs`'s `FreeMap`
+- `2951` `fn emit_frees_for_names`
+- `2974` `fn emit_nfr_call_end` — emits `nir_nfr_call_end` at a return point; a no-op unless the current fn declared `nfr(...)` (NFR annotations, 2026-08 work)
+- `2989` `fn emit_field_masking` — masks every `requires(...)`-annotated field of a struct value in place before it's returned to a caller without the matching proof; a no-op (no branch emitted) for any type with no masked field
+- `3023` `fn emit_requirement_check` — whether the current fn's own role/claim-view *parameter* satisfies a `Requirement`, fail-closed (`"false"`) if it has no such parameter
+- `3042` `fn emit_str_field_eq_check` — the shared core both `emit_requirement_check` and `emit_acquire` reduce to: GEP a field, load its `str`, compare via `nir_str_eq`
+- `3082` `fn emit_zero_value` — the masked-out value `emit_field_masking` stores
+- `3114` `fn guard_index_in_bounds` — `Vector`/`Matrix` dynamic-index bounds check
+- `3141` `fn while_loop`
+- `3180` `fn expr` — **the** scalar-value lowering entry point: `Expr` → one LLVM register/literal operand
+- `3703` `fn call` — scalar-returning call dispatch (builtins + user fns)
+- `4002` `fn call_args`
+- `4065` `fn call_indirect` — `fn(..)->..`-typed value calls; spells out the full `<ret>(<params>)` function type at the call site since the callee isn't a named `@fn`
+- `4109` `fn call_builtin_scalar` — the huge per-builtin-name match for scalar-shaped builtins
+- `4316` `fn bearing_deg`
+- `4355` `fn call_builtin_agg` — same, for aggregate-shaped (`Vector`/`Matrix`-returning) builtins
+- `4575`–`4768` geometry/linalg helper cluster: `lla_to_ecef_vals`, `ecef_to_lla_vals`, `enu_rotation_vals`, `mat_mul_ptr_vals`, `mat_mul_a_bt_vals`, `mat_vec_mul_ptr_vals`, `vec_add_vals`, `load_all_f64_vals`, `store_all_f64_vals` — the fully-unrolled-at-compile-time linalg codegen
+- `4786` `fn expr_ptr` — **the** aggregate-value lowering entry point: `Expr` → pointer to a stack-allocated value (the `struct`/`enum`/`Vector`/`Matrix` counterpart to `expr`)
+- `4897` `fn array_lit`
+- `4934` `fn call_ptr` — aggregate-returning call dispatch (mirrors `call`)
+- `4973` `fn emit_check_role` — `check_role(identity, "role")`'s codegen: reads `identity.claims_json` (`nir_check_role`, `runtime-kernels/src/lib.rs`) and hand-builds a `Result<RoleView, str>` (same tag-then-payload shape `construct_variant` uses generically, written directly here since no `Expr` exists to recurse on)
+- `5062` `fn emit_acquire` — `acquire`'s codegen: `Ok(RoleView(name))`/`Err(reason)` gated on `emit_str_field_eq_check` against an arbitrary `proof` expression's own `role`/`value` field
+- `5132` `fn binary` — the main `BinOp` lowering entry point, dispatches to the specialized helpers below for non-scalar cases
+- `5289`/`5320`/`5347`/`5373` `fn guard_nonzero_divisor`/`guard_call_ok`/`guard_io_ok`/`guard_recv_ok` — the shared Tier-1/2 trap idiom (icmp → branch → flight-recorder dump + `abort()` + `unreachable`) for division, a fallible native-kernel call (`nir_inv`/`nir_solve`/singular-matrix), a negative `tcp` I/O result, and `recv`'s `<= 0` (peer-closed-is-also-an-error) case respectively
+- `5399`/`5408`/`5422`/`5434`/`5444`/`5455` low-level emit helpers: `str_parts`, `icmp`, `fcmp`, `agg_elem_ptr`, `agg_load_elem`, `agg_store_elem`
+- `5465`/`5477`/`5490`/`5501`/`5510`/`5517` `fn emit_mul`/`emit_add`/`emit_sub`/`float_const`/`emit_call1`/`emit_call2` — scalar-instruction emit helpers
+- `5529` `fn emit_deep_eq` — recursive structural equality for any `Ty` (mirrors the interpreter-era `Value::PartialEq`: content equality for `box`/`&`, field-by-field for structs, tag-then-payload for enums, elementwise for `Vector`/`Matrix`)
+- `5740` `fn agg_eq` — `struct`/`enum`/`Vector`/`Matrix` structural `==`/`!=`, built on `emit_deep_eq`
+- `5758` `fn str_eq` — `str` `==`/`!=` via a native-runtime `nir_str_eq` call, not hand-emitted IR
+- `5783`/`5796`/`5850`/`5923` `fn agg_binary`/`agg_elementwise`/`agg_mul`/`agg_scale` — `Vector`/`Matrix` `+`/`-`/`.*`/`./`/`*` lowering, fully unrolled
+- `5937` `fn short_circuit` — `&&`/`||` as real branches, not eager and/or
+- `5976` `fn block_trailing_ty`
+- `5983` `fn if_expr` — `if`/`else` as a value-producing expression (the block-value-then-merge pattern `match_expr` reuses)
+- `6155` `fn match_expr` — top-level `match` lowering, delegates to `match_enum`/`match_literal`
+- `6216` `fn match_enum` — real LLVM `switch` on the tag word, one case per declaration-order variant
+- `6341` `fn match_literal` — `str`/`i64`/`bool` literal-pattern match; `str` as a sequential `nir_str_eq`-then-branch chain
+- `6510` `fn block_side_effects` — runs a block for side effects only (unit-valued `if`/`match` arms)
+- `6533` `fn block_value_to_slot`
+- `6578` `fn emit_c_main` — synthesizes the real C-ABI `main` wrapping the program's own `main` (return-value-as-exit-code / str-prints-and-exits convention)
+- `6715` `pub enum OptLevel` — `-O0`/`-O2` (the whole point of the doc comment above it: `-O2`'s aggressive optimization is what actually stresses a subtly-wrong `unreachable`)
+- `6737` `static RUNTIME_KERNELS_LIB` — the statically-embedded `runtime_kernels.rs` static-lib bytes (`include_bytes!`), so a compiled binary has no runtime dependency on this compiler's own installation
+- `6751` `static NATIVE_STATIC_LIBS` — OS-level system libs `RUNTIME_KERNELS_LIB`'s code needs at final link time (e.g. `ws2_32.lib` for `nir_tcp_*` on Windows), captured by `build.rs` via `rustc --print=native-static-libs`; read only under `#[cfg(windows)]`
+- `6753` `pub fn build` — the actual `clang`/linker invocation producing a native binary from emitted IR
+- `6767` `pub fn build_with_native_plugins` — `build`'s counterpart for a project entrypoint with a native-callable plugin roster (rfcs/0005 §3)
+- `6778` `fn build_impl` — the shared body both `build` and `build_with_native_plugins` funnel through
 
-## interpreter.rs (~5000 lines, as of 2026-08-23)
-
-- `81` `struct MqConn` / `impl Debug/Deref/DerefMut` — thin wrapper around a `redis::Connection`
-- `103` `pub enum Value` — every runtime value shape (the interpreter's dynamic type)
-- `277` `struct ChannelInner` / `283` `enum TransportState` / `289` `impl ChannelInner` (`send`/`recv`) / `384` `impl Drop` — `chan`'s runtime backing, in-process or cross-process (sandbox) transport
-- `412`–`504` raw I/O helpers: `write_value`/`read_value` (cross-process channel wire format), `write_tcp`/`read_tcp`, `write_file`/`read_file`
-- `525` `struct SandboxChild` / `536` `impl` (`pid`, `stop`) / `565` `impl Drop` — real child-process handle with a genuine `Drop`-driven kill, not just Rust memory reclamation
-- `576` `impl PartialEq for Value` — manual (not derived: `Thread`'s `JoinHandle` has no `PartialEq`); `Enum`/`Struct` compare name+fields structurally here — this is what `codegen.rs::agg_eq` and `eval_binary`'s `Value::Struct`/`Value::Enum` arm both delegate to
-- `607` `fn literal_pattern_matches` — `match`'s literal-pattern arm test, backed by the `PartialEq` above
-- `617` `impl Value` (`ty_name`, `render`) — runtime type name for error messages; `render` is `print`'s actual formatting (bool→`1`/`0`, not `true`/`false` — matches the compiled backend's disclosed cosmetic difference)
-- `692` `pub enum ErrorKind` — every structured runtime-error shape (serializes for `--format=json`)
-- `785` `pub struct RuntimeError`
-- `859`–`1997` free-function builtin implementations, roughly one cluster per builtin family: JWT/JWKS (`jwks_key`, `hmac_sha256_base64url`, `mock_issue_token` at `1107`, `identity_claims`, `verified_identity_value`), sessions (`application_session_value`, `refresh_token_value`), hashing (`sha256_hex`/`sha256_hex_chain`), DB (`db_query` free fn at `1412`, `sql_bind_params`), HTTP/HTTPS (`build_http_request`, `parse_http_response`, `send_and_receive`, `http_request`/`https_request`), dense linalg (`matrix_det`/`matrix_inv`/`matrix_solve`/`matrix_rank`), geometry (`lla_to_ecef`/`ecef_to_lla`/`enu_rotation`/bearing), Kalman filter (`kf_predict`/`kf_update`)
-- `1997` `fn eval_builtin` — **the** builtin dispatch: name → implementation, the interpreter's counterpart to `codegen.rs`'s `call_builtin_scalar`/`call_builtin_agg`
-- `2671` `enum Signal` / `2676` `impl From<RuntimeError>` — the control-flow signal type (`Return`/`Err`/ordinary value) `eval_expr` threads through
-- `2688` `struct Env` / `2697` `impl Env` — the interpreter's variable environment (scope stack)
-- `2732` `pub struct Interpreter` — the whole interpreter's state; cheap to reconstruct per-thread (`Arc::clone` the program/source)
-- `2896` `struct RngState` / `impl` — SplitMix64 + Box-Muller, the seeded-determinism RNG (docs/goal.md's determinism row)
-- `2938` `pub enum ReplayOutcome` — `transact` crash-replay's result shape
-- `2954` `impl Interpreter` — the big impl block (through ~4900), methods below are inside it
-- `2997` `pub fn run_main` / `3007` `run_main_on_big_stack` — top-level entry points
-- `3019` `pub fn call_named` — call an arbitrary function by name (what `serve.rs`'s `POST /api/<fn>` and the CLI's `--call` path both use)
-- `3055` `pub fn replay_pending_transactions` — crash-replay entry point, run once at `serve` startup before new requests
-- `3190`/`3200`/`3209` `fn find_fn`/`find_struct`/`find_variant` — AST lookup by name
-- `3290` `fn eval_transact_slot` / `3300` `eval_transact_slot_args` / `3327` `run_transact_write_slot` / `3372` `call_network_with_retry` — `transact`'s slot execution (docs/TRANSACT.md Layer 2's retry-with-backoff lives at `3372`)
-- `3465` `fn call` — ordinary (non-transact) function-call dispatch, the interpreter's counterpart to `codegen.rs::call`/`call_ptr`
-- `3552` `fn effect_of_fn` — lazy per-fn effect lookup, only computed when tracing is on
-- `3583` `fn check_ty` — runtime type-tag verification
-- `3695`/`3702` `fn exec_block`/`exec_stmts` — a block's value is its last expression-statement, same convention `if`'s branches use
-- `3755` `fn eval_expr` — **the** expression evaluator, the interpreter's counterpart to `codegen.rs::expr`/`expr_ptr` combined (one function, not split — no aggregate/scalar distinction needed without LLVM register types)
-- `4740` `fn spawn_sandbox` — cross-process sandboxed function call, lossless value round-trip over the channel wire format
-- `4812` `fn eval_binary` — `BinOp` evaluation; the `Value::Struct`/`Value::Enum` arm here (added 2026-08-23 alongside the str-ban work) is what makes `struct`/`enum` `==`/`!=` actually work at runtime, not just typecheck
-
-## typeck.rs (~3461 lines, as of 2026-08-23)
+## typeck.rs (5151 lines, as of 2026-09-07)
 
 - `61` `pub enum TypeErrorKind` — every structured type error shape (serializes for `--format=json`); every new static check this project adds gets a variant here, e.g. `StrInFnSignature`
-- `376` `pub struct TypeError` / `impl Display` — wraps a `TypeErrorKind` with its `Span`, and formats it human-readably
-- `720` `struct FnSig` / `732` `struct Scopes` — signature table and lexical-scope variable-type stack
-- `752` `pub struct Checker<'a>` — the whole typecheck pass's state (registry, signatures, accumulated errors)
-- `771` `pub fn typecheck` — top-level entry point; registers every struct/enum/fn name (two namespaces: type names vs. callable names — see Row 11 §3.1/3.2), then checks every `fn` body. A program the interpreter runs was always fully typed and proved-returning first.
-- `921` `fn error` — push one `TypeErrorKind` at a `Span`, the one place every check funnels through
-- `968`/`1009`/`1018` `fn check_screen`/`check_dashboard`/`check_metric_ref` — Row 12 UI-DSL shape checks (existence/shape only, not full signature enforcement — see `crates/compiler/UI_DSL_TODO.md`)
-- (near `check_screen`) `fn check_pattern_expr`/`check_format_expr`/`check_min_max_expr` — `field <name> { pattern/format/min/max: ... }` shape + field-type-applicability checks (2026-08-24), incl. compiling `pattern`'s regex via the `regex` crate at typeck time
-- `1050` `fn validate_ty` — well-formedness of a type expression itself (arity, unknown names) — recurses through every type-former the same way `ast.rs::Ty::contains_str` does
-- `1100` `fn check_fn` — per-function entry point: the "enum favoring" `str`-in-signature scan lives here (2026-08-23), then body-checks, then `NotAllPathsReturn`
-- `1132`/`1138`/`1144` `fn check_stmts`/`check_block`/`check_stmt` — statement-level checking (no value context)
-- `1185` `fn check_stmt_expr`
-- `1211` `fn check` — **the** "does this expr have exactly this type" entry point; every value position (`let`, `return`, assignment RHS, call arg) goes through here, so "no implicit conversions" is enforced in exactly one place
-- `1275` `fn infer` — the no-expected-type counterpart to `check`, for unary operands and other positions the grammar doesn't pin down
-- `1616`/`1664` `fn infer_sandbox_spawn`/`infer_spawn`
-- `1688`/`1768`/`1789` `fn infer_transact`/`infer_transact_slot`/`infer_transact_slot_durable` — `transact`'s slot-shape rules (`txn_id`'s exemption from the str-ban lives in `check_fn`, not here — this only validates the `transact` expression itself)
-- `1824` `fn infer_call` — ordinary function-call type inference (builtins dispatch separately, see `infer_builtin_call`)
-- `1943` `fn infer_acquire` — privileged first-class function (`acquire`/`requires`) checking, §6a
-- `1972`/`2011` `fn infer_struct_construction`/`infer_variant_construction`
-- `2082` `fn resolve_type_args` — generic instantiation resolution
-- `2126` `fn check_match` — exhaustiveness (every enum variant covered exactly once, no wildcard in v1) is checked unconditionally here, regardless of how the match's value is used
-- `2275` `fn check_literal_match` — the `str`/`i64`/`bool` literal-pattern sibling of `check_match`
-- `2386` `fn infer_builtin_call` — the huge per-builtin-name signature table (`json_get_str`, `db_query`, `http_post`, `oidc_validate_token`, ... — this is where a new builtin's typeck signature gets added)
-- `2866`–`2931` builtin-checking helpers: `builtin_arity_hint`, `wrong_arg`, `literal_dimension`, `expect_f64_matrix`/`expect_square_f64_matrix`/`expect_f64_vector`
-- `2931` `fn infer_binary` — the `BinOp` type-inference dispatch (`Eq`/`NotEq` permit any matching type generically here — including `struct`/`enum` — which is why `interpreter.rs::eval_binary` needed a matching runtime arm)
-- `3018`/`3078` `fn infer_mul`/`infer_hadamard` — linear-algebra `*` and elementwise `.*`/`./`
-- `3107` `fn infer_array_lit`
-- `3143` `fn unify_operands` — the shared "do these two operand types agree" logic every binary operator's inference goes through; returns `Ty::Error` on mismatch so callers can suppress follow-on diagnostics
-- `3214` `fn check_if` — every branch (including a missing `else`, unless `ty` is `unit`) must produce the same type
-- `3274` `fn check_block_value` — a block used in value position (the mechanism `if`/`match`/`transact` all share)
-- `3315` `fn bind_type_params` / `3336` `fn definitely_returns` / `3352` `fn if_definitely_returns` / `3372` `fn is_elementwise_operand` / `3386` `fn is_sandbox_safe` — free-function helpers used across the checker
-- `3404` `pub struct FragmentEnv` / `3441` `pub fn validate_fragment` — the agent-facing "typecheck one expression fragment in a given variable-type context" entry point (docs/goal.md row 9 / `docs/nirdosha-agent-api.md`'s A3 endpoint's underlying capability)
+- `527` `pub struct TypeError` / `532` `impl Display` — wraps a `TypeErrorKind` with its `Span`, and formats it human-readably
+- `1014` `enum MatchWant<'t>` — the three-way "how is this `match`'s value used" distinction (bare statement / no-expected-type infer / a real expected `&Ty`) a plain `Option<&Ty>` would wrongly conflate — see `check_match`
+- `1020`/`1039` `struct FnSig`/`Scopes` — signature table and lexical-scope variable-type stack
+- `1059` `pub struct Checker<'a>` — the whole typecheck pass's state (registry, signatures, accumulated errors)
+- `1115` `pub fn typecheck` — top-level entry point; requires a zero-arg `fn main()`, the entrypoint every `build`/`emit-llvm` caller is about to execute
+- `1130` `pub fn typecheck_optional_main` — same, but tolerates no `main` at all — a generated nirdosha-lane program (N `module { }` blocks of `fn`/`screen`, no `main`) is exactly this shape by design
+- `1139` `pub fn typecheck_with_native_plugins` — plus a native (compiled-path) plugin's declared signatures (`plugin::NativePluginBuiltin`, rfcs/0008) — registers name/params/ret for arity/type checking only, since a native plugin has no effects field
+- `1157` `pub fn typecheck_optional_main_with_ui_components` — plus `ui_plugin::NativeUiComponent`-contributed `layout` widget kinds (rfcs/0009 Phase B); a component is only referenceable inside `layout { ... }`, never callable from `.nir` code like `plugins` above
+- `1177`/`1184` `pub struct TypeWarning` / `pub enum TypeWarningKind` — non-fatal findings kept out of `TypeError` on purpose: adding a new fatal condition to `typecheck`'s `Result` would be a behavior change beyond what a warning should cost
+- `1237` `pub fn ungated_fn_warnings` — every `fn` reachable with no auth token and no `requires(public)` opt-out (`docs/API_TRUST_MODEL.md` T1b), surfaced at `serve`/`emit-ui` time instead of only discovered in a security review
+- `1246`/`1258`/`1266` `fn is_reachable_with_no_token`/`is_verified_identity`/`is_optional_verified_identity` — `ungated_fn_warnings`' own helpers
+- `1276` `pub fn workflow_owner_warnings` — every declared `workflow`'s non-terminal `state` with no `owner` entry; terminal states are exempt since nothing is ever *decided* there
+- `1314` `pub fn collect_role_claim_strings` — every `role(...)`/`claim(...)` string literal a program references, for the demo identity picker; `role(...)` is any-of so every name is collected, not just the first
+- `1371` `fn typecheck_impl` — the real pass every `pub fn typecheck*` above thin-wraps, parameterized over `require_main`/native-plugin signatures/plugin effects/`extra_widget_kinds`. `impl<'a> Checker<'a>` (`1597`–`4973`) holds every method below unless noted otherwise
+- `1598` `fn error` — push one `TypeErrorKind` at a `Span`, the one place every check funnels through
+- `1610` `fn check_fn_ref` — a screen/dashboard `->`-target slot (`list`/`create`/`update`/`delete`, an action's or dashboard tile's target) must be a bare `Expr::Ident` naming a real user fn; builtins excluded
+- `1628` `fn check_visibility_expr` — `view: role("admin")` / `edit: claim(...)`, same shape `requires(...)` accepts but arriving as an ordinary `Expr`
+- `1652`/`1688`/`1716` `fn check_pattern_expr`/`check_format_expr`/`check_min_max_expr` — `field <name> { pattern/format/min/max: ... }` shape + field-type-applicability checks, incl. compiling `pattern`'s regex via the `regex` crate at typeck time
+- `1749` `fn check_field_render_expr` — a field's `render: "..."` value (e.g. `searchable_select`); its companion `source` key is checked separately since it's a sibling entry
+- `1803` `fn check_searchable_select_source_expr` — `source` naming either a declared struct (paginated `/_nirdosha/table/<snake>` route) or a declared fn (unpaginated `callFn` fallback) — the one shape `check_fn_ref`'s "must be a fn" rule doesn't fit
+- `1823`/`1892`/`1900` `fn check_screen`/`check_screen_layout`/`check_layout_node` — Row 12 UI-DSL shape checks; `check_layout_node` is this DSL family's first genuinely recursive node, widened by `extra_widget_kinds` (rfcs/0009 Phase B) past the closed `divider`/`card`/`timeline` set
+- `1999` `fn check_validate` — a `validate { ... }` block's predicates, typed as real `bool` expressions regardless of the target fn's own shape (a struct param, a `db`-touching body, a loop all still get real static errors here, even though none are statically *proven* by the Z3 pass)
+- `2042` `fn check_action_show_result` — `show_result: true` forces the action's already-resolved target fn to return `Result(json, _)`
+- `2071` `fn check_dashboard` — Row 12 `dashboard` shape checks (sibling of `check_screen`)
+- `2119` `fn check_encode_entry` — `chart`/`panel` `encode <channel> { field/type/aggregate }` (rfcs/0009 Phase A, shared between `visual` and `panel`); `field` is checked to be a string only, since the backing fn returns opaque `json` with no struct to resolve against
+- `2185` `fn check_render_expr` — shared `render: "..."` value-in-allowed-set check, serving `visual`/`dashboard`/`panel` alike; `context` is a pre-formatted description since one check serves three callers
+- `2209` `fn check_workspace` — `workspace`/`panel` shape checks (rfcs/0009 follow-up): mirrors `check_screen`, plus one extra check `screen` doesn't need — a panel's `source` must be a one-`id`-in/`Result(json,_)`-out fn (`docs/ROADMAP.md` Track E1)
+- `2308` `fn check_metric_ref`
+- `2320` `fn check_duplicate_type_params`
+- `2340` `fn check_visibility` — `pub`/namespaced-name access rules; a qualified self-reference from within a declaration's own module is always legal even when not exported
+- `2359` `fn validate_ty` — well-formedness of a type expression itself (arity, unknown names), recursing through every type-former the same way `ast.rs::Ty::contains_str` does
+- `2414` `fn check_fn` — per-function entry point: the str-in-signature scan, then body-checks, then `NotAllPathsReturn`
+- `2476` `fn check_workflow_decl` — a `workflow` block's `send_email`/`send_sms`/`notify`/etc. action calls; every argument's type is now checked against the callee's real declared parameter types (arity included), not just "does this fn exist"
+- `2562`/`2568`/`2574` `fn check_stmts`/`check_block`/`check_stmt` — statement-level checking (no value context)
+- `2615` `fn check_stmt_expr`
+- `2641` `fn check` — **the** "does this expr have exactly this type" entry point; every value position goes through here, so "no implicit conversions" is enforced in exactly one place
+- `2705` `fn infer` — the no-expected-type counterpart to `check`
+- `3062`/`3110` `fn infer_sandbox_spawn`/`infer_spawn`
+- `3134`/`3214`/`3235` `fn infer_transact`/`infer_transact_slot`/`infer_transact_slot_durable` — `transact`'s slot-shape rules
+- `3270` `fn infer_call` — ordinary function-call type inference (builtins dispatch separately, see `infer_builtin_call`)
+- `3403` `fn infer_acquire` — privileged first-class function (`acquire`/`requires`) checking
+- `3432`/`3471` `fn infer_struct_construction`/`infer_variant_construction`
+- `3542` `fn resolve_type_args` — generic instantiation resolution
+- `3586` `fn check_match` — exhaustiveness (every enum variant covered exactly once, no wildcard in v1), using `MatchWant` to distinguish statement/value/expected-type positions
+- `3742` `fn check_literal_match` — the `str`/`i64`/`bool` literal-pattern sibling of `check_match`
+- `3852` `fn is_builtin_or_plugin`
+- `3863` `fn infer_builtin_call` — the huge per-builtin-name signature table (this is where a new builtin's typeck signature gets added)
+- `4542`–`4602` builtin-checking helpers: `builtin_arity_hint`, `wrong_arg`, `literal_dimension`, `expect_f64_matrix`/`expect_square_f64_matrix`/`expect_f64_vector`
+- `4612` `fn infer_binary` — the `BinOp` type-inference dispatch (`Eq`/`NotEq` permit any matching type generically, including `struct`/`enum`)
+- `4699`/`4759` `fn infer_mul`/`infer_hadamard` — linear-algebra `*` and elementwise `.*`/`./`
+- `4788` `fn infer_array_lit`
+- `4812` `fn check_bool_operand`
+- `4824` `fn unify_operands` — the shared "do these two operand types agree" logic every binary operator's inference goes through
+- `4895` `fn check_if` — every branch (including a missing `else`, unless `ty` is `unit`) must produce the same type
+- `4955` `fn check_block_value` — a block used in value position; closes the `impl<'a> Checker<'a>` block at `4973`
+- `4996` `fn bind_type_params` — Row 11 layer 6's structural type-parameter binder, `resolve_type_args`'s fallback path
+- `5018`/`5034`/`5054`/`5068` `fn definitely_returns`/`if_definitely_returns`/`is_elementwise_operand`/`is_sandbox_safe` — free-function helpers used across the checker
+- `5086`/`5123` `pub struct FragmentEnv` / `pub fn validate_fragment` — the agent-facing "typecheck one expression fragment in a given variable-type context" entry point (docs/goal.md row 9 / `docs/nirdosha-agent-api.md`'s A3 endpoint's underlying capability)
 
-## ast.rs (~1681 lines, as of 2026-08-23)
+## ast.rs (2624 lines, as of 2026-09-07)
+
 - `25` `pub enum Ty` — every static type this language has; the grammar's `type` production made concrete
-- `243` `impl Ty` — methods below are inside it
-- `244` `fn from_name` / `271` `fn name` — string ↔ `Ty` for primitive type names
-- `316`–`390` classification predicates: `is_unsigned`, `is_integer`, `is_numeric`, `is_aggregate` (lives in one SSA register vs. needs a stack slot — `codegen.rs`'s `expr` vs. `expr_ptr` split), `is_transact_scalar` (the 4 types `transact`'s durability log can serialize)
-- `403` `fn contains_str` — the "enum favoring" str-ban's recursive scan (added 2026-08-23), walks every type-former the same way `validate_ty`/`substitute_ty` do
-- `434` `fn is_affine` — the property that makes ownership meaningful; deliberately blind to `Ty::Named`'s real affinity (see `TypeRegistry::is_affine` below for the struct/enum-aware version)
-- `459`/`475` `fn in_range`/`bounds` — an integer type's legal value range, used by both the interval-analysis proof and codegen's guard emission
-- `518`/`530` `pub struct Param`/`Field`
-- `550` `pub struct StructDecl`
-- `572`/`586` `pub struct Variant`/`EnumDecl`
-- `611`/`645` `pub fn prelude_enums`/`prelude_structs` — `Option(T)`/`Result(T,E)` and every Row-12 identity struct (`VerifiedIdentity`, `RoleView`, ...), injected into every program at parse time
-- `746` `pub enum Effect` / `760` `impl` (`name`) — the `effect(...)` annotation vocabulary (`pure`/`io`/`network`/`concurrent`/`rng`)
-- `778` `pub struct TransactSlot`
-- `785` `pub struct FnDecl` — a function declaration's full shape (params, ret, body, `effect(...)`, `requires(...)`)
-- `827` `pub enum Requirement` / `839` `impl` (`proof_ty`, `describe`) — `requires(role/claim: ...)`'s parsed shape
-- `863` `pub struct Block`
-- `868` `pub enum Stmt`
-- `889`/`916` `pub enum BinOp`/`UnOp`
-- `922` `pub enum Expr` — every expression form the parser produces
-- `1136` `pub struct MatchArm` / `1165` `enum LiteralPattern` / `1173` `enum ElseBranch`
-- `1178` `impl Expr` (`span`) — every `Expr` variant's source span, for error reporting
-- `1216` `pub struct Program` — the whole-program AST root (`fns`/`structs`/`enums`/`screens`/`dashboard`)
-- `1244`–`1305` Row 12 UI-DSL AST: `FieldOverride`, `ActionDecl`, `ScreenDecl`, `MetricRef`, `DashboardDecl`
-- (just above `FieldOverride`) `pub fn well_known_format_pattern` — `field <name> { format: "..." }`'s fixed vocabulary (`email`/`phone`/`date`/`url`/`uuid`) → regex, the single source of truth `typeck.rs`/`ui_gen.rs` both consume (2026-08-24)
-- `1305` `pub struct TypeRegistry<'a>` — the struct/enum declaration lookup table every later pass (typeck, ownership, effects, codegen, ui_gen) builds once and queries repeatedly
-- `1327`–`1396` `impl TypeRegistry` methods: `build`, `struct_decl`/`enum_decl`, `struct_fields`/`enum_variants`, `struct_type_params`/`enum_type_params`, `is_struct`/`is_enum`, `find_variant`, `is_affine` (the struct/enum-aware version, delegates to `Ty::is_affine` for everything else)
-- `1435` `pub fn result_of` — `Result(ok, str)` shorthand every builtin signature uses (builtins are exempt from the str-ban — see `docs/LANGUAGE.md` §6b)
-- `1439`/`1455` `pub fn zip_type_params`/`substitute_ty` — Row 11 layer 6's generic-substitution mechanism, used identically by typeck/ownership/codegen
-- `1490` `pub fn literal_value` — extracts a literal integer from an `Expr`, for `zeros`/`ones`/`identity`'s compile-time-only dimension argument
-- `1522` `pub const BUILTIN_NAMES` — the full builtin name list (grep here for "does builtin X exist")
-- `1679` `pub fn is_builtin`
+- `346` `impl Ty` — methods below (through `632`) are inside it
+- `347`/`375` `fn from_name`/`name` — string ↔ `Ty` for primitive type names
+- `423`–`502` classification predicates: `is_unsigned`, `is_integer`, `is_numeric`, `is_aggregate` (lives in one SSA register vs. needs a stack slot — `codegen.rs`'s `expr` vs. `expr_ptr` split), `is_transact_scalar` (the 4 types `transact`'s durability log can serialize)
+- `515` `fn contains_str` — the "enum favoring" str-ban's recursive scan, walks every type-former the same way `validate_ty`/`substitute_ty` do
+- `546` `fn is_affine` — the property that makes ownership meaningful; deliberately blind to `Ty::Named`'s real affinity (see `TypeRegistry::is_affine` below for the struct/enum-aware version)
+- `571`/`587` `fn in_range`/`bounds` — an integer type's legal value range, used by both the interval-analysis proof and codegen's guard emission
+- `633`/`645` `pub struct Param`/`Field`
+- `685` `pub struct StructDecl`
+- `732`/`746` `pub struct Variant`/`EnumDecl`
+- `784`/`943` `pub fn prelude_enums`/`prelude_structs` — `Option(T)`/`Result(T,E)` and every Row-12 identity struct (`VerifiedIdentity`, `RoleView`, ...), injected into every program at parse time
+- `923` `fn zero_payload_enum` — shared constructor `prelude_enums` calls for each of its zero-payload enums
+- `1101`/`1115` `pub enum Effect` / `impl` (`name`) — the `effect(...)` annotation vocabulary (`pure`/`io`/`network`/`concurrent`/`rng`)
+- `1133` `pub struct TransactSlot`
+- `1140` `pub struct FnDecl` — a function declaration's full shape (params, ret, body, `effect(...)`, `requires(...)`)
+- `1232`/`1239` `pub struct NfrSpec` / `impl` — a non-functional-requirement annotation (a latency/error-rate budget) on a `fn`; a sustained violation escalates on every trip, no debouncing (disclosed follow-up)
+- `1259`/`1271` `pub enum Requirement` / `impl` (`proof_ty`, `describe`) — `requires(role/claim: ...)`'s parsed shape
+- `1295` `pub struct Block`
+- `1300` `pub enum Stmt`
+- `1321`/`1348` `pub enum BinOp`/`UnOp`
+- `1354` `pub enum Expr` — every expression form the parser produces
+- `1573` `pub struct MatchArm` / `1602` `enum LiteralPattern` / `1610` `enum ElseBranch`
+- `1615` `impl Expr` (`span`) — every `Expr` variant's source span, for error reporting
+- `1654` `pub struct Program` — the whole-program AST root
+- `1724` `pub struct ValidateDecl` — a `validate { ... }` block's predicates, mirroring `contract_check::check_fn_contract`'s own `&[String]` list-of-predicates shape, just fed already-parsed `.nir` `Expr`s instead of extraction-JSON strings
+- `1740` `pub struct ImportDecl` — one file's own `import` statement, uninterpreted here — resolving/loading/merging another file's `pub` declarations is `main.rs`'s job
+- `1777` `pub fn well_known_format_pattern` — `field <name> { format: "..." }`'s fixed vocabulary (`email`/`phone`/`date`/`url`/`uuid`) → regex, the single source of truth `typeck.rs`/`ui_gen.rs` both consume
+- `1794`/`1804` `pub struct FieldOverride`/`ActionDecl`
+- `1828`/`1877` `pub enum LayoutNode` / `impl` — the recursive `layout { ... }` widget tree; its `Widget` variant is rfcs/0009 Phase B's one plugin extension point, and this is this DSL family's first genuinely recursive node
+- `1901` `pub struct ScreenDecl`
+- `1917`/`1932` `pub struct MetricRef`/`DashboardDecl`
+- `1946` `pub struct Transition` — a `workflow` state's `on <event> -> <state>`; a `via_link` transition means `workflow_lower.rs` also synthesizes an unauthenticated `<event>_via_link` fn and a per-workflow link-token struct
+- `1958` `pub struct StateDecl` — `on_entry`/`on_exit` reuse `TransactSlot` (bare-call-only action slots) rather than a new node type
+- `1996` `pub struct WorkflowDecl` — parsed as its own top-level decl rather than parser-time-flattened, since lowering needs the full set of states/transitions gathered first
+- `2018`/`2034` `pub struct PanelDecl`/`WorkspaceDecl` — rfcs/0009 follow-up: several unrelated functions' results composed onto one page, all keyed off one `subject` struct's `id`
+- `2070` `pub fn scope_key` — `(ns, name)` → the one canonical string both a namespaced declaration and every reference to it resolve through; no "which module am I inside" resolution context is ever needed
+- `2077` `pub struct TypeRegistry<'a>` — the struct/enum declaration lookup table every later pass (typeck, ownership, effects, codegen, ui_gen) builds once and queries repeatedly
+- `2105`–`2286` `impl<'a> TypeRegistry<'a>` methods: `empty`, `build`, `struct_decl`/`enum_decl`, `struct_fields`/`enum_variants`, `struct_type_params`/`enum_type_params`, `is_struct`/`is_enum`, `find_variant`, `is_affine`/`is_affine_visiting` (the struct/enum-aware version, with a cycle guard, delegates to `Ty::is_affine` for everything else)
+- `2287` `pub fn result_of` — `Result(ok, str)` shorthand every builtin signature uses (builtins are exempt from the str-ban)
+- `2296` `pub fn workflow_result_of` — same shape, `WorkflowActionError` in place of `str`, for `send_email`/`send_sms`/`send_push`/`notify`/`workflow_lower.rs`-synthesized fns (`docs/WORKFLOW.md`)
+- `2300`/`2316` `pub fn zip_type_params`/`substitute_ty` — Row 11 layer 6's generic-substitution mechanism, used identically by typeck/ownership/codegen
+- `2352` `pub fn literal_value` — extracts a literal integer from an `Expr`, for `zeros`/`ones`/`identity`'s compile-time-only dimension argument
+- `2384` `pub const BUILTIN_NAMES` — the full builtin name list (grep here for "does builtin X exist")
+- `2622` `pub fn is_builtin`
 
-## parser.rs (1415 lines, as of 2026-08-23)
+## ui_gen.rs (2318 lines, as of 2026-09-07)
+- `79` `const PRELUDE_STRUCT_NAMES` — the `ast::prelude_structs()` infrastructure types (`VerifiedIdentity`, `Money`, ...) screens are never derived from
+- `83` `struct FieldSpec` — one field of a derived form/table column: control kind, gating (`view_roles`/`view_claim`/`edit_roles`/`edit_claim`), format constraints (`pattern`/`min`/`max`), a `render` display hint, and (2026-08-27+) `select_source`/`search_param`/`select_page_size` for a `searchable_select` field
+- `174` `enum SelectSource` — `Table(snake_table_name)` (reuses `/_nirdosha/table/<t>` pagination) or `Fn(name)` (unpaginated) for a `searchable_select` field's dropdown source
+- `181` `struct Action` — one CRUD-convention (or declared-custom) fn backing a screen: gating, `effect_badges`, its own `params` as a `FieldSpec` tree, plus `label`/`style`/`confirm`/`show_result` for a declared custom action
+- `245`/`267` `struct Metric`/`EncodingChannelSpec` — one dashboard tile/chart; `chart_mark`/`chart_encoding` (rfcs/0009 Phase A) populated only when `render == MetricRender::Chart`
+- `281`/`289` `enum MetricRender`/`impl` (`as_str`, `from_kv`) — `visual`'s closed render vocabulary: `BarChart`/`Graph`/`Heatmap`/`Timeline`/`Chart` (`Chart` added by rfcs/0009 Phase A)
+- `322` `fn parse_chart_config` — flat `mark`/`encode.<channel>.<key>` kv-entries -> `(mark, encoding)`, already typeck-proven well-formed (rfcs/0009 Phase A)
+- `350` `struct Screen` — one derived screen: title, `module` nav grouping, fields/actions, `is_singular`, and (Track F1) an optional declared `layout: Option<LayoutNode>`
+- `383`/`406`/`414` `struct Panel`/`enum PanelRender`/`impl` — one `workspace` panel; same `Chart` addition as `MetricRender`, extended to panels
+- `445` `struct Workspace` — one declared `workspace` block: subject struct's read-only header fields plus its panels
+- `471` `struct WorkflowQueue` — one declared `workflow`'s derived "Workflows" nav entry (pending/submitted-by-me/advance/history fns, `data_fields`, `all_states` for a stepper)
+- `506`/`531` `fn to_snake_case`/`to_display_label` — PascalCase struct-name conversions
+- `521` `fn find_fn`
+- `548` `fn ty_label` — a `readonly` field's honest type label
+- `572`/`576` `fn resolve_struct`/`resolve_enum`
+- `587` `fn is_date_like_field_name` — naming-convention heuristic for calendar-picker vs. plain text input
+- `612`/`616` `fn build_field_root`/`build_field` — **the** field→form-control mapping: `build_field_root` gives every independent top-level field a fresh `visiting` cycle guard (2026-08-27, replacing a flat depth cap — a legitimate `Order -> LineItem -> Product -> Category` schema no longer misrenders as `readonly`); `Option(T)` unwraps, a zero-payload-only enum renders as a dropdown, `struct Text { value: str }` renders as a plain input, a struct reference expands one level deep, everything else falls back to `readonly`
+- `758`/`762` `fn fn_requires_login`/`fn_role_gate`
+- `770` `fn effect_badges`
+- `786`/`815` `fn build_action`/`build_custom_action` — CRUD-convention and declared-`screen`-action derivation
+- `834`/`849`/`860`/`873`/`886` `fn kv_str`/`kv_ident`/`kv_num`/`kv_bool`/`kv_gate` — `screen` DSL's `key: value` entry helpers (string/bare-name/numeric/boolean values, `role(...)`/`claim(...)` gate extraction)
+- `904` `fn find_screen_decl`
+- `910` `fn to_title_case`
+- `924`/`931`/`942` `fn is_numeric_scalar`/`is_stat_return_ty`/`is_chart_return_ty` — `stat_`/`chart_` naming-convention dashboard-metric detection
+- `954`/`971`/`990` `fn build_metric_from_fn`/`build_metrics`/`apply_declared_metrics` — shared metric-building plumbing; `apply_declared_metrics` layers a declared `dashboard { tile/chart "..." -> fn }` on top of naming-convention inference
+- `1000`/`1008` `fn build_stats`/`build_charts` — `build_charts` also folds in declared `visual` items (rfcs/0009 Phase A `chart` render, via `parse_chart_config`)
+- `1034`/`1042`/`1063`/`1085`/`1126` `pub struct GatedField` / `fn gates_from_screen_decl` / `pub fn field_gates_for_struct`/`field_gates_for_fn`/`update_gates_for_fn` — field-visibility gate resolution. **Now dead code, zero callers**: these existed for `serve.rs`'s server-side redaction/edit-blocking to consult, but `serve.rs` was deleted entirely (interpreter-removal pass); nothing replaced that consumption (only a doc-comment mention remains, in `ast.rs:1817`) — grep-verified, not carried over from the stale prose still in this file's own doc comments
+- `1158`/`1170`/`1176`/`1199` `pub struct ValidatedField` / `fn resolve_pattern`/`validations_from_screen_decl`/`pub fn field_validations_for_fn` — field-format-constraint resolution (`pattern`/`format`/`min`/`max`); same now-orphaned-by-`serve.rs`-deletion situation as `GatedField` above
+- `1237` `fn apply_field_overrides`
+- `1294` `fn build_screens` — assembles the full per-struct `Screen` list (the main derivation pass)
+- `1371`/`1404` `fn build_workflow_queues`/`workflows_json`
+- `1432`/`1470` `fn build_workspaces`/`workspaces_json`
+- `1516` `fn action_json`
+- `1535` `fn layout_json` — `layout { ... }` -> JSON tree; a `Widget` leaf's `entries` carries every kv-entry generically (not just the three std kinds' special-cased `source`/`title`), so a plugin-contributed widget's `render_js` can read its own config keys (rfcs/0009 Phase B)
+- `1602` `fn widget_entry_json`
+- `1612` `fn field_json`
+- `1638` `fn identity_catalog_json`
+- `1657` `fn mode_badge_html`
+- `1667` `fn metrics_json`
+- `1692` `fn manifest_json`
+- `1760`/`1782`/`1795` `pub fn generate`/`generate_with_ui_components`/`fn generate_impl` — top-level entry points: program → complete self-contained HTML string; `generate_with_ui_components` (rfcs/0009 Phase B) additionally splices linked `ui_plugin::NativeUiComponent`s' JS in and registers them into `WIDGET_RENDERERS`
+- `1842` `fn ui_components_script` — rfcs/0009 Phase B: splices each linked component's `render_js` plus a `WIDGET_RENDERERS[name] = render_fn` registration; empty (byte-identical `const WIDGET_RENDERERS = {};`) for `generate`'s own `components: &[]`
+- `1861`/`1876` `fn logo_data_uri`/`favicon_data_uri` — brand PNGs embedded via `include_bytes!` as base64 `data:` URIs
+- `1897`–`1986` `pub struct Theme` / `ThemeFonts`/`ThemeRadius`/`ThemeDensity`/`ThemeMotion`/`ThemeLayout`/`ThemeTypeScale` — 1:1 mirror of protobox's `resolve_design_tokens()` JSON shape (docs/LANGUAGE.md §11b)
+- `1987` `fn theme_value_is_safe`
+- `1997`–`2021` `const RAMP_STEPS` / `struct RampRoleStep` + the `PRIMARY`/`ON_PRIMARY`/`SURFACE`/etc. consts — the semantic-role → ramp-step mapping deriving `--md-*` from the raw `brand`/`neutral` ramps
+- `2023`/`2162`/`2189` `fn theme_override_css`/`theme_html_class`/`theme_bootstrap_script` — the three `__NIRDOSHA_*__` placeholders `generate_impl` splices in
+- `2204` `const TEMPLATE` — `include_str!("ui_gen_template.html")`
+
+## parser.rs (2258 lines, as of 2026-09-07)
 - `13` `pub struct ParseError`
-- `18` `pub struct Parser` — hand-written recursive-descent, strictly one token of lookahead, no backtracking (docs/GRAMMAR.md's Row 7 claim)
+- `18` `pub struct Parser` — hand-written recursive-descent, strictly one token of lookahead (`peek2` at `103` is the sole, deliberate exception), no backtracking (docs/GRAMMAR.md's Row 7 claim); `depth` is the combined `parse_expr`/`parse_unary` nesting counter `MAX_PARSE_DEPTH` guards
+- `31` `const MAX_PARSE_DEPTH: usize = 50` — past this many combined `parse_expr`/`parse_unary` nesting levels, fail with a normal `ParseError` instead of a real stack overflow (a red-team finding: ~1000 nested parens SIGABRTs an unguarded parse)
+- `55` `const MAX_LAYOUT_DEPTH: usize = 12` — same adversarial-input concern as `MAX_PARSE_DEPTH`, sized for `layout { }`'s much shallower realistic ceiling
 - `57` `impl Parser` — the whole parser, methods below are inside it
-- `64`/`74` `fn enter_nesting`/`exit_nesting` — recursion-depth guard (stack-overflow protection for deeply nested expressions)
+- `64`/`74` `fn enter_nesting`/`exit_nesting` — shared entry/exit pair enforcing `MAX_PARSE_DEPTH`
 - `78`/`82`/`86`/`94` `fn peek`/`span`/`bump`/`expect` — the token-stream primitives everything else is built from
+- `103` `fn peek2` — one token past `peek()`; this grammar's only two-token lookahead, used by `parse_layout_container_body` to tell a `key: value` config entry from a nested layout item
 - `105`/`124` `fn expect_ident`/`expect_usize_literal`
-- `139` `fn expect_type` — `type ::= "&" type | "box" type | i8 | ... | bool | unit | ident "(" type,* ")"`
-- `264` `pub fn parse_program` — top-level entry point: `program ::= item*`
-- `315` `fn parse_module_decl` — `module "Name" { ... }` nav-grouping sugar (single-level only)
-- `369`–`499` Row 12 UI-DSL parsing: `parse_kv_entry`, `parse_screen_decl`, `parse_field_override`, `parse_action_decl`, `parse_dashboard_decl`
-- `499` `fn parse_type_param_list` — `struct Pair(A, B)`'s generic parameter list
-- `521`/`551` `fn parse_struct_decl`/`parse_enum_decl`
-- `593` `fn parse_fn_decl`
-- `630`/`686` `fn parse_effect_annotation`/`parse_requires_annotation` — `effect(...)`/`requires(role/claim: ...)`
-- `717` `fn expect_str_lit`
-- `731`/`742` `fn parse_block`/`parse_stmt`
-- `753`/`772`/`783`/`794` `fn parse_audited_stmt`/`parse_let_stmt`/`parse_return_stmt`/`parse_while_stmt`
-- `803` `fn parse_expr` — expression parsing entry point, feeds into the precedence-climbing chain below
-- `826` `fn parse_match_expr`
-- `911`–`997` `transact { ... }` parsing: `parse_transact_expr`, `parse_optional_int_modifier` (retry/timeout counts), `parse_transact_slot`, `parse_optional_transact_slot`
-- `997` `fn parse_assignment`
-- `1017` `fn parse_if_expr`
-- **Precedence-climbing chain** (each calls the next, lowest to highest precedence — this *is* how binary-operator precedence works in this LL(1) grammar, not left-recursion): `1037 parse_logic_or` → `1048 parse_logic_and` → `1059 parse_equality` → `1075 parse_comparison` → `1093 parse_additive` → `1109 parse_multiplicative` → `1127 parse_unary`
-- `1134` `fn parse_unary_inner` — the largest single production: unary ops, `box`/`&`/`*`, `spawn`/`join`/`chan`/`send`/`recv`, `sandbox`/`stop`, `connect`/`listen`/`accept`, `acquire`, literals
-- `1290` `fn parse_call` — call-args and the chained-call rejection (`f()()` is a parse error)
-- `1333` `fn parse_postfix` — `.field` access
-- `1361` `fn parse_primary` — identifiers, parenthesized exprs, literals
+- `155` `fn parse_qualified_name` — `IDENT ("::" IDENT)*` joined into one canonical dotted-path string (`docs/ROADMAP.md` Track F, F2); every *reference* site (types, `match` variant names, `primary`'s bare idents) goes through this, never a separate `Path` AST node
+- `187` `fn expect_type` — `type ::= "&"|"box"|"froze"|"thread"|"chan" type | "sandbox" | Vector(T,N) | Matrix(T,R,C) | handle(Kind) | fn(T,..)->R | i8|...|bool|unit | ident(type,*)`
+- `264` `pub fn parse_program` — top-level entry point: leading `use "path.nir"*` imports, then `item*`; calls `workflow_lower::lower` on the assembled `Program` before returning
+- `394` `fn parse_validate_decl` — `validate IDENT { kv_entry* }` (reuses `parse_kv_entry` unchanged for `pre`/`post`)
+- `417` `fn parse_module_decl` — `module (STRING | namespace_module) { ... }`; dispatches to `parse_namespace_module_decl` on `IDENT`, else the legacy pure-nav-grouping `STRING` form
+- `484` `fn parse_namespace_module_decl` — the real namespace form (Track F2): `pub?`-prefixed items get `exported`/`ns` set; `nav: "..."` overrides the display name, single-level only
+- `557` `fn parse_kv_entry` — one `key: value` slot shared by `screen`/`field`/`action`/`paginate`/`panel` bodies; value is an ordinary `parse_expr()`
+- `575` `fn parse_encode_channel_entries` — `encode <channel> { field/type/aggregate: ... }` inside a `visual`/`panel` body (rfcs/0009 Phase A), flattened into `"encode.<channel>.<key>"`-prefixed `KvEntry`s
+- `614` `fn parse_screen_decl` — `screen IDENT { paginate{} | field{} | action{} | layout{} | kv_entry }*`; at most one `layout { }` per screen
+- `660` `fn parse_field_override`
+- `675` `fn parse_action_decl` — `action STRING -> IDENT { kv_entry* }?`, body optional
+- `699` `fn parse_layout_decl` — `layout { layout_node* }`, wrapped in one synthetic root `LayoutNode::Column`
+- `737` `fn parse_layout_node` — one `row`/`column`/`grid`/`group STRING?`/`tabs{tab STRING{...}}*`/`field IDENT`/`action STRING`/`IDENT { kv_entry* }` (widget leaf) item; depth-capped at `MAX_LAYOUT_DEPTH`
+- `830` `fn parse_layout_container_body` — the shared `{ kv_entry* layout_node* }` body every container uses `peek2` to disambiguate
+- `858` `fn parse_dashboard_decl` — `dashboard { (tile|chart) STRING -> IDENT | visual STRING -> IDENT { (kv_entry|encode)* }? }*`; at most one `dashboard { }` per program (enforced in `parse_program`)
+- `917` `fn parse_workspace_decl` — `workspace IDENT { panel_decl | kv_entry }*` (Track E1)
+- `949` `fn parse_panel_decl` — `panel STRING { action_decl | encode | kv_entry }*`, leading `"panel"` consumed by the caller
+- `978` `fn parse_workflow_decl` — `workflow IDENT { data_block? state_decl+ }` (docs/WORKFLOW.md); rejects zero `state`s
+- `1013` `fn parse_workflow_data_block` — `data { field ("," field)* ","? }`
+- `1047` `fn parse_state_decl` — `state IDENT "terminal"? { on_entry{} | on_exit{} | on ... -> ... | kv_entry }*`
+- `1095`/`1109` `fn parse_action_block`/`parse_action_call` — `on_entry`/`on_exit` bodies, reusing `TransactSlot` for a plain `name(args)` call
+- `1123` `fn parse_transition` — `on "link"? IDENT -> IDENT`
+- `1143` `fn parse_type_param_list` — a `struct`/`enum` declaration's bare-name type-parameter list
+- `1165` `fn parse_struct_decl`
+- `1199` `fn parse_field_mask_requires` — `field: ty requires(role/claim: ...)` on a struct field (masking gate; deliberately not shared with the fn-level `requires` parser since a field can't be `requires(public)`)
+- `1233` `fn parse_enum_decl`
+- `1275` `fn parse_fn_decl` — `fn IDENT(params) (-> type)? effect(...)? requires(...)? nfr(...)? block`
+- `1313` `fn parse_effect_annotation` — `effect(pure | rng,io,concurrent,network)`; `pure` (the empty set) can't combine with others
+- `1373` `fn parse_requires_annotation` — `requires(role: "..." | claim: "...", "..." | public)`
+- `1411` `fn parse_nfr_annotation` — `nfr(latency_ms/error_rate_max/throughput_min_per_sec/concurrency_max: ...)`, every field optional, each independently range-checked (e.g. `error_rate_max` in `[0.0, 1.0]`)
+- `1483`/`1504` `fn expect_i64_lit`/`expect_f64_lit` — bare (optionally negated) numeric literals for `nfr(...)`'s own slots
+- `1529` `fn expect_str_lit`
+- `1543` `fn parse_block`
+- `1554` `fn parse_stmt` — `let | return | while | audited | expr`
+- `1565` `fn parse_audited_stmt` — `audited STRING { stmt* }`
+- `1584`/`1595`/`1606` `fn parse_let_stmt`/`parse_return_stmt`/`parse_while_stmt`
+- `1615` `pub(crate) fn parse_expr` — expression entry point, feeds `if`/`transact`/`match`/assignment into the nesting-guarded precedence-climbing chain below
+- `1638` `fn parse_match_expr` — scrutinee via full `parse_expr`; an arm's pattern is either a qualified enum-variant name (optionally `(bindings)`) or (2026-08-2x) a literal/wildcard pattern (`str`/`int`/`bool`/`_`, `ast::LiteralPattern`), dispatched on the arm's leading token alone
+- `1727` `fn parse_transact_expr` — fixed-order `transact { precheck? network (retry N)? (timeout N)? verify commit compensate? log? }` (docs/TRANSACT.md — no permutation parsing)
+- `1747`/`1773`/`1802` `fn parse_optional_int_modifier`/`parse_transact_slot`/`parse_optional_transact_slot`
+- `1813` `fn parse_assignment` — `ident "=" assignment | logic_or`, right-associative
+- `1833` `fn parse_if_expr`
+- **Precedence-climbing chain** (each calls the next, lowest to highest precedence): `1853 parse_logic_or` → `1864 parse_logic_and` → `1875 parse_equality` → `1891 parse_comparison` → `1909 parse_additive` → `1925 parse_multiplicative` → `1943 parse_unary`
+- `1950` `fn parse_unary_inner` — the largest single production: `!`/`-`/`*`(deref)/`box`/`froze`/`&`/`spawn`/`acquire`/`join`/`chan`/`send`/`recv`/`sandbox`/`stop`/`connect`/`listen`/`accept`/`open`, literals
+- `2110` `fn parse_call` — call-args and the chained-call rejection (`f()()` is a parse error)
+- `2153` `fn parse_postfix` — `.field` access and `v[i]`/`m[i,j]` indexing (one bracket group each, not chained `[i][j]`), sits between `call` and `primary` — neither can follow a *call*'s own result
+- `2181` `fn parse_primary` — literals, qualified idents, parenthesized exprs, and `[e1, e2, ...]` array/vector/matrix literals (`Expr::ArrayLit`, `typeck.rs` decides which)
+- `2247` `pub fn parse_standalone_expr` — module-level fn (outside `impl Parser`): parses `src` as one bare expression, not a whole program — `contract_check.rs`'s entry point for turning a Hoare predicate string into a real `Expr` via this grammar's own precedence, requiring the whole string consumed
 
-## ui_gen.rs (963 lines, as of 2026-08-23)
-- `80`/`127`/`180`/`192` `struct FieldSpec`/`Action`/`Metric`/`Screen` — the derived-UI shape, serialized as the JSON manifest the client-side renderer reads
-- `212` `fn to_snake_case`
-- `227` `fn find_fn`
-- `237` `fn to_display_label`
-- `254` `fn ty_label`
-- `277`/`281` `fn resolve_struct`/`resolve_enum`
-- `292` `fn is_date_like_field_name` — naming-convention heuristic for calendar-picker vs. plain text input
-- `309` `fn build_field` — **the** field→form-control mapping: `Option(T)` unwraps, a zero-payload-only enum renders as a dropdown, the `Text {value: str}` free-text carrier (2026-08-23, str-ban work) renders as a plain input instead of a nested group, a struct reference expands one level deep, everything else falls back to `readonly`
-- `413`/`417` `fn fn_requires_login`/`fn_role_gate`
-- `425` `fn effect_badges`
-- `441`/`469` `fn build_action`/`build_custom_action` — CRUD-convention and declared-`screen`-action derivation
-- `487`/`503` `fn kv_str`/`kv_gate` — `screen` DSL's `key: value` entry helpers (`role(...)`/`claim(...)` extraction)
-- (near `kv_str`) `fn kv_num` — numeric sibling of `kv_str`, for `min`/`max` (2026-08-24)
-- `521` `fn find_screen_decl`
-- `527` `fn to_title_case`
-- `541`/`548`/`559` `fn is_numeric_scalar`/`is_stat_return_ty`/`is_chart_return_ty` — `stat_`/`chart_` naming-convention dashboard-metric detection
-- `570`/`588`/`592` `fn build_metrics`/`build_stats`/`build_charts`
-- `600` `pub struct GatedField` / `608`/`629`/`651`/`692` field-visibility gate resolution: `gates_from_screen_decl`, `field_gates_for_struct`, `field_gates_for_fn`, `update_gates_for_fn` — this is what `serve.rs`'s server-side redaction/edit-blocking actually consults
-- (near `update_gates_for_fn`) `pub struct ValidatedField` / `fn resolve_pattern`/`validations_from_screen_decl` / `pub fn field_validations_for_fn` — field-format-constraint resolution (`pattern`/`format`/`min`/`max`), 2026-08-24; unlike `update_gates_for_fn`, matches either a struct's `create` OR `update` slot — this is what `serve.rs::check_field_validations` consults
-- `727` `fn apply_field_overrides`
-- `749` `fn build_screens` — assembles the full per-struct `Screen` list (the main derivation pass)
-- `818`/`829`/`840` `fn field_json`/`metrics_json`/`manifest_json` — JSON-manifest serialization
-- `900` `pub fn generate` — top-level entry point: program → complete self-contained HTML string (embeds `manifest_json` into `ui_gen_template.html`)
-- (near `generate`) `pub struct Theme` / `ThemeFonts`/`ThemeRadius`/`ThemeDensity`/`ThemeMotion`/`ThemeLayout`/`ThemeTypeScale` — 2026-08-25 redesign, a 1:1 mirror of protobox's `resolve_design_tokens()` JSON shape (docs/LANGUAGE.md SS11b); `fn theme_override_css`/`theme_html_class`/`theme_bootstrap_script` — the three `__NIRDOSHA_*__` placeholders `generate` splices in; `const RAMP_STEPS` / `struct RampRoleStep` + the `PRIMARY`/`ON_PRIMARY`/`SURFACE`/etc. consts — the semantic-role → ramp-step mapping deriving `--md-*` from the raw `brand`/`neutral` ramps
+## contract_check.rs (909 lines, as of 2026-09-07)
 
-## serve.rs (957 lines, as of 2026-08-23)
-- `54` `pub struct AuthConfig` — JWKS/issuer/audience server-side config
-- `60`/`68` `fn cors_headers`/`header`
-- `78` `pub fn run` — top-level entry point: binds the HTTP server, wires `--db` migration (`migrate.rs::plan_and_apply`) + crash-replay before serving
-- (near `run`) `struct ThemeCache` / `fn theme_ttl`/`refresh_theme_html_if_stale` — live `--theme` reload, 2026-08-25 (docs/LANGUAGE.md SS11b): re-reads `theme.json` from disk and regenerates the served HTML on `GET /` at most once per TTL (env-overridable via `NIRDOSHA_TEST_THEME_TTL_MS` for `tests/theme_reload.rs`), tolerating a missing/malformed file by keeping the last-good page instead of erroring
-- `113` (inline in `run`) — `migrations_dir` derivation (`--db` path's parent + `/migrations`) and the `migrate.rs`/`replay_pending_transactions` call sequence — see `docs/ROADMAP.md` Track B1/B2 before changing this
-- `262` `fn to_snake_case`
-- (near `build_table_catalog`) `struct RoleMappingCache` / `fn load_role_mapping`/`refresh_role_mapping_if_stale`/`role_mapping_ttl`/`identity_has_mapped_role` — the identity role-mapping cache (`docs/ROADMAP.md` Track A6, 2026-08-24): app_role -> idp_role synonyms, loaded eagerly at `run` startup + refreshed on a TTL (env-overridable for `tests/role_mapping.rs`), consulted by every `requires(role:...)`/`view`/`edit` check via `identity_has_mapped_role` in place of a bare `interpreter::identity_has_role`
-- `290` `fn build_table_catalog`
-- `301`/`317` `fn json_to_sql_value`/`sql_value_to_json`
-- `342` `fn dispatch_table_query` — the paginated/searchable table route (`serverTableApi`); a `list_<struct>` doing a join or computed column is invisible to this route, client falls back to the plain unpaginated call
-- `474` `fn resolve_identity` — bearer-token → validated identity, the real server-side `requires(...)` enforcement `Expr::Acquire` alone doesn't provide
-- `514` `fn identity_satisfies_gate`
-- `540` `fn redact_gated_fields` — field-level view-gate enforcement (reads `ui_gen::GatedField`)
-- `579` `fn dispatch` — the actual request router, deliberately plain-data-in/`(status, json body)`-out with no `tiny_http` types, so `tests/serve.rs` can exercise it without a real socket
-- `741` `fn check_edit_gates` — field-level edit-gate enforcement
-- (near `check_edit_gates`) `fn check_field_validations` — field-format-constraint enforcement (`pattern`/`format`/`min`/`max`), 2026-08-24; unlike `check_edit_gates`, needs no `--db` (checks only the incoming value, never a stored one) and runs for both `create_`/`update_`
-- `794` `fn value_matches_stored`
-- `806` `fn describe_requirement`
-- `813` `fn is_verified_identity`
-- `817` `fn json_err`
-- `821`/`825` `fn resolve_struct`/`resolve_enum`
-- `836` `fn decode_enum_value` — the one enum shape that round-trips through a JSON request body: zero-payload-only
-- `860` `fn decode_value` — JSON request body → `Value`, generic over any struct (this is why `struct Text { value: str }` needed zero `serve.rs` changes)
-- `908` `fn encode_value` — the inverse: `Value` → JSON response body
+- `1` — module doc: Tier-1 contract checking (`docs/API_TRUST_MODEL.md` §7.5, built out for real) — given a real `.nir` fn and a Hoare predicate string (a user story's `pre_logic`/`post_logic`, or a `workflow`'s `routing_fn` contract), either proves it for every admissible input or produces a concrete counterexample; deliberately narrow scope (integer params/return only, no loops/calls/division/interprocedural reasoning) — anything outside that is `Unsupported`, reported honestly rather than silently approximated (approximation is sound for a proof but unsound for a counterexample)
+- `30` — doc comment on `extra_bindings`: a story's predicate can name a PRD concept (e.g. `high_value_threshold`) the real fn hardcodes as a literal rather than taking as a parameter; the caller must supply a concrete value per such name, or get `UnboundIdentifier` naming exactly the gap
+- `56` `pub enum ContractCheckResult`
+- `95` `pub fn check_fn_contract` — top-level entry point, `(program, fn_name, pre_logic, post_logic, extra_bindings)` → `ContractCheckResult`
+- `142` `pub fn check_fn_contract_exprs` — same, given already-parsed `Expr`s instead of predicate strings
+- `146` `fn check_fn_contract_exprs_with_summaries`
+- `178` `struct Summary`
+- `188` `pub struct ValidateOutcome` — one `validate { ... }` predicate's proof result
+- `222` `pub fn run_program_validates` — every `validate` block in a program, proved
+- `267` `pub fn check_program_contracts` — pass/fail gate, collapses every `ValidateOutcome` into one `Result`
+- `284` `pub fn check_program_contracts_diagnostics` — same, structured per-violation diagnostics instead of a flat error list
+- `298` `fn contract_error_message`
+- `328` `pub struct ContractDiagnostic`
+- `341` `pub fn unsupported_validate_notes` — every `validate` predicate this pass honestly can't model, surfaced by `main.rs::print_unsupported_validate_notes`
+- `354` `fn check_fn_contract_parsed` — the real Z3-backed proof/counterexample search, once both predicate strings are parsed `Expr`s
+- `429` `fn assert_bounds`
+- `435`/`511`/`515` `fn collect_idents`/`collect_idents_block`/`collect_idents_stmts` — free-identifier discovery driving the `extra_bindings` requirement
+- `535`/`537` `struct Scopes`/`impl` — symbolic-`Int`-valued variable environment (mirrors `smt.rs`'s own)
+- `552` `struct Eval<'s>` / `599` `enum Flow` / `614` `impl Eval<'_>` — the fn body's own symbolic evaluator (through `~894`), structurally parallel to `smt.rs::Checker`
+- `895` `fn is_bool_shaped`
 
-## ownership.rs (848 lines, as of 2026-08-23)
-- `76`/`82` `pub enum OwnershipErrorKind` / `struct OwnershipError`
-- `104` `struct OwnScopes` / `106` `impl` — the move-tracking scope stack (name → (type, moved-flag))
-- `143` `fn merge_moved` — branch-uniform merge: an affine value moved on only *some* `if`/`match` branches is rejected everywhere after that point (the checker isn't branch-uniform — cleanup must happen exactly once, on every path, uniformly)
+## ownership.rs (855 lines, as of 2026-09-07)
+
+- `1` — module doc: static move-checker (`docs/goal.md` row 1's "no GC, no manual `free()`"), runs after `typeck.rs` over the same AST; now genuinely load-bearing (2026-09 correction to this file's own doc comment — see the code itself) now that `codegen.rs`'s `emit_affine_free` drives real `nir_free` calls off this pass's `FreeMap`, unlike the deleted `interpreter.rs`'s clone-on-read semantics that made a use-after-move merely inert
+- `16` — the affine rule: `Ty::is_affine` (currently only `Ty::Box`) using a variable by name (as a `let` initializer, assignment RHS, call arg, `return` value) transfers ownership; any later use on the same path is "use after move"
+- `35` — known limitation: no place-expression semantics, so `&box T` is borrow-only, not read-through (`**r` through a reference doesn't work)
+- `53` — loops are checked twice: once silently to discover what state one iteration produces, merged with the pre-loop state, then checked again for real from that merged state
+- `76` `pub enum OwnershipErrorKind`
+- `82`/`87` `pub struct OwnershipError` / `impl Display`
+- `104`/`106` `struct OwnScopes`/`impl` — the move-tracking scope stack (name → (type, moved-flag))
+- `143` `fn merge_moved` — branch-uniform merge: an affine value moved on only *some* `if`/`match` branches is rejected everywhere after that point
 - `169` `pub struct FreeMap` — the ownership pass's real deliverable for codegen: which `nir_free` call to emit, at which AST node's span, for every affine binding
 - `219`/`227` `fn still_owned_affine`/`all_still_owned_affine`
 - `231` `pub struct Checker<'a>`
 - `273` `fn builtin_return_ty` — needs the same builtin-signature shape `typeck.rs::infer_builtin_call` has, but without re-deriving it through real type inference
-- `306` `fn run_checker`
-- `331` `pub fn check_ownership` — top-level entry point
-- `344` `pub fn compute_free_map` — the other top-level entry point, what `codegen.rs` actually calls to know what to free and when
-- `349` `fn error`
-- `355`/`367`/`375`/`415` `fn check_stmts`/`check_block`/`check_stmt`/`check_stmt_expr`
-- `424` `fn check_if_branches` / `479` `check_match_arms` / `530` `check_while` — the branch-uniform-affine-cleanup enforcement points
-- `562` `fn touch_expr` — the core move-checking visitor; `consume=true` at value positions, `false` only inside `Expr::Deref` (reading *through* a box is exempt)
-- `833` `fn touch_ident` — where a name actually gets marked moved
+- `307` `fn run_checker`
+- `332` `pub fn check_ownership` — top-level entry point
+- `345` `pub fn compute_free_map` — the other top-level entry point, what `codegen.rs` actually calls to know what to free and when
 
-## runtime_kernels.rs (825 lines, as of 2026-08-23)
-- `1` — module doc: this file compiles as an isolated `rustc --crate-type staticlib` (no `--extern`), linked into every `codegen.rs`-produced binary; the same "native call costs what inlined IR costs" reasoning as `@printf`/libm
-- `29`–`214` pure-Rust `f64`-slice math (called from Rust, not `extern "C"` — the `nir_det`/etc. wrappers below call into these): `matrix_det`, `matrix_inv`, `matrix_solve`, `matrix_rank`, `mat_mul_f64`, `mat_vec_mul_f64`, `mat_transpose_f64`, `vec_add_f64`, `vec_sub_f64`
-- `218` `fn kf_update` — Kalman filter update step, shared by the two `nir_kf_update_*` C-ABI wrappers
-- `279`/`329` `fn sha256_compress`/`sha256` — the from-scratch SHA-256 (no `sha2` crate access here — see module doc), bit-verified against the standard's own test vectors
-- `375`/`388` `fn hex_encode`/`constant_time_eq` — pure-Rust helpers behind `nir_sha256_hex`/`nir_constant_time_str_eq`
-- **The C-ABI surface** (`extern "C" fn`, what `codegen.rs` actually emits `call`s to by name) — `410 nir_det`, `419 nir_inv`, `435 nir_solve`, `451 nir_rank`, `464 nir_kf_update_state`, `494 nir_kf_update_cov`, `527 nir_str_eq`, `562 nir_tcp_connect`, `576 nir_tcp_listen`, `590 nir_tcp_accept`, `603 nir_tcp_send`, `620 nir_tcp_recv`, `637 nir_tcp_stop`, `665 nir_sha256_hex`, `677 nir_constant_time_str_eq`, `725 nir_rand_seed`, `743 nir_rand_f64`, `755 nir_rand_gaussian`, `791 nir_alloc`, `814 nir_free`
-- `706`/`715` `fn splitmix64_next`/`rand_next_f64` — the process-wide RNG stream backing `nir_rand_*` (necessarily process-wide, not per-"interpreter instance" — docs/LANGUAGE.md §9)
+## smt.rs (708 lines, as of 2026-09-07)
 
-## smt.rs (697 lines, as of 2026-08-23)
-- `61` `pub struct SmtReport` — the whole program's Z3-discharged proof result set (which bounds/div-by-zero/index checks got proven statically, elidable at codegen)
-- `78` `struct Scopes` / `80` `impl` — symbolic-`Int`-valued variable environment (mirrors `typeck.rs`/`codegen.rs`'s own `Scopes`, but maps names to Z3 terms, not `Ty`s)
-- `106` `pub fn analyze` — top-level entry point, real Z3-backed SMT checking (row 4's interval-analysis precursor was upgraded to this)
-- `125`/`136`/`145`/`156` `fn assert_bounds`/`prove_in_range`/`prove_nonzero`/`prove_index_in_bounds` — the actual theorem-proving calls
-- `169` `fn ty_dims`
-- `177` `struct Checker<'s>` / `187` `impl` — methods below are inside it
-- `188`/`194`/`200` `fn stmts`/`block`/`stmt`
-- `239` `fn expr_stmt`
-- `267`/`271` `fn enter_branch`/`exit_branch` — path-condition scoping for `if`/`match` branches
-- `275` `fn while_loop`
-- `300` `fn expr` — the main symbolic-evaluation walk; anything this can't reduce gets a fresh, unconstrained `Int` (always sound, claims no information — same fallback shape as `refine.rs`'s `Interval::unknown()`)
-- `481` `fn block_value`
-- `500` `fn binary`
-- `540` `fn bool_expr`
-- `593`/`595`/`610` `fn assigned_names`/`walk_stmts`/`walk_expr` — free-variable/reassignment discovery for loop-invariant handling
-
-## refine.rs (675 lines, as of 2026-08-23)
-- `1` — module doc: **Tier 1** bounds proving via interval (range) analysis, *not* SMT — a deliberate, documented substitution for when a real solver isn't available (no system Z3/`cmake` in this environment), not a silent downgrade. `smt.rs` is the real Z3-backed Tier 2 upgrade; the two are complementary, not one superseding the other — `codegen.rs::guard_in_range`/`guard_index_in_bounds` elide a check if *either* tier already proved it.
-- `74`/`79` `struct Interval`/`impl` — `exact`/`unknown`/`full`/`union`/`neg`/`add`/`sub`/`mul`/`within`/`excludes_zero`: the abstract-interval arithmetic itself
-- `154` `pub struct RefineReport` — Tier 1's proof result set, same shape/role as `smt.rs::SmtReport`
+- `1` — module doc: SMT-backed refinement checking (`docs/goal.md` §3/§6 Phase 2's real Tier-1 pass), a real Z3 solver (`z3` crate) proving (1) an arithmetic expression's value fits its declared target type, (2) a division's divisor is never zero; supersedes `refine.rs`'s interval analysis as the primary Tier-1 checker, though `refine.rs` stays in the tree undeleted
+- `48` — **now accurate as of this pass** (previously claimed "not wired to elide anything, no backend exists yet" — corrected 2026-09-07): `codegen.rs` takes `&SmtReport` directly and skips a `guard_in_range`/`guard_index_in_bounds` trap wherever `SmtReport::proven_in_range`/`proven_index_bounds` already proved it. `refine.rs`'s `RefineReport` has no equivalent consumer.
+- `70` `pub struct SmtReport` — the whole program's Z3-discharged proof result set, consumed directly by `codegen.rs`
+- `87`/`89` `struct Scopes`/`impl` — symbolic-`Int`-valued variable environment
+- `115` `pub fn analyze` — top-level entry point, called from `main.rs::cmd_build`/`cmd_emit_llvm` before codegen
+- `134`/`145`/`154`/`165` `fn assert_bounds`/`prove_in_range`/`prove_nonzero`/`prove_index_in_bounds` — the actual theorem-proving calls
 - `178` `fn ty_dims`
-- `186`/`188` `struct Scopes`/`impl` — interval-valued variable environment (mirrors `smt.rs`'s `Scopes` but with `Interval` instead of a Z3 `Int` term)
-- `232` `pub fn analyze` — top-level entry point
-- `248`/`258` `struct Refiner`/`impl` — methods below are inside it
-- `259`/`265`/`271` `fn stmts`/`block`/`stmt`
-- `301` `fn while_loop`
-- `330` `fn expr` — the main interval-evaluation walk (structurally parallel to `smt.rs::Checker::expr`)
-- `519` `fn block_value`
-- `538` `fn binary`
-- `571`/`573`/`588` `fn assigned_names`/`walk_stmts`/`walk_expr`
+- `186`/`196` `struct Checker<'s>`/`impl` (through `~602`) — the main symbolic-evaluation walk, mirroring `contract_check.rs::Eval`
+- `603` `fn assigned_names` — free-variable/reassignment discovery for loop-invariant handling
 
-## main.rs (517 lines, as of 2026-08-23)
-- `7` `fn main` — CLI entry point: pulls `--format=json`/`--otel-console`/`--transact-log=` off anywhere in argv, then dispatches on the first remaining arg to a subcommand (`build`/`emit-llvm`/`emit-ast`/`emit-ui`/`serve`/`--sandbox-worker`), or `cmd_interpret` if the first arg is just a path
-- `71` `fn print_usage`
-- `92` `fn read_source`
-- `103` `fn print_value` — renders a successful run's result uniformly regardless of entry point (`run`/`run_diagnostic`); `--format=json` only changes how *failures* are reported
-- `127` `fn cmd_interpret` — the default (no subcommand) path: parse → typecheck → own-check → `Interpreter::run_main`
-- `177` `fn typecheck_and_own` — the shared parse+typecheck+ownership pipeline every subcommand but `emit-ast` gates on; `codegen.rs::check_supported` is a separate, narrower, backend-specific gate run later inside `build`/`emit-llvm` themselves
-- `195` `fn cmd_build` — `nirdosha build <file> -o <out> [--opt0]`: full pipeline → `codegen::build` → native binary
-- `240` `fn cmd_emit_llvm` — same pipeline, prints IR text instead of linking
-- `278` `fn cmd_emit_ast` — parses only (not the full `typecheck_and_own` gate) — a program that doesn't yet typecheck is still legitimate to inspect here, unlike `build`/`emit-llvm`/`emit-ui`
-- `320` `fn cmd_emit_ui` — needs the *typed* program (screen inference reads resolved struct fields/fn signatures), same gate as `build`/`emit-llvm`
-- `381` `fn cmd_serve` — binds `serve.rs::run`; a bearer token with no server-side `AuthConfig` is a clear 500, not silently accepted or ignored
-- `455` `fn cmd_sandbox_worker` — not a user-facing subcommand; the only caller is a `sandbox` handle's own `Expr::SpawnSandbox`, which execs this same binary with `--sandbox-worker` to become the child process
+## refine.rs (680 lines, as of 2026-09-07)
+
+- `1` — module doc: bounds proving via interval (range) analysis, a documented Z3-independent substitution for `smt.rs`'s SMT approach — same two proof targets (value fits its type, divisor never zero), strictly weaker (no condition-based narrowing, no correlated-variable reasoning)
+- `30` — **corrected 2026-09-07**: this module's own doc used to say "not wired to elide anything, there's no codegen yet" — codegen exists now and does elide checks, but from `smt.rs::SmtReport`, not this module's `RefineReport`; nothing in `main.rs`/`codegen.rs` calls `refine::analyze` today, only `tests/refine.rs` does, so the "documented Z3-unavailable fallback" this file describes isn't actually wired as a fallback anywhere in the real pipeline
+- `78`/`83` `struct Interval`/`impl` — the abstract-interval arithmetic itself
+- `158` `pub struct RefineReport` — Tier-1's proof result set, same shape/role as `smt.rs::SmtReport`, but orphaned from the build pipeline (see above)
+- `182` `fn ty_dims`
+- `190`/`192` `struct Scopes`/`impl` — interval-valued variable environment
+- `236` `pub fn analyze` — top-level entry point (test-only caller today)
+- `252`/`262` `struct Refiner`/`impl` (through `~574`) — the main interval-evaluation walk
+- `575` `fn assigned_names`
+
+## main.rs (613 lines, as of 2026-09-07)
+
+- `3` `fn main` — CLI entry point: dispatches the first arg to a subcommand (`init`/`build`/`emit-llvm`/`emit-ast`/`emit-ui`/`emit-catalog`/`gen-crud`) or prints usage on no/unknown args. No bare `run`, `serve`, or `--sandbox-worker` remain — all three were removed along with `interpreter.rs`/`serve.rs` (see `typecheck_and_own_optional_main_with_ui_components`'s own doc comment at `87`).
+- `32` `fn print_usage`
+- `58`/`71` doc comment / `fn typecheck_and_own` — the shared parse→typecheck→ownership-check pipeline for `build`/`emit-llvm`. Returns the entry file's own source alongside the `Program`, a holdover from when the now-removed `cmd_sandbox_worker` needed it (`Interpreter::new`'s `source` arg); both current callers discard it (`let (program, _src) = ...`).
+- `75`/`88` doc comment / `fn typecheck_and_own_optional_main_with_ui_components` — same pipeline but tolerant of no `fn main()` (a generated nirdosha-lane program's shape), plus every linked `ui_plugin::NativeUiComponent`'s `name` as a legal `layout` widget kind (rfcs/0009 Phase B). `cmd_emit_ui`'s sole entry point — no plain sibling exists, callers passing `&[]` when nothing was discovered.
+- `101` `fn print_ungated_fn_warnings` — surfaces `typeck::ungated_fn_warnings` at `emit-ui` time (`docs/API_TRUST_MODEL.md` T1b)
+- `113` `fn typecheck_and_own_impl` — the real shared body both `typecheck_and_own` and the UI-components variant funnel through
+- `169` `fn print_unsupported_validate_notes` — surfaces `contract_check::unsupported_validate_notes`
+- `176`/`179` doc comment / `fn load_theme` — `--theme <path>` (`emit-ui`) resolution: reads a JSON file matching `ui_gen::Theme`'s shape, layered over the baked-in MD3 tokens
+- `188`/`202` doc comment / `fn cmd_init` — `nirdosha init <project-name> [--dest][--no-email][--no-roles][--sms][--push][--force]`: scaffolds a starter `.nir` file, a bundled copy of this executable, a `run.sh`/`run.bat` launcher, and a placeholder `jwks.json`. **Stale scaffolding, a real bug, not just a doc issue**: the generated launcher (`init.rs::render_launcher_unix`/`_windows`) invokes `nirdosha serve {project_name}.nir ...` — `serve` was deleted from this file's own dispatch table along with the interpreter, so every freshly-`init`'d project's `./run.sh`/`run.bat` fails with an unknown-subcommand error today. Not fixed here — there's no compiled-path equivalent of dynamic, auth-gated `serve` to point it at yet.
+- `307` `fn cmd_build` — `nirdosha build <file> -o <out> [--opt0]`: full pipeline → `codegen::build` → native binary
+- `348` `fn cmd_emit_llvm` — same pipeline, prints IR text instead of linking
+- `382` `fn cmd_emit_ast` — parses only (not the full `typecheck_and_own` gate)
+- `421`/`424` doc comment / `fn cmd_gen_crud` — `nirdosha gen-crud <plan.json> --db <literal> [-o out.nir]`: generates real, compiling CRUD persistence bodies from a plan (`crud_gen.rs`), replacing protobox's placeholder-only Python stub generation, deterministically, no LLM call
+- `480` `fn resolve_ui_component_manifest` — `--manifest-path` if given, else a `Cargo.toml` sitting next to the input `.nir` file, else `None` — feeds `ui_plugin::discover_components` (rfcs/0009's Cargo-metadata auto-discovery)
+- `488` `fn cmd_emit_ui` — `nirdosha emit-ui <file.nir> -o out.html [--theme <path>][--manifest-path <Cargo.toml>]`: needs the *typed* program (screen inference reads resolved struct fields/fn signatures)
+- `575` `const STD_CATALOG_JSON` — `include_str!` of `catalog/std/0.1.json` (rfcs/0009 Phase 0)
+- `577` `fn cmd_emit_catalog` — `nirdosha emit-catalog [-o out.json]`: prints the std catalog (no plugin-merge step yet — see `rfcs/0009`'s Status box)
+
+## token.rs (521 lines, as of 2026-09-07)
+
+- `1` — module doc: tokens and the lexer; every token carries a `Span` for structured error reporting downstream (parser, typeck, codegen — corrected 2026-09-07, previously said "parser, interpreter")
+- `11` `pub struct Span`
+- `17` `pub enum Tok` — every token kind the lexer produces
+- `233` `pub struct Token`
+- `238` `const TYPE_NAMES` — the fixed primitive/keyword type-name list `expect_type`/the lexer both key off
+- `244` `pub struct LexError`
+- `249` `pub struct Lexer<'a>` — the hand-written lexer, methods below are inside it
+
+## effects.rs (512 lines, as of 2026-09-07)
+
+- `1` — module doc: effect inference (`docs/goal.md` rows 4/9, `docs/PROTOLANG_PORT.md`'s "Locked design 1") — computes every fn's real effect set (`ast::Effect`) by walking its body; `typeck::typecheck` is the one that checks a declared `effect(...)` annotation against this pass's result, this module only computes
+- `18` — classification table: `pure` (empty set, default), `rng` (`rand_*`), `io` (`print`, file I/O, SQLite), `concurrent` (`spawn`/`join`, `chan`, `sandbox`/`stop`), `network` (`connect`/`listen`/`accept`, `tcp`, `mq_*`, Postgres-flavored `db_connect`)
+- `36` — recursion: least-fixpoint iteration over the whole call graph (correct for direct/mutual recursion), monotone lattice of at most 4 tags, so termination is guaranteed
+- `57` `pub struct FnEffects`
+- `62` `pub fn infer_effects` — top-level entry point
+- `76` `pub fn infer_effects_with_plugins` — same, plus a native/UI-plugin's own declared effect set folded in
+- `115`/`117` `struct Scopes`/`impl`
+- `135`/`141`/`147` `fn walk_stmts`/`walk_block`/`walk_stmt`
+- `181` `fn local_ty` — a local binding's already-syntactically-explicit type, looked up not inferred
+- `277` `fn db_connect_effect` — `network` vs `io` classification for `db_connect`, based on whether its connection-string argument is (or might be) Postgres
+- `290` `fn walk_expr` — the main per-expression effect-accumulation walk

--- a/crates/compiler/src/main.rs
+++ b/crates/compiler/src/main.rs
@@ -56,17 +56,18 @@ fn print_usage() {
 }
 
 /// Load (resolving any `use "..."` — `docs/ROADMAP.md` Track F, F2 piece 3)
-/// -> typecheck -> ownership-check, shared by `build` and `emit-llvm` —
-/// same static gates `nirdosha::run` applies before ever interpreting,
+/// -> typecheck -> ownership-check, shared by `build` and `emit-llvm`,
 /// applied here before ever generating code. Codegen's own
 /// `check_supported` (a third, narrower gate — signed-integer/bool/unit
 /// only, no `box`/`&`/`*`) runs separately, inside `codegen::build`/
 /// `emit_llvm_ir` themselves, since it's specific to this backend, not a
 /// property of the language generally. Returns the entry file's own
-/// source alongside the (possibly multi-file-merged) `Program` — the
-/// one caller that still needs it directly is `cmd_sandbox_worker`
-/// (`Interpreter::new`'s own `source` argument); every other caller
-/// just uses the `Program`.
+/// source alongside the (possibly multi-file-merged) `Program` — a
+/// holdover from when `cmd_sandbox_worker` (`Interpreter::new`'s own
+/// `source` argument) was a real caller; that command was removed along
+/// with the interpreter (see `typecheck_and_own_optional_main_with_ui_components`'s
+/// doc comment below), and both current callers (`cmd_build`/
+/// `cmd_emit_llvm`) discard it (`let (program, _src) = ...`).
 fn typecheck_and_own(path: &str) -> Result<(nirdosha::ast::Program, String), String> {
     typecheck_and_own_impl(path, true, &[])
 }

--- a/crates/compiler/src/ownership.rs
+++ b/crates/compiler/src/ownership.rs
@@ -1,17 +1,17 @@
 //! Static move-checker — docs/goal.md row 1's actual content ("no GC, no manual
 //! `free()`"). Runs after `typeck.rs`, over the same AST.
 //!
-//! **Why this doesn't matter for *this* interpreter's safety, and why it's
-//! built anyway.** `interpreter.rs` clones a `Value` on every variable
-//! read (`Env::get`), so right now, aliasing a `box` can't actually corrupt
-//! anything — two "owners" just end up with two independent Rust-owned
-//! trees. A real (future, LLVM-compiled, arena/region-based) backend
-//! wouldn't clone; it would hand out the same address twice, and a
-//! use-after-move would be a real dangling pointer or double-free. This
-//! pass proves, statically, that no well-typed Nirdosha program ever does
-//! that — the proof a real backend needs already exists before there's a
-//! real backend to need it, which is the honest way to read "row 1 is
-//! partially done": the discipline is proved, not yet load-bearing.
+//! **Why this mattered even before it was load-bearing, and why it's
+//! load-bearing now.** This pass predates `codegen.rs` (the LLVM
+//! backend): back when the now-deleted `interpreter.rs` cloned a `Value`
+//! on every variable read (`Env::get`), aliasing a `box` couldn't
+//! actually corrupt anything — two "owners" just ended up with two
+//! independent Rust-owned trees, so this pass's proof was real but not
+//! yet load-bearing. `codegen.rs` is the "future backend" that paragraph
+//! used to gesture at: it doesn't clone, it hands out the same address
+//! twice (`emit_affine_free`'s real `nir_free` call is driven directly by
+//! this pass's `FreeMap`), so a use-after-move here would now be a real
+//! dangling pointer or double-free if this pass ever let one through.
 //!
 //! **The rule.** Every type is either *affine* (`Ty::is_affine` — currently
 //! only `Ty::Box`) or freely copyable (everything else). Using an

--- a/crates/compiler/src/refine.rs
+++ b/crates/compiler/src/refine.rs
@@ -27,14 +27,18 @@
 //! kind of place a soundness bug hides, and a wrong proof is worse than
 //! no proof, so it's left as "unknown" (full range) rather than risked.
 //!
-//! **Not wired to elide the runtime check.** `interpreter.rs` keeps every
-//! Tier-2 check exactly as before, proven or not. Eliding a check only
-//! pays off once there's a real ahead-of-time backend generating a binary
-//! that runs faster without it — there's no codegen yet (docs/goal.md §3's
-//! Backend layer), so removing the interpreter's redundant check now
-//! would only remove a safety net for zero benefit. This pass's output —
-//! `RefineReport` — is the real, standalone deliverable: a genuine static
-//! proof, ready for a future backend to act on.
+//! **Still not wired to elide anything, but for a different reason than
+//! originally written here.** The "there's no codegen yet" framing this
+//! paragraph used to give is stale — `codegen.rs` (LLVM, the interpreter's
+//! deleted replacement) is now the only backend, and it *does* elide
+//! `guard_in_range`/`guard_index_in_bounds` traps proven safe — just from
+//! `smt.rs`'s `SmtReport`, not from this module's `RefineReport`. Nothing
+//! in `main.rs`/`codegen.rs` calls `refine::analyze` at all today; this
+//! pass runs only under its own tests (`tests/refine.rs`). It remains in
+//! the tree as the documented, Z3-independent proof technique (see
+//! `smt.rs`'s own module doc), but "wire it in as the fallback when Z3
+//! isn't available" — the reason given below for keeping it — was never
+//! actually built; there is no such fallback switch in the real pipeline.
 //!
 //! **Loops: widen, don't iterate to a fixed point.** A `while` body might
 //! run any number of times, so any binding it reassigns is widened to its

--- a/crates/compiler/src/smt.rs
+++ b/crates/compiler/src/smt.rs
@@ -45,9 +45,18 @@
 //! larger undertaking than this pass, or most refinement-type systems
 //! without an invariant-inference research component, attempt.
 //!
-//! **Not wired to elide the interpreter's runtime check** — same
-//! reasoning as `refine.rs`: there's no backend yet to spend a Tier-1
-//! proof's performance payoff on, so the redundant runtime check stays.
+//! **Now wired to actually elide the runtime check.** This module's own
+//! doc comment once said otherwise ("no backend yet to spend a Tier-1
+//! proof's performance payoff on") — that stopped being true once the
+//! interpreter was deleted and `codegen.rs` (the LLVM backend) became
+//! the only backend: `emit_llvm_ir`/`build` take a `&SmtReport`
+//! directly, and `codegen.rs::guard_in_range`/`guard_index_in_bounds`
+//! skip emitting a trap wherever `SmtReport::proven_in_range`/
+//! `proven_index_bounds` already proved it can't fire. `refine.rs`'s
+//! own `RefineReport` has no equivalent consumer — it's exercised only
+//! by its own tests today, not read by `main.rs`/`codegen.rs` at all,
+//! so it isn't actually serving as a documented Z3-unavailable fallback
+//! in the real pipeline, whatever its module doc says.
 
 use std::collections::{HashMap, HashSet};
 

--- a/crates/compiler/src/token.rs
+++ b/crates/compiler/src/token.rs
@@ -1,7 +1,7 @@
 //! Tokens and the lexer. Every token carries a `Span` so downstream errors
-//! (parser, interpreter) can report structured, machine-checkable positions
-//! instead of prose — the diagnostic shape docs/goal.md row 9 asks for, started
-//! here rather than bolted on later.
+//! (parser, typeck, codegen) can report structured, machine-checkable
+//! positions instead of prose — the diagnostic shape docs/goal.md row 9
+//! asks for, started here rather than bolted on later.
 
 // `Hash` is for `refine.rs`, which keys a `HashSet<Span>` of proven-safe
 // sites — every other consumer only needed equality/ordering before this.

--- a/crates/presence-gateway/README.md
+++ b/crates/presence-gateway/README.md
@@ -1,5 +1,23 @@
 # nirdosha-presence-gateway
 
+> **2026-09 — the server side of this crate's own contract no longer
+> exists.** Everything below describes talking to `nirdosha serve` (a
+> live HTTP server: `POST /api/_presence_connect`/`_presence_disconnect`,
+> `serve.rs::handle_presence`) and testing against it in-process
+> (`crates/compiler/tests/serve.rs::start_server`, `tests/mq.rs`). The
+> interpreter and `serve.rs` were deleted entirely (`docs/
+> API_TRUST_MODEL.md` §4a) — there is no `nirdosha serve` subcommand, no
+> compiled serving mode, and neither `crates/compiler/tests/serve.rs`
+> nor `crates/compiler/tests/mq.rs` exist anymore. This crate's own
+> `tests/gateway_integration.rs` (the "Testing" section below) also no
+> longer exists — this crate currently has no server it can talk to, and
+> no automated proof that it still works. The gateway process itself
+> (`src/`, this Cargo.toml's `[dependencies]`) is untouched and may well
+> still be structurally sound; what's gone is the other end of the
+> protocol it was built against. Read the rest of this file as a design
+> record of that protocol, not as a description of a currently-working
+> integration.
+
 `docs/WORKFLOW.md`'s "notify presence bridge" section and `docs/ROADMAP.md`'s Track
 A5 — the one piece of `workflow { }`'s `notify()` that `nirdosha` itself
 deliberately doesn't build: a real WebSocket connection to a browser.

--- a/crates/ui-plugin-example-sparkline/README.md
+++ b/crates/ui-plugin-example-sparkline/README.md
@@ -16,10 +16,15 @@ use nirdosha::ui_plugin::NativeUiComponent;
 
 let sparkline = NativeUiComponent {
     name: nirdosha_ui_plugin_example_sparkline::NAME.to_string(),
-    render_js: nirdosha_ui_plugin_example_sparkline::RENDER_JS,
-    render_fn: nirdosha_ui_plugin_example_sparkline::RENDER_FN,
+    render_js: nirdosha_ui_plugin_example_sparkline::RENDER_JS.to_string(),
+    render_fn: nirdosha_ui_plugin_example_sparkline::RENDER_FN.to_string(),
 };
 ```
+
+(`render_js`/`render_fn` are owned `String`, not `&'static str` — a
+*discovered* component's JS is read from disk at `emit-ui` runtime, so
+the field can't stay a compile-time constant; this crate's own
+`&'static str` constants still convert via `.to_string()`.)
 
 `crates/compiler/tests/ui_plugin_examples.rs` does exactly this, then
 runs the real `typecheck_optional_main_with_ui_components`/
@@ -49,13 +54,23 @@ via the page's own `callFn`, and draws a small inline SVG trend line —
 zero external charting library, the same "self-contained" stance every
 other renderer in `ui_gen_template.html` already holds.
 
-## No Cargo-driven discovery yet
+## Cargo-driven discovery is real for this crate
 
 `[package.metadata.nirdosha] kind = "nir-ui-component"` in this crate's
-own `Cargo.toml` is there for a future `nirdosha build`/`emit-ui`
-auto-discovery pass to grep for — that pass isn't built (rfcs/0009's
-own "Open questions" names it as shared, still-open work with
-`rfcs/0008` Phase 3's identical discovery problem for native builtins).
-Until it lands, whoever wants this widget depends on this crate
-directly and hand-assembles the `NativeUiComponent`, exactly as shown
-above — a real, disclosed narrowing, not a broken promise.
+own `Cargo.toml` is exactly what `ui_plugin::discover_components`
+(`nirdosha emit-ui --manifest-path <Cargo.toml>`, or auto-detected next
+to the input `.nir` file) greps an app author's own dependency graph
+for via a real `cargo metadata` call — no hand-assembled Rust slice
+needed. `crates/compiler/tests/ui_plugin_discovery.rs` spawns the real
+compiled `nirdosha` binary against a scratch project whose own
+`Cargo.toml` path-depends on this crate and proves auto-detection, the
+explicit flag, and the untouched no-manifest default all work.
+
+This closes rfcs/0009's own "Open questions" item **for UI components
+specifically** — it does not close `rfcs/0008` Phase 3 (Cargo-driven
+discovery for *native builtins*), a genuinely different, harder problem
+since a native builtin crosses a real ABI boundary and a UI component
+doesn't (see `ui_plugin.rs`'s own doc comment for the full reasoning).
+The hand-assembled path shown above (`crates/compiler/tests/
+ui_plugin_examples.rs`) still works too, and remains useful for
+anything short of a real linked dependency.

--- a/crates/ui-plugin-example-sparkline/src/lib.rs
+++ b/crates/ui-plugin-example-sparkline/src/lib.rs
@@ -14,17 +14,29 @@
 //! `plugin-example-native-shout`/`plugin-example-native-kv`'s own
 //! posture toward the compiled-builtin ABI): this crate hands over
 //! plain data, not a Rust type living in the compiler crate. A consumer
-//! builds its own `ui_plugin::NativeUiComponent { name: NAME.into(),
-//! render_js: RENDER_JS, render_fn: RENDER_FN }`.
+//! builds its own `ui_plugin::NativeUiComponent { name: NAME.to_string(),
+//! render_js: RENDER_JS.to_string(), render_fn: RENDER_FN.to_string() }`
+//! (`render_js`/`render_fn` are owned `String`, not `&'static str` —
+//! a *discovered* component's JS is read from disk at `emit-ui` runtime,
+//! so the field can't stay a compile-time constant; `RENDER_JS`/
+//! `RENDER_FN` here still convert via `.to_string()`).
 //!
-//! **No Cargo-driven auto-discovery yet** (rfcs/0009's own "Open
-//! questions," shared with rfcs/0008 Phase 3): `crates/compiler/tests/
-//! ui_plugin_examples.rs` depends on this crate directly and reads
-//! these constants at test time, standing in for what a future
-//! `nirdosha build`/`emit-ui` discovery pass would do automatically —
-//! the same "hand-assemble it in Rust source for now" posture
-//! `crates/compiler/tests/native_plugin_codegen.rs` already has toward
-//! `NativePluginBuiltin` ahead of its own still-open Phase 3.
+//! **Cargo-driven auto-discovery exists for this crate specifically**
+//! (`ui_plugin::discover_components`, `nirdosha emit-ui
+//! --manifest-path`/auto-detected `Cargo.toml`): this crate's own
+//! `Cargo.toml` carries `[package.metadata.nirdosha] kind =
+//! "nir-ui-component"`, which is exactly what that discovery pass greps
+//! an app author's dependency graph for — see that `Cargo.toml`'s own
+//! comment and `crates/compiler/tests/ui_plugin_discovery.rs` for the
+//! real, no-hand-assembly, no-dev-dependency end-to-end proof.
+//! `crates/compiler/tests/ui_plugin_examples.rs` additionally depends on
+//! this crate directly via an ordinary `[dev-dependencies]` edge and
+//! reads these constants to hand-assemble a `NativeUiComponent` itself —
+//! a second, independent proof that the crate's exported constants are
+//! usable on their own, not a stand-in for discovery not existing.
+//! (Still open, and shared with `rfcs/0008` Phase 3: Cargo-driven
+//! discovery for native *builtins*, a genuinely different, harder
+//! problem — see `ui_plugin.rs`'s own doc comment for why.)
 
 /// The bare identifier a `.nir` program writes as a layout leaf:
 /// `sparkline { source: <fn> field: "..." }`.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,5 +1,21 @@
 # Deploying nirdosha to Kubernetes
 
+> **2026-09 — this deployment path currently has no live server to
+> deploy.** Every mechanism below (the runtime image's `ENTRYPOINT
+> ["nirdosha"]` running as a long-lived Pod, `--transact-log`/
+> `--workflow-log`, the `/_nirdosha/table/<name>` route, `/healthz`/
+> `/readyz`) assumes a working `nirdosha serve`. The interpreter and
+> `serve.rs` were deleted entirely (`docs/API_TRUST_MODEL.md` §4a) —
+> there is no `serve` subcommand anymore (it errors "unknown
+> subcommand"), and `nirdosha build`/`emit-ui` (the CLI's replacements)
+> produce a native binary or a static HTML file, neither of which is a
+> long-running server a Kubernetes Deployment/StatefulSet + Service +
+> Ingress has anything to route to. This file, `docs/KUBERNETES.md`, and
+> `docs/KUBERNETES_ADVANTAGE.md` describe a real design that shipped
+> before the interpreter removal and hasn't been revisited since — treat
+> the rest of this document as a design record to reconcile with the
+> current CLI, not a working deployment guide today.
+
 Three ways in, all rendering the same shape (see `../docs/KUBERNETES.md` for
 the compliance matrix these implement and `../docs/KUBERNETES_ADVANTAGE.md`
 for the case for nirdosha over a classic two-tier stack on k8s):

--- a/docs/GRAMMAR.md
+++ b/docs/GRAMMAR.md
@@ -353,12 +353,15 @@ pub_item    ::= "pub"? (fn_decl | struct_decl | enum_decl)
 // enforcement paths consume the same `entries`, neither part of this
 // grammar layer: `contract_check::check_program_contracts` (a real
 // Z3-backed Tier-1 proof, hard-failing the build only on a genuine
-// counterexample -- integer params/return, no loop/call/division) and
-// `interpreter.rs::call`'s runtime backstop (re-checks every `pre`/
-// `post` against the real concrete values on every actual call,
+// counterexample -- integer params/return, no loop/call/division) and,
+// previously, `interpreter.rs::call`'s runtime backstop (re-checked every
+// `pre`/`post` against the real concrete values on every actual call,
 // unconditionally -- the only enforcement for a contract on a `fn`
 // outside that static subset, true of nearly every real `fn` in a real
-// app).
+// app). That module was deleted along with the rest of the interpreter
+// (2026-09-06) and `codegen.rs` never gained a replacement -- a `validate`
+// block outside the Tier-1 static subset is unenforced at runtime today
+// (`docs/LANGUAGE.md`'s `validate`/Hoare-contracts section).
 validate_decl ::= "validate" ident "{" kv_entry* "}"
 
 // `docs/WORKFLOW.md`'s durable state machine — desugared by `workflow_lower.rs`

--- a/docs/KUBERNETES.md
+++ b/docs/KUBERNETES.md
@@ -23,6 +23,24 @@ comment. `[N/A]` means "correctly delegated to the platform/operator,
 not a gap this codebase should close" — e.g. TLS termination belongs at
 an Ingress/mesh, not in `tiny_http`.
 
+> **Drift note (2026-09-07, code as truth).** Every `[DONE]` row below
+> (health/readiness probes, graceful SIGTERM, `/metrics`, structured
+> logs, the presence-gateway sidecar, all of it) was real against
+> `serve.rs` as of 2026-08-27/28. `serve.rs` — along with
+> `interpreter.rs`/`dbconn.rs`/`durability.rs`/`observability.rs`/
+> `pool.rs`/`thread_pool.rs` — was deleted entirely on 2026-09-06
+> (`refactor: remove tree-walking interpreter and its only consumers`).
+> There is currently no `nirdosha serve` binary to containerize at
+> all — every `[DONE]` claim below now describes a Kubernetes story for
+> a runtime that no longer exists in this tree, not the current
+> compiled-only `nirdosha`. The Dockerfile/Helm chart/Kustomize
+> manifests likely still reference a `serve` invocation that would fail
+> to start; re-verify before relying on any of this for a real
+> deployment. This is a real, unresolved regression this pass
+> surfaces rather than silently patches, since restoring it is a
+> product decision (revive `serve.rs` on the compiled path vs. a new
+> design), not a doc fix.
+
 ## The one question that actually matters: what happens at >1 replica?
 
 `nirdosha serve` fuses UI and API into **one process** — it answers

--- a/docs/KUBERNETES_ADVANTAGE.md
+++ b/docs/KUBERNETES_ADVANTAGE.md
@@ -12,6 +12,19 @@ oversold. Where a property is narrower than the ideal, that's said
 plainly, the same way `docs/PHASE0.md`'s own "Twelfth update" discloses the
 `recv`-hang gap in the deadlock-freedom claim rather than hiding it.
 
+> **Drift note (2026-09-07, code as truth).** This document was checked
+> against `interpreter.rs`/`serve.rs` on 2026-08-27 — both were deleted
+> entirely on 2026-09-06 (`refactor: remove tree-walking interpreter
+> and its only consumers`; see `docs/VALUES.md`'s own account of why).
+> Every row in the table immediately below, and the RBAC/dispatch claim
+> in "Top 5 reason" #4, describe that now-removed runtime — there is
+> currently no `nirdosha serve`, so none of "ready to use as-is, today"
+> is actually available today. `transact` (#1) and `workflow` (#2) are
+> similarly stranded — see `docs/TRANSACT.md`/`docs/WORKFLOW.md`'s own drift
+> notes. Reasons #3 and #5 (single-binary footprint, compile-time
+> memory/overflow safety) still hold: both describe `codegen.rs`'s
+> compiled path, which the interpreter removal didn't touch.
+
 ## Ready to use as-is, today
 
 Before the comparative case: these are standing capabilities, already

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -12,23 +12,38 @@ performance.
 
 ## 1. Execution modes
 
+> **2026-09 — there is no interpreter anymore.** The tree-walking
+> interpreter (bare `nirdosha <file.nir>`, `--format=json`, `run`,
+> `serve`, `--sandbox-worker`) was deleted entirely
+> (`crates/compiler/src/interpreter.rs`/`serve.rs`, both removed —
+> `docs/API_TRUST_MODEL.md` §4a). Every "interpreter-only" label
+> elsewhere in this document (§2's type table, `db`/`json`/`mq`/
+> `transact`/`sandbox`/`file`, most Row 12 identity builtins, §11
+> onward's `nirdosha serve`-dependent DSL sections) now means **does
+> not run in any form today**, not "works, just not compiled" — there
+> is no fallback left to run it on. Only what §10's compiled-vs-
+> interpreter-only table marks "Yes" actually executes.
+
 ```sh
-nirdosha <file.nir> [--format=json]   # interpret (tree-walking)
 nirdosha build <file.nir> -o <out> [--opt0]   # compile to a native binary (LLVM, -O2 by default)
 nirdosha emit-llvm <file.nir>         # print the generated LLVM IR
 nirdosha emit-ast <file.nir>          # print the parsed AST as JSON
+nirdosha emit-ui <file.nir> [-o out.html] [--theme theme.json] [--manifest-path Cargo.toml]
+                                       # derive a static Material-styled web UI (§11)
+nirdosha emit-catalog [-o out.json]   # print the std UI catalog as data (rfcs/0009 Phase 0)
+nirdosha init <project-name> [...]    # scaffold a self-contained starter project
+nirdosha gen-crud <plan.json> --db <literal> [-o out.nir]   # deterministic struct+CRUD source from a JSON plan
 ```
 
-- **Interpret** — always works for every construct in this document.
-- **Build/emit-llvm** — only supports the subset covered in §10
+- **Build/emit-llvm/emit-ui** — only support the subset covered in §10
   ("What's compiled"). Everything else is rejected at compile time with
   a specific reason (`codegen::check_supported`), never silently
   mis-compiled.
-- `--format=json` — on failure, prints a structured `Diagnostic` (one
-  shape across type/ownership/runtime errors) instead of a plain-text
-  message. `emit-ast` always prints JSON — the same `Serialize`-derived
+- **`emit-ast`** always prints JSON — the same `Serialize`-derived
   shape a fragment-validation caller (`typeck::validate_fragment`) can
-  deserialize back.
+  deserialize back. There is no `--format=json` flag anymore (it was
+  interpreter/`run`-only); a `build`/`emit-llvm`/`emit-ui` failure
+  prints a plain-text diagnostic only.
 
 ---
 
@@ -955,6 +970,24 @@ necessarily interpreted — a non-affine `struct`/`enum`/`match`, and
 
 ## 11. `screen`/`dashboard` — declarative UI DSL (Row 12, `emit-ui`/`serve` only)
 
+> **2026-09 — `nirdosha serve` no longer exists; read every `serve`
+> reference below as history.** `serve.rs` was deleted entirely
+> alongside the interpreter (§1, `docs/API_TRUST_MODEL.md` §4a/§5) —
+> there is no compiled serving mode and no live HTTP server anywhere in
+> this codebase today. What survives: `nirdosha emit-ui` still derives
+> the static manifest/HTML this section describes, and `ui_gen.rs`
+> still computes field-level `view`/`edit`/`pattern`/`format`/`min`/
+> `max` as client-side hide/disable/HTML5-attribute hints. What does
+> **not** survive, despite being described in present tense below:
+> server-side RBAC/field-masking enforcement (`redact_gated_fields`/
+> `check_edit_gates`/`check_field_validations`), the role-mapping cache
+> (§11a), theme live-reload (§11b), auto-generated DB schema migrations
+> "at serve startup" (§13), the workflow queue's `POST`/replay endpoints
+> (§14), and workspace/panel's backing routes (§15) — all of it was
+> `serve.rs`-resident and none of it runs. Treat this whole span as a
+> design record of what the interpreted `serve` used to enforce, not a
+> description of a currently-running server.
+
 `nirdosha emit-ui`/`nirdosha serve` already derive a full CRUD+dashboard
 web UI from nothing but a program's `struct` declarations and its
 `list_/create_/update_/delete_/get_<struct>` and `stat_/chart_<name>`
@@ -1603,10 +1636,10 @@ already known-sound before it's merged in. Two different files each
 declaring the same module identifier is a real, reported collision, not
 a silent overwrite; an import cycle is a clean error, not a hang. This
 is wired into every command that actually loads a `.nir` file from disk
-(`nirdosha <file>`, `build`, `emit-llvm`, `emit-ui`, `serve`,
-`--sandbox-worker`) — `nirdosha <file> --format=json`'s structured
-`--format=json` diagnostics are the one disclosed exception, not yet
-`use`-aware (`docs/NEXT_GEN.md` §F2's own risk register).
+— `build`, `emit-llvm`, `emit-ast`, `emit-ui` (`loader::load_program`,
+`main.rs`) — the complete list now that the bare-interpret entry point,
+`serve`, and `--sandbox-worker` were removed along with the interpreter
+(§1, `docs/API_TRUST_MODEL.md` §4a).
 
 **What's still `[OPEN]`, disclosed rather than silently unsupported:**
 a `screen`/`dashboard`/`workflow`/`workspace` block can't reference a

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -16,6 +16,22 @@ has, or would need its own struct/fn-introspection pass duplicated.
 It can reuse it completely — that's the finding this whole doc is
 built on.
 
+> **Drift note (2026-09-07, code as truth).** `interpreter.rs` and
+> `serve.rs` — the "one HTTP backend any renderer talks to" this
+> doc's whole finding leans on — were both deleted entirely on
+> 2026-09-06 (`refactor: remove tree-walking interpreter and its only
+> consumers`), after this doc was last written (2026-09-04). There is
+> currently no `nirdosha serve` subcommand and no live server for a
+> mobile client (Standard or Rich profile) to call `POST /api/<fn>`/
+> `POST /_nirdosha/table/<name>` against. `ui_gen.rs`'s manifest-IR
+> reasoning (`build_screens`, `Screen`/`FieldSpec`/`Action`/`Metric`)
+> still holds — that part is compiled-path code and untouched — but
+> every claim below about `serve.rs`'s routes/redaction/identity
+> checks describes infrastructure that would need to be rebuilt on the
+> compiled path (or a revived server) before Track D could actually
+> ship, not infrastructure this doc can still assume is sitting there
+> ready to reuse.
+
 ## The finding that matters
 
 **This doesn't need a new frontend.** `ui_gen.rs::build_screens` already

--- a/docs/NEXT_GEN.md
+++ b/docs/NEXT_GEN.md
@@ -6,6 +6,22 @@ against, written *before* the first line of it lands — the same order
 `docs/MOBILE.md`/`docs/WORKFLOW.md`/`docs/TRANSACT.md` were written in for their own
 features, not after.
 
+> **Drift note (2026-09-07, code as truth).** This document (last
+> touched 2026-09-04) reasons throughout about `interpreter.rs` and
+> `serve.rs` as live, current files — both were deleted entirely on
+> 2026-09-06 (`refactor: remove tree-walking interpreter and its only
+> consumers`). That affects two things below concretely: (1) F1's
+> "already reusable" `serve.rs` routes/identity-check reasoning is now
+> the same gap `docs/MOBILE.md`'s own drift note describes — no live
+> server exists to point a second renderer at; (2) F2's "shipped,
+> `[DONE]`" namespacing description leans on `interpreter.rs`'s
+> `fn_index`/name-resolution behavior specifically — since that file no
+> longer exists, whether namespacing still holds on the compiled
+> (`codegen.rs`) path needs re-checking against current code before
+> trusting this section's `[DONE]` claim at face value. F3's contract
+> checker (`contract_check.rs`, `smt.rs`) is unaffected — neither file
+> was touched by the interpreter removal.
+
 ## Why this came up
 
 Grew out of a direct 2026-09-03 conversation, prompted by two real bugs

--- a/docs/PROTOBOX_INTEGRATION.md
+++ b/docs/PROTOBOX_INTEGRATION.md
@@ -16,6 +16,24 @@ rediscovered per integration. Everything below is either shipped and
 verified today, or explicitly marked as an open gap — no aspirational
 claims.
 
+> **Drift note (2026-09-07, code as truth).** This entire pipeline
+> (§1-§9) is built around `nirdosha serve` — the compiled binary has no
+> `serve` subcommand any more. `interpreter.rs` and `serve.rs`
+> (and `dbconn.rs`/`durability.rs`/`observability.rs`/`pool.rs`, the
+> rest of what `serve` needed) were deleted entirely on 2026-09-06
+> (`refactor: remove tree-walking interpreter and its only consumers`
+> — three days after this doc was last written). Current subcommands
+> are `init`/`build`/`emit-llvm`/`emit-ast`/`emit-ui`/`emit-catalog`/
+> `gen-crud` only. Concretely: `nirdosha init`'s scaffolded `run.sh`
+> (§2) will not run, there is no live `/api/<fn>` or
+> `/_nirdosha/table/<snake>` route (§4-§6) for protobox's QA harness or
+> a generated app's own UI to call, and role/provider-config live-edit
+> (§4) has nothing to point at. Treat §1-§9 as the target contract for
+> when a compiled or revived serving story exists, not as what
+> `nirdosha init && ./run.sh` produces today — a real, unresolved gap
+> worth surfacing to whoever owns the protobox integration, not
+> something this pass can silently paper over.
+
 ## 1. The pipeline, end to end
 
 ```

--- a/docs/PROTOLANG_PORT.md
+++ b/docs/PROTOLANG_PORT.md
@@ -17,6 +17,16 @@ the rest, and does it the same way: study the ProtoLang mechanism, name the
 Nirdosha requirement it actually maps to (or admit it doesn't map to one),
 and either lock a narrow design or say plainly why it's deferred or rejected.
 
+> **Drift note (2026-09-07, code as truth).** `interpreter.rs` — cited
+> below (e.g. the I/O error model row, the HTTP request-building
+> reference) as where today's runtime behavior lives — was deleted
+> entirely on 2026-09-06 (`refactor: remove tree-walking interpreter
+> and its only consumers`), along with `serve.rs`/`nirdosha serve`.
+> Those specific behaviors aren't wrong as history, but nothing in this
+> tree currently executes them; see `docs/TRANSACT.md`/`docs/SANDBOXING.md`'s
+> own drift notes for the same fact applied to the two sections this
+> doc explicitly builds on.
+
 ## Method
 
 Every ProtoLang mechanism below gets one of four verdicts:

--- a/docs/PUBLIC_ROADMAP.md
+++ b/docs/PUBLIC_ROADMAP.md
@@ -200,11 +200,17 @@ above)
   (`docs/LANGUAGE.md` §7/§10, `rfcs/0007-apm-runtime-kernel.md` §8).
   Word-sized payloads/arguments/results only; `sandbox` is unaffected,
   still open below.
-- [DONE] Scalar-only native plugin calls (Kind A plugins) —
+- [DONE] Native plugin calls (Kind A plugins) —
   `plugin::NativePluginBuiltin`/`codegen::build_with_native_plugins`
   (`rfcs/0005-plugin-boundary-safety-and-performance.md` §3), ~250x
-  faster than interpreted plugin dispatch for this subset; `str`/
-  aggregate-typed plugin builtins still interpreter-only
+  faster than interpreted plugin dispatch ever was for the scalar
+  subset; widened past scalars to `str`, `handle(Kind)`, and
+  `&handle(Kind)` (`rfcs/0008-native-plugin-abi-widening.md` Phase 1,
+  two real reference crates: `crates/plugin-example-native-{shout,kv}`)
+  — there is no interpreter left for anything to fall back to.
+  Aggregate (`Vector`/`Matrix`)-typed plugin builtins remain
+  unsupported; Cargo-driven auto-discovery of a plugin crate is still
+  open (`rfcs/0008` Phase 3).
 - [DONE] The compiled-path runtime kernels (`det`/`inv`/`tcp`/`file`/...)
   moved from a bare, dependency-free `rustc` invocation to a real Cargo
   package (`crates/runtime-kernels/`, `docs/adr/0003-runtime-kernels-

--- a/docs/SANDBOXING.md
+++ b/docs/SANDBOXING.md
@@ -10,6 +10,20 @@ yet, and it invents a second, incompatible channel primitive alongside the
 buys us, independent of that syntax, and how we intend to get there without
 duplicating work already done.
 
+> **Drift note (2026-09-07, code as truth).** Row 1 below ("Done —
+> `sandbox`/`stop`") describes behavior (`SandboxChild`,
+> `Interpreter::with_sandbox_exe`, the `--sandbox-worker` re-exec) that
+> lived entirely in `interpreter.rs`/`main.rs`'s interpreter-only code
+> paths, deleted on 2026-09-06 (`refactor: remove tree-walking
+> interpreter and its only consumers`). `sandbox`/`stop` still parse and
+> typecheck, but `codegen.rs` explicitly rejects them
+> (`"codegen doesn't support 'sandbox' yet -- sandbox/stop are
+> interpreter-only for now"`), and there is no interpreter left to fall
+> back to — so today there is no way to actually *run* a `sandbox`
+> expression at all, compiled or otherwise. Read "Done" below as
+> "was done, on a runtime no longer in this tree," not as a current
+> capability.
+
 ## What it brings to the table
 
 **1. Sandboxes as a third tier of the safety story, not a bolt-on.**

--- a/docs/TRANSACT.md
+++ b/docs/TRANSACT.md
@@ -14,6 +14,21 @@ real durability log, crash replay, `network`'s own `retry`/`timeout`, and a
 real cross-process `network`/`commit` test) — see "How we're going to get
 there" below for exactly what each one delivered.
 
+> **Drift note (2026-09-07, code as truth).** That "implemented" claim
+> was true against the tree-walking interpreter, which — along with
+> `durability.rs`/`transact_log.rs`/`pool.rs`/`dbconn.rs`, everything
+> `transact`'s durability log and crash replay were built on — was
+> deleted entirely on 2026-09-06 (`refactor: remove tree-walking
+> interpreter and its only consumers`; see `docs/VALUES.md`'s "we
+> removed the interpreter entirely, on purpose" for why). `transact` is
+> still parsed and typechecked, but `codegen.rs` has no lowering for it
+> yet (compiled programs can't run one at all today), and there is
+> currently no interpreted execution path either. Every "verified live"
+> claim below describes the now-removed interpreter build, not the
+> current compiled-only binary — treat this document as the target
+> design for `transact` on the compiled path, not a description of
+> what `nirdosha build` produces today.
+
 ## What it brings to the table
 
 **1. Names the actual failure mode, instead of assuming "no exception ==

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -13,6 +13,21 @@ notification actions and external triggers, generalizing the
 `status TEXT` + hand-rolled `CREATE TABLE`/append-only-log pattern every
 one of those processes was independently re-deriving.
 
+> **Drift note (2026-09-07, code as truth).** `interpreter.rs` and
+> `serve.rs` — the two things "the interpreter" and "`nirdosha serve`'s
+> automatic RPC exposure" below refer to — were deleted entirely on
+> 2026-09-06 (`refactor: remove tree-walking interpreter and its only
+> consumers`). `workflow_lower.rs` itself is untouched and still
+> desugars `workflow` blocks into ordinary `fn`/`enum`/`struct`
+> declarations, so that part of the finding below still holds — but
+> those declarations now only flow through the *compiled* path
+> (`codegen.rs`), which doesn't yet lower `transact`/`db`/`json`/`http`/
+> notification-sending calls a real workflow body needs (see
+> `docs/TRANSACT.md`'s own drift note). There is currently no live
+> `POST /api/<fn>` RPC surface at all. Treat the "shipped" claims below
+> as true of the removed interpreter build, not the current
+> compiled-only binary.
+
 The finding that matters, same shape as `docs/TRANSACT.md`'s own: **this
 doesn't need a new runtime.** `workflow` is a compiler-stage desugaring —
 every `workflow` block becomes ordinary `fn`/`enum`/`struct` declarations

--- a/docs/adr/0004-external-data-service-boundary.md
+++ b/docs/adr/0004-external-data-service-boundary.md
@@ -1,7 +1,49 @@
 # 0004: External Data & Service Boundary — plugin-backed `db`/`mq` connections by URL scheme
 
 Date: 2026-09-05
-Status: accepted
+Status: accepted (decision stands; the mechanism itself no longer executes anywhere as of 2026-09-06 — see note below)
+
+> **2026-09-07 note, not a supersession.** This was accepted and shipped
+> correctly on 2026-09-05. The next day, `c82fa1f` ("refactor: remove
+> native plugin ecosystem") deleted `crates/plugin-example-mysql`/
+> `-activemq` (and the other three gallery crates) as a direct, disclosed
+> consequence of the separate interpreter-removal pass — its commit
+> message says plainly that every `plugin-example-*` crate "depended
+> entirely on the tree-walking interpreter's `PluginBuiltin`/`PluginFn`
+> dispatch, which no longer exists." Everything below describes real,
+> working code at the time it was written, but every noun in it —
+> `interpreter.rs`, `serve.rs`, `run_with_plugins`, `dbconn::connect`,
+> `HandleRegistry`, both named plugin crates — is now either deleted
+> entirely or (for `dbconn.rs`) stripped of the interpreter that called
+> it. This was a clean, intentional removal, not code lost in a merge:
+> `git log --oneline --all -- crates/plugin-example-mysql` shows a clean
+> linear history (add in `6264dd2`, two real feature commits including
+> this ADR's own `61d255e`, then one explicit delete in `c82fa1f`) —
+> nothing silently dropped in a merge, no orphaned branch holding work
+> this branch lost.
+>
+> **One real leftover worth knowing about, found while checking this**:
+> `mq_connect_via` — the one new builtin this ADR added — is still a
+> declared, typechecked builtin today (`ast::BUILTIN_NAMES`,
+> `typeck.rs::infer_builtin_call`, `effects.rs`, `ownership.rs`'s
+> `builtin_return_ty` all still list it). A `.nir` program can still
+> write `mq_connect_via(...)` and have it typecheck cleanly — but there
+> is no execution path left for it anywhere: the interpreter that
+> implemented it is gone, and `codegen.rs` hard-rejects `Ty::Mq`
+> entirely (`unsupported("codegen doesn't support mq yet")`). This isn't
+> unique to `mq_connect_via` — the same is true of every other `db`/`mq`
+> builtin (`db_connect`, `db_query`, `mq_publish`, ...), all of which
+> predate this ADR. It's the general "no backend left, in either path"
+> state this whole document's mechanism now shares with plain `db`/`mq`,
+> not a partial, botched removal specific to this ADR.
+>
+> No decision here is reversed by this note — routing a `scheme://`
+> string to a plugin by naming convention is still, in principle, the
+> right shape for whenever `db`/`mq` gain compiled-path codegen and a
+> revived (necessarily different — the compiled plugin ABI is scalar-
+> only, `rfcs/0008`) plugin mechanism. This note exists so a future
+> reader doesn't try to exercise this ADR's own evidence commands
+> against crates that no longer exist.
 
 ## Context
 

--- a/docs/goal.md
+++ b/docs/goal.md
@@ -26,8 +26,11 @@ of the others (§1, §7).
 > checkable today is a narrower, concrete slice: `rand_seed`/`rand_f64`/
 > `rand_gaussian` (Phase 3) make a simulation run's random draws
 > byte-for-byte reproducible from a seed — no OS entropy, no hidden
-> global state (see `interpreter.rs`'s `Interpreter::rng` field and
-> `crates/compiler/tests/mission_critical.rs`'s determinism tests). That's the
+> global state (originally `interpreter.rs`'s `Interpreter::rng` field;
+> the interpreter was deleted 2026-09-06, so today this is
+> `crates/runtime-kernels`'s per-thread `nir_rand_seed`/`nir_rand_f64`/
+> `nir_rand_gaussian`, and `crates/compiler/tests/mission_critical.rs`'s
+> determinism tests). That's the
 > honest foundation a future row-10 implementation pass would extend,
 > not a claim that row 10 itself is done.
 
@@ -62,6 +65,18 @@ of the others (§1, §7).
 > mis-compiled; a program that never actually constructs/matches one
 > still compiles normally, since the `Option`/`Result` prelude's mere
 > presence isn't itself a use.
+
+> **Superseded, 2026-09-06:** `struct`/`enum`/`match` compile for real
+> now (`codegen.rs::declare_named_type`/`match_enum`/`match_literal`;
+> `docs/LANGUAGE.md` §10) — this was already stale within days of being
+> written above. More importantly, "interpreter-only" is no longer a
+> real category at all: the tree-walking interpreter (`interpreter.rs`)
+> and its HTTP server (`serve.rs`) were deleted entirely this date (see
+> `docs/API_TRUST_MODEL.md`'s provenance note). `codegen.rs` is the only
+> backend left; anything it doesn't yet accept (`db`/`json`/`http`/`mq`/
+> `transact`/`workflow`/`sandbox`) simply doesn't run in any form —
+> `codegen.rs::check_supported` is the one ground-truth list, not any
+> comparison against a reference interpreter.
 
 ---
 

--- a/docs/nirdosha-agent-api.md
+++ b/docs/nirdosha-agent-api.md
@@ -8,6 +8,19 @@ the codebase or is explicitly planned in docs/Nirdosha_Unified_Plan.md.
 Nothing is aspirational hand-waving -- if it's not built yet, it
 says so and references the phase that delivers it.
 
+> **2026-09 correction.** The tree-walking interpreter
+> (`interpreter.rs`) and `serve.rs` were deleted entirely in a later
+> session (see `docs/API_TRUST_MODEL.md`'s own provenance note) --
+> `nirdosha` is compiled-path-only now (`init`/`build`/`emit-llvm`/
+> `emit-ast`/`emit-ui`/`emit-catalog`/`gen-crud`, no bare `run`, no
+> `serve`, no `--sandbox-worker`). That breaks this document's
+> grounding for **B1** (wraps the now-gone `nirdosha::run`/
+> `run_diagnostic`) and the `--format=json` flag referenced below (also
+> removed with the interpreter) -- both marked inline where they occur.
+> Everything else here (validate_fragment, codegen's `check_supported`,
+> the sandbox/stop *AST support*, refine.rs/smt.rs) is unaffected or
+> noted separately.
+
 ------------------------------------------------------------------------
 WHAT PROBLEM THESE APIs SOLVE
 ------------------------------------------------------------------------
@@ -37,9 +50,15 @@ The hardest things in the LLM-code-generation world today:
 Nirdosha's existing architecture addresses each of these:
 
   1. LL(1) grammar + planned GBNF export → constrained decoding
-  2. --format=json → structured diagnostics (already shipped)
+  2. --format=json → structured diagnostics (removed with the
+     interpreter -- see the 2026-09 correction above; a compiled-path
+     replacement would need new work, not a wrap of existing code)
   3. refine.rs + smt.rs → SMT-discharged bounds proofs (shipped)
-  4. sandbox/stop → real OS process isolation (shipped)
+  4. sandbox/stop → parses and typechecks, but has no working runtime
+     path today -- codegen explicitly rejects it
+     (`codegen.rs`: "codegen doesn't support `sandbox` yet") and the
+     interpreter that used to run it is gone; not "shipped" as an
+     isolation mechanism right now
   5. rand_seed → deterministic RNG (shipped)
   6. validate_fragment → type-check expression fragments in
      context (shipped)
@@ -91,8 +110,12 @@ Auth:        none (local tool -- not a multi-tenant platform)
 
 The server is a thin HTTP wrapper around the compiler crate
 (`crates/compiler/src/lib.rs`). It links the compiler as a library and
-exposes its existing functions (run, run_diagnostic,
-validate_fragment, typecheck, check_ownership) as HTTP endpoints.
+would expose its existing functions as HTTP endpoints --
+`typeck::validate_fragment`, `typeck::typecheck`,
+`ownership::check_ownership` still exist (module-qualified, not
+crate-root re-exports). `run`/`run_diagnostic` do **not** exist any
+more: the interpreter they belonged to was deleted (see the 2026-09
+correction above), so B1 below has no live function left to wrap.
 
 ------------------------------------------------------------------------
 A. CODE GENERATION & VALIDATION
@@ -427,6 +450,18 @@ B. EXECUTION & SIMULATION
 
 ================ B1. POST /v1/run ========================
 
+**2026-09: no longer buildable as specified.** This wrapped the
+tree-walking interpreter's `nirdosha::run(src)`/`run_diagnostic(src)`,
+and that interpreter was deleted entirely (see the 2026-09 correction
+at the top of this document). There is no compiled-path equivalent of
+"run this arbitrary program and print its output" today -- `build`
+produces a native binary you then execute yourself, which is a
+different shape (a build step in between, no in-process diagnostics
+capture). Reviving this endpoint means designing a compiled-execution
+equivalent, not restoring a wrapper.
+
+Original design (kept for reference, no longer grounded in shipped code):
+
 Run a Nirdosha program via the tree-walking interpreter.
 Wraps: `nirdosha::run(src)` or `nirdosha::run_diagnostic(src)`.
 
@@ -466,9 +501,12 @@ Response (200 OK, runtime error with format=json):
 ================ B2. POST /v1/run-sandboxed ===============
 
 Run a Nirdosha program inside an isolated OS process.
-Uses the existing `sandbox`/`stop` primitives (shipped in commit
-579c1bc, docs/SANDBOXING.md layer 1) to fork a child process that
-re-execs the nirdosha binary.
+**2026-09: also no longer buildable as specified** -- `sandbox`/`stop`
+parse and typecheck, but the interpreter machinery that actually forked
+and re-exec'd a child process (`SandboxChild`, `spawn_sandbox`) lived in
+`interpreter.rs` and was deleted with it; `codegen.rs` explicitly
+rejects `sandbox` as unsupported today. Same status as B1: needs new
+compiled-path work, not a wrap.
 
 THIS IS THE HARD THING IT MAKES EASY:
   Running LLM-generated code safely is the #1 blocker for autonomous
@@ -1154,17 +1192,25 @@ the code the LLM writes -- which is the gap nobody has shipped yet.
 IMPLEMENTATION NOTES
 ------------------------------------------------------------------------
 
-The server is a thin HTTP wrapper. It links the compiler crate
-as a library (crates/compiler/src/lib.rs already exposes run, run_diagnostic,
-validate_fragment, Diagnostic, RunFailure). The additional work:
+The server is a thin HTTP wrapper. It links the compiler crate as a
+library -- but as of the 2026-09 interpreter removal,
+`crates/compiler/src/lib.rs` only re-exports `Diagnostic` at the crate
+root; `validate_fragment` is `typeck::validate_fragment`, and `run`/
+`run_diagnostic`/`RunFailure` no longer exist at all (B1/B2 above are
+no longer just "wire it up"). The additional work:
 
   1. HTTP server (axum or actix-web, ~200 lines of route handlers)
   2. Grammar-constrained decoding integration (calls an external
      OpenAI-compatible endpoint with the GBNF grammar -- Phase 2 dep)
   3. Benchmark harness scoring loop (Phase 5 scaffold exists in crates/bench/)
   4. Provenance hashing (sha256 of source + AST, straightforward)
+  5. A compiled-path execution story for B1/B2 (see those sections) --
+     the interpreter they wrapped is gone, so this is new design work,
+     not a wrap of existing code
 
-No compiler internals change. The compiler already has every
-function these APIs need. The server just calls them.
+Most compiler internals this spec needs (validate_fragment, typecheck,
+check_ownership, codegen's check_supported) are unchanged. B1/B2 are
+the exception: the server can no longer "just call" an existing
+function for them.
 
 ========================================================================

--- a/examples/features/README.md
+++ b/examples/features/README.md
@@ -1,10 +1,22 @@
 # Nirdosha — feature catalogue
 
-One `.nir` file per language feature, each independently runnable
-(`nirdosha <file>`) and verified against `target/debug/nirdosha`. Every
-file is self-contained — no external services required, though a few
-(25/28/47) degrade gracefully (a real `Err`, not a crash) when Redis or
-network access isn't available.
+One `.nir` file per language feature. Every file is self-contained — no
+external services required, though a few (25/28/47) degrade gracefully
+(a real `Err`, not a crash) when Redis or network access isn't
+available.
+
+**2026-09 — there is no interpreter anymore, so "runnable" no longer
+means what it used to here.** The tree-walking interpreter and
+`nirdosha <file>`/`nirdosha serve` were deleted entirely (`docs/
+API_TRUST_MODEL.md` §4a). Only a file whose constructs are all in
+`codegen.rs::check_supported`'s accepted set (`docs/LANGUAGE.md` §10's
+compiled-vs-not table) can still be compiled and actually run today
+(`nirdosha build <file> -o out && ./out`); every file above can still be
+parsed/typechecked (`nirdosha emit-ast`/`emit-ui`), but a file built
+around an interpreter-only construct (`db`/`json`/`mq`/`sandbox`/`tcp`/
+`file`/`transact`/most Row 12 identity builtins — most of the numbered
+list below) no longer executes through any current `nirdosha` command
+at all, and isn't re-verified by this repo's own CI as of this note.
 
 `45_module_namespacing.nir` `use`s `45_module_namespacing_helper.nir` —
 that's the one file here meant to be read, not run, on its own.
@@ -57,8 +69,8 @@ that's the one file here meant to be read, not run, on its own.
 | 43 | `43_layout.nir` | `layout { row/column/grid/group/tabs/divider/timeline }` |
 | 44 | `44_module_nav_grouping.nir` | `module "Display Name" { ... }` — legacy nav grouping, not scoping |
 | 45 | `45_module_namespacing.nir` (+ `..._helper.nir`) | `module Ident { pub ... }` real namespacing + `use` |
-| 46 | `46_db_schema_and_role_mapping_conventions.nir` | `serve --db` auto schema migrations + `RoleMapping` identity cache (pure convention, no new syntax) |
-| 47 | `47_external_service_boundary.nir` | plugin-backed `db`/`mq` by URL scheme (`db_connect`/`mq_connect_via`) |
+| 46 | `46_db_schema_and_role_mapping_conventions.nir` | the (now-deleted, `serve --db`-only) auto schema migrations + `RoleMapping` identity cache convention (pure convention, no new syntax) |
+| 47 | `47_external_service_boundary.nir` | plugin-backed `db`/`mq` by URL scheme (`db_connect`/`mq_connect_via`) — the two reference plugin crates this demonstrated (`plugin-example-mysql`/`-activemq`) were deleted along with the interpreter (`docs/adr/0004`'s 2026-09-07 note); `mq_connect_via` itself still typechecks but has no execution path left, same as the rest of `db`/`mq` |
 | 49 | `49_nfr.nir` | `nfr(latency_ms:/error_rate_max:/throughput_min_per_sec:/concurrency_max:)` — compiled, automatic APM tracking |
 | 50 | `50_field_masking_and_check_role.nir` | field-level `requires(role/claim:...)` masking + function-level `requires(role:...)`/`acquire` + compiled `check_role` — the README's own hero example |
 
@@ -66,11 +78,10 @@ that's the one file here meant to be read, not run, on its own.
 
 Properties of the toolchain/compiler rather than `.nir` syntax you write:
 
-- **Execution modes** (`nirdosha <file>` / `build` / `emit-llvm` /
-  `emit-ast` / `emit-ui` / `serve`, `--format=json`) — every feature
-  file above is itself run through the interpret path; several
-  (workflow/screen/dashboard-bearing ones) are also checked with
-  `emit-ui`.
+- **Execution modes** (`init` / `gen-crud` / `build` / `emit-llvm` /
+  `emit-ast` / `emit-ui` / `emit-catalog` — see the 2026-09 note above:
+  there is no interpreter, no bare `nirdosha <file>`, and no `serve`/
+  `--format=json` anymore).
 - **Static guarantees** (type checking, ownership/move-checking,
   interval analysis, Z3 bounds proving) — properties every file above
   is already subject to, not a separate construct to demonstrate.

--- a/rfcs/0007-apm-runtime-kernel.md
+++ b/rfcs/0007-apm-runtime-kernel.md
@@ -42,13 +42,17 @@ None of it is reachable from the compiled path — `runtime-kernels` is
 its own Cargo workspace, statically linked as a `.a` staticlib into a
 compiled binary, and its own module doc states it "cannot `use`
 anything from `interpreter.rs` directly across that compilation-unit
-boundary." A binary from `nirdosha build` today has, for the only two
-effects that compile at all (`tcp`, `file`), a handful of raw `extern
-"C"` syscall wrappers — one `connect()`/`open()` per call, no pooling,
-no scheduling, no admission control, no telemetry, no audit hook.
+boundary." A binary from `nirdosha build` today has, for the effects
+that compiled at the time this was written (`tcp`, `file`), a handful
+of raw `extern "C"` syscall wrappers — one `connect()`/`open()` per
+call, no pooling, no scheduling, no admission control, no telemetry, no
+audit hook. **Update (2026-09)**: `spawn`/`join`/`chan`/`send`/`recv`
+compile now too, with a real admission `Domain::Thread` ceiling and a
+dynamic stall detector — see §8's own "Update" for the full picture;
+only `db`/`sandbox` remain hard rejections.
 
-As `db` (Track B item B2) and `spawn`/`chan`/`sandbox` (item B6) gain
-codegen over time, should `runtime-kernels` grow the same way the
+As `db` (Track B item B2) and `sandbox` (item B6) gain codegen over
+time, should `runtime-kernels` grow the same way the
 interpreter did — independent per-effect resource managers, never
 unified, discovering their coupling only after each ships separately —
 or should a single, deliberately designed resource-control kernel exist
@@ -206,9 +210,10 @@ open work the decision document didn't need to solve.
 **Global coordination plane.** Named for completeness, but **its exit
 criteria are close to vacuous today**: cross-shard wait-for sweeps
 matter once there are multiple real, contended resource domains. With
-only `tcp` and `file` compiling, and no DB/spawn contention possible
-yet, there's very little for a coordinator to coordinate. This plane's
-real design work should wait for B2/B6, not be speculatively built now.
+only `tcp`/`file`/`thread` (as of 2026-09, §8's Update) having admission
+domains, and no DB contention possible yet, there's still very little
+for a coordinator to coordinate. This plane's real design work should
+wait for B2, not be speculatively built now.
 
 **Failure behavior table** — kept unchanged from the decision document;
 it's a general design principle (fail-open telemetry, fail-closed hard
@@ -264,7 +269,9 @@ What the compiled path actually has as a boundary, today:
    **For the compiled path, that fallback is the primary and, for now,
    only case** — not a corner case of a request-classification system
    that mostly doesn't apply here.
-2. Once `spawn` compiles (B6), a spawned task's entry point becomes a
+2. Now that `spawn` compiles (2026-09, §8's Update) — though still
+   without the compiled thread *scheduler* §8 says this boundary-unit
+   idea actually needs — a spawned task's entry point becomes a
    second, more natural boundary unit — closer in spirit to "a request"
    — since a task has a definable start and a manifest of what it will
    do, the way a request handler does in the original design.
@@ -333,10 +340,13 @@ Two findings this resolves:
    exactly the calls that exist because they're supposed to be cheap —
    not negligible the way it is for the boundary calls.
 
-**Still unmeasured, and unmeasurable until Track B lands**: `db`
-(B2) and `spawn`/`chan`/`sandbox` (B6) don't compile, so this harness
-says nothing about those domains. Whatever kernels eventually back
-them need this same measurement repeated against their own baseline.
+**Still unmeasured, and unmeasurable until Track B lands**: `db` (B2)
+and `sandbox` (B6) don't compile, so this harness says nothing about
+those domains — `spawn`/`chan` compile now too (§8's Update) but
+haven't been run through this specific benchmark harness yet. Whatever
+kernels eventually back `db`/`sandbox`, and a `spawn`/`chan` pass of
+this harness, need this same measurement repeated against their own
+baseline.
 
 ## 6. Telemetry/data transmission design
 
@@ -353,6 +363,18 @@ architectural problem" the way the decision document frames it for the
 interpreter — a compiled-path telemetry exporter can be designed
 without that particular piece of debt from day one, if this is built
 after that finding is internalized.
+
+**Update (2026-09), corrected**: "ring buffers... batching" above read
+as pure future design when this section was written; one of those
+pieces is real now. `kernel::recorder` is a genuine double-buffered
+ring (grant/release/denial events only, boundary-scoped, never on the
+`send`/`recv` hot path) with real batching (gzip-compress-and-flush
+one full page at a time, off the hot path, on `thread_pool`) — see
+§10's Phase 1 row for the exact mechanism. What's still exactly as
+undesigned as this section originally said: an aggregator thread,
+OTLP/any network export, spill, sampling, and the redaction-vs-
+replay-fidelity separation — `kernel::recorder` writes to a local file
+only, nothing crosses the process boundary.
 
 ## 7. Metrics design
 
@@ -591,9 +613,9 @@ than a `nirdosha serve` process an operator already controls.
 |---|---|---|---|
 | **0 — Foundations** | ✅ **Done.** Phase 0 harness measures the zero-admission baseline — see §5. | ✅ Done. | The decision doc's Phase 0 assumed an interpreter/RFC-0006 baseline; this measured the actual compiled-path substrate instead, and found the two SLOs are not equally at risk (§5). |
 | **2/3 — Admission mechanism, live** | ✅ **Built and measured**, ahead of the sequencing this table originally proposed. `crates/runtime-kernels/src/kernel/`: one atomic compare-and-swap per domain (`Tcp`, `File`), gating `nir_tcp_connect`/`nir_tcp_listen`/`nir_tcp_accept`/`nir_file_open` only — never `send`/`recv`/`read`/`write`, resolving §5's "which SLO is at risk" finding by not putting admission on that path at all, rather than by hitting an aggressive nanosecond budget on it. `kernel_bench` re-run against it: every boundary call within run-to-run noise of the original baseline (`rfcs/evidence/0007-apm-runtime-kernel/README.md`'s "Update" section) — no measurable regression. A generic `HandleTable<T>` also now exists, unwired, for the next resource domain (`json`/`db`/`mq`) to use instead of inventing its own table. **Also now built, both unwired, both ported near-verbatim from the interpreter-side modules of the same name (real design, zero interpreter dependency, confirmed by actually checking before porting)**: `kernel::pool` (generic `r2d2`-backed connection *pooling* — reuse, distinct from admission) and `kernel::thread_pool` (eager-growth reused-worker OS thread pool, the exact deadlock-avoidance design `rfcs/0006`'s spawn/join concerns need) — 17 total unit tests across all three modules, all passing, including `thread_pool`'s own adversarial suite (panic containment, flaky-spawner injection, deep spawn/join chains that would deadlock a bounded pool). **One real, disclosed gap found while porting, not before**: `thread_pool`'s panic containment (`catch_unwind`) only works under a profile with unwinding enabled; this crate's `[profile.release]` sets `panic = "abort"` (the profile a real compiled `.nir` binary actually ships as), where a panicking spawned job would abort the whole process — flagged prominently in `thread_pool`'s own module doc as unresolved, not silently carried over. **Still open**: the compiler-side manifest pass (frontend, path-agnostic) hasn't been built; `AdmissionDenied` as a distinct, surfaced error kind (today a denial folds into the same `-1` every other failure returns); neither `pool` nor `thread_pool` is wired to any `nir_*` kernel yet, since `db`/`mq`/`spawn` don't compile. | Real code now exists in the tree, not just a measured baseline — the two originally-separate phases (build a lease-check stub; measure its cost) happened together, and the mechanism landed as live enforcement (generous ceiling) rather than pure shadow/observe-only mode first. The pooling/worker-reuse primitives are new relative to the original table entirely — added after explicitly re-checking whether anything from the deleted interpreter-side modules should be resurrected into the kernel's foundation now, rather than reinvented per-domain later. |
-| **1 — Telemetry data plane** | `kernel.rs`'s own self-metrics (`stats()` — grants/denials/currently-held per domain) exist now, in the smallest possible form (§7's "kernel self-metrics are first-class" principle) — no exporter, no rings, no aggregation, not yet called from anywhere. Still open: rings/aggregator/batching/exporter, and a new compiled-binary config/export mechanism (env-var or build-time, undesigned). | Telemetry overhead within re-derived targets; 100% drop accounting; a decided answer for how a compiled binary is told where to export telemetry. | Added the config-mechanism exit criterion — the decision doc didn't need one, since `nirdosha serve` already has `--otel-*` flags (and `serve` no longer exists at all as of this session's separate interpreter-removal work). |
+| **1 — Telemetry data plane** | `kernel.rs`'s own self-metrics (`stats()` — grants/denials/currently-held per domain) exist, in the smallest possible form (§7's "kernel self-metrics are first-class" principle), plus (**correction, 2026-09-07**: this row previously said "no rings" — that stopped being true the same commit this table's Phase 2/3 row already credits) a real local ring: `kernel::recorder` double-buffers every `acquire`/`release`/denial event into one of two pages (`NIRDOSHA_KERNEL_RECORDER_PAGE_CAPACITY`, default 1024), gzip-compresses each full page independently (valid concatenated gzip members, RFC 1952) on a background `thread_pool` worker the instant it fills, and appends it to a local file (`NIRDOSHA_KERNEL_RECORDER_PATH`); the final partial page is flushed synchronously from `nir_kernel_flight_recorder_dump`, which every `codegen.rs` trap-guard (`guard_nonzero_divisor`/`guard_call_ok`/`guard_io_ok`/`guard_recv_ok`) already calls before aborting. This is real, tested (`kernel/recorder.rs`'s own unit tests), and running in every compiled binary today — but it answers "what led up to a crash," a local diagnostic log, not "aggregate metrics across a fleet." Still open, and still fully undesigned: any network export (OTLP or otherwise) of either this ring or `stats()`'s counters, cross-process aggregation, and a decided mechanism for a compiled binary to be told where to send data off-box at all. | Telemetry overhead within re-derived targets; 100% drop accounting; a decided answer for how a compiled binary is told where to export telemetry. | Added the config-mechanism exit criterion — the decision doc didn't need one, since `nirdosha serve` already has `--otel-*` flags (and `serve` no longer exists at all as of this session's separate interpreter-removal work). This row's own "no rings" claim was corrected 2026-09-07 after `kernel::recorder` was found built and wired in but never credited here. |
 | **Manifests** | Compiler manifest pass (frontend, path-agnostic) — not started. | Manifests emitted for classifiable call sites; declared bounds feed the kernel's ceilings instead of the current hardcoded default. | Unchanged from the original table's Phase 2 half. |
-| **`db`/`spawn` enforcement** | `db` once B2 lands; `spawn` budget only once B6's compiled scheduler exists (see §8's spawn note) — both still fully blocked on codegen that doesn't exist. | `AdmissionDenied` compatibility tests pass for each as it lands. | Unchanged — the decision doc's "DB pools first" ordering is still inverted here, since DB doesn't compile yet. |
+| **`db`/`spawn` enforcement** | `db` still fully blocked on codegen that doesn't exist (`Ty::Db` is a hard `codegen.rs` rejection), pending B2. `spawn` is **partially ahead of this row's own sequencing** (**correction, 2026-09-07**: this row previously said `spawn` budget was "still fully blocked" too — the very next table row already credits the fix that made that stale): `Domain::Thread` is a real, live admission ceiling (`NIRDOSHA_KERNEL_MAX_THREAD`), acquired in `nir_thread_spawn` and released in `nir_thread_join` (§8's "Housekeeping" paragraph). What's still genuinely blocked, per §8's own argument, is a *budget* in the fuller sense the decision document meant — priority inheritance, non-blocking admission with parked-continuation waiters, and anything else that presumes a real compiled scheduler RFC 0006 hasn't built — none of which the simple ceiling above attempts. | `AdmissionDenied` compatibility tests pass for each as it lands. | Unchanged for `db` — the decision doc's "DB pools first" ordering is still inverted here, since DB doesn't compile yet. For `spawn`, corrected 2026-09-07: the ceiling half of this row shipped earlier than the row itself was updated to say. |
 | **4 — Global coordination and deadlock recovery** | Likely light/deferred until 2+ real contended domains exist (post-B2) — moot with only `Tcp`/`File` today. | Cross-shard detection SLOs, but only meaningful once there's more than one shard worth coordinating. | Unchanged. |
 | **5 — NFR composition, replay** | Single-function `nfr(...)` declaration, O(1) tracking, and threshold escalation are now ✅ **done** (`docs/LANGUAGE.md` §6f, §9 above) — ahead of this row's original sequencing, same pattern as Phase 2/3's admission mechanism landing early. Still open, as originally scoped: composition checks across a call chain, precedence/override semantics, per-principal ceilings, and opt-in replay. The decision document's "interpreter-parity revisit" is now moot outright, not just deferred: the interpreter was removed entirely in a separate pass this session (`run`/`serve`, `interpreter.rs`, and every module that only existed to serve it are gone from the tree) — there is no interpreter left to reach parity with. | Composition checks reject contradictory declarations; replay artifacts meet access-control rules. | The parity question this row used to defer is now closed by events, not by decision; single-function declaration/tracking/escalation moved from "not started" to "done" ahead of the rest of this row. |
 

--- a/rfcs/evidence/0007-apm-runtime-kernel/README.md
+++ b/rfcs/evidence/0007-apm-runtime-kernel/README.md
@@ -2,9 +2,11 @@
 
 `kernel_bench/` measures the actual, current, zero-admission cost of
 `crates/runtime-kernels`'s `nir_tcp_*`/`nir_file_*` kernels — the only
-two effects that compile at all today (`db`/`spawn`/`chan`/`sandbox`
-are still hard `codegen.rs` rejections). RFC 0007 §5 needs this before
-any of its numeric SLOs can be treated as more than a guess.
+two effects that compiled at the time this harness was written
+(`db`/`spawn`/`chan`/`sandbox` were still hard `codegen.rs` rejections;
+**update, 2026-09**: `spawn`/`chan` compile now too, see RFC 0007 §8 —
+`db`/`sandbox` remain rejections). RFC 0007 §5 needs this before any of
+its numeric SLOs can be treated as more than a guess.
 
 ## What it does
 
@@ -99,11 +101,14 @@ of the call it's guarding, for effects that exist specifically because
 they're supposed to be cheap.
 
 **Caveat on `db`/`spawn`.** This harness cannot say anything about
-those domains — they don't compile yet (`codegen.rs` hard-rejects
-them). Whatever `nir_db_*`/`nir_spawn_*` kernels eventually get built
-per Track B items B2/B6 will need this same measurement repeated
-against their own baseline before RFC 0007's SLOs can be considered
-validated for those domains too.
+those domains — at the time this was written, neither compiled yet
+(`codegen.rs` hard-rejected them). **Update (2026-09)**: `spawn`/`chan`
+compile now (RFC 0007 §8), but haven't been run through this harness;
+`db` remains a hard rejection. Whatever `nir_db_*` kernel eventually
+gets built per Track B item B2, and a `spawn`/`chan` pass of this
+harness, will need this same measurement repeated against their own
+baseline before RFC 0007's SLOs can be considered validated for those
+domains too.
 
 ## Update: the admission mechanism now exists, and this harness measured it live
 


### PR DESCRIPTION
## Summary
- Wide code-vs-doc audit after the interpreter/`serve.rs` removal: dozens of docs (READMEs, RFCs, agent-skills, ADRs) and a few Rust doc comments still described the deleted interpreter/server as live. Corrects present-tense claims to match current behavior — this repo's deliberate historical narrative (past-tense deletion notes, RFC Status boxes) is left untouched.
- Regenerates `crates/compiler/src/INDEX.md` against the current source (it still listed deleted `interpreter.rs`/`serve.rs` as current files, and every other entry had drifted).
- Fixes internal inconsistencies in `rfcs/0007-apm-runtime-kernel.md` — `Domain::Thread` admission and the `kernel::recorder` flight recorder both shipped without the RFC's own tables crediting them.
- Adds a dated correction note to `docs/adr/0004` clarifying its plugin-backed `db`/`mq` mechanism no longer executes anywhere (interpreter deleted, reference plugin crates removed in `c82fa1f`), without rewriting the original decision record.
- Flags (does not fix) two real bugs found along the way: `nirdosha init` scaffolds a launcher that calls the now-nonexistent `nirdosha serve`, and the Kubernetes/deploy docs assume the same missing command.

Docs/comments only — no behavior change. `cargo check -p nirdosha` verified clean.

## Test plan
- [x] `cargo check -p nirdosha` passes
- [ ] Human review of the doc/comment wording for tone and accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)