### PR TITLE
RFC 0011: uniform service-provider model — open admission domains, revived plugin dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,6 +1211,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "nirdosha-plugin-native-authed-http"
+version = "0.1.0"
+
+[[package]]
 name = "nirdosha-plugin-native-kv"
 version = "0.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,13 @@ members = [
     # the automated "compiles and the real binary runs correctly" proof.
     "crates/plugin-example-native-shout",
     "crates/plugin-example-native-kv",
+    # rfcs/0011-uniform-service-provider-model.md Phase 8: the RFC's own
+    # closing checklist item -- one real, shipped `call`-shape plugin,
+    # proving Phases 3-7's plugin-provider machinery works end to end
+    # with real compiled/linked/executed code, not just typechecked
+    # `NativePluginBuiltin` metadata. See its own README and
+    # `crates/compiler/tests/native_plugin_examples.rs`.
+    "crates/plugin-example-native-authed-http",
     # rfcs/0009-ui-catalog-extensibility.md Phase B's real reference UI
     # component -- a genuinely separate crate (not inline Rust in a
     # test file) contributing a `layout { ... }` widget kind. See its

--- a/crates/compiled-serve/src/lib.rs
+++ b/crates/compiled-serve/src/lib.rs
@@ -35,7 +35,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
-use nirdosha_runtime_kernels::kernel::{self, Domain};
+use nirdosha_runtime_kernels::kernel::{self, domain};
 
 mod http;
 mod ratelimit;
@@ -93,7 +93,7 @@ pub struct Route {
 #[derive(Clone)]
 pub struct ServeConfig {
     /// Header-read timeout — a client that connects and sends nothing
-    /// must not park a thread (and a `Domain::ServeHttp` lease) forever.
+    /// must not park a thread (and a `domain::serve_http()` lease) forever.
     pub header_timeout: Duration,
     /// Body-read timeout, separate from the header timeout — a slow
     /// body (not a slow header) gets its own budget.
@@ -112,7 +112,7 @@ pub struct ServeConfig {
     pub allowed_origins: Vec<String>,
     /// Paths rate-limited by `ratelimit` — e.g. `/auth/login`,
     /// `/api/_demo_login`. Every other path is unlimited at this layer
-    /// (`Domain::ServeHttp`'s own admission ceiling is the general
+    /// (`domain::serve_http()`'s own admission ceiling is the general
     /// backstop).
     pub rate_limited_paths: Vec<&'static str>,
     pub rate_limit_max_per_window: u32,
@@ -194,7 +194,7 @@ impl Readiness {
 impl Listener {
     /// Runs the accept loop forever (or until the process exits) —
     /// spawns a thread per accepted connection, unconditionally; the
-    /// **thread**, not this accept loop, checks `Domain::ServeHttp`
+    /// **thread**, not this accept loop, checks `domain::serve_http()`
     /// admission and fails fast with a real `503` if denied, so a
     /// saturated ceiling never makes the accept loop itself stall or
     /// queue (`rfcs/0010`'s own "admission failure is a fast, visible
@@ -216,7 +216,7 @@ impl Listener {
     }
 }
 
-/// Releases a `Domain::ServeHttp` lease exactly once, on drop.
+/// Releases a `domain::serve_http()` lease exactly once, on drop.
 ///
 /// **Only covers a panic in this crate's own Rust logic** (`dispatch`'s
 /// own code — CORS, rate limiting, JSON marshaling — everything except
@@ -242,12 +242,12 @@ struct ServeHttpLease;
 
 impl Drop for ServeHttpLease {
     fn drop(&mut self) {
-        kernel::release(Domain::ServeHttp);
+        kernel::release(domain::serve_http());
     }
 }
 
 fn handle_connection(mut stream: TcpStream, routes: &[Route], config: &ServeConfig, limiter: &ratelimit::RateLimiter, readiness: &Readiness) {
-    if !kernel::acquire(Domain::ServeHttp) {
+    if !kernel::acquire(domain::serve_http()) {
         let _ = http::write_response(&mut stream, 503, "text/plain", b"503 Service Unavailable -- server at capacity", &[], None);
         return;
     }

--- a/crates/compiled-serve/src/tests.rs
+++ b/crates/compiled-serve/src/tests.rs
@@ -225,7 +225,7 @@ fn a_body_over_the_max_size_is_rejected_with_413() {
 /// so that case isn't (and can't safely be) exercised here.
 ///
 /// A tight, isolated unit test of the `Drop` impl itself, not an
-/// end-to-end request through a real `Listener` — `Domain::ServeHttp`'s
+/// end-to-end request through a real `Listener` — `domain::serve_http()`'s
 /// held count is a single process-wide counter shared by every
 /// concurrently-running test in this binary (`cargo test`'s default
 /// parallelism), so a broader "run N real requests, compare the
@@ -236,10 +236,10 @@ fn a_body_over_the_max_size_is_rejected_with_413() {
 /// test to interleave in, keeps the same real guarantee without it.
 #[test]
 fn serve_http_lease_drop_releases_exactly_one_admission() {
-    assert!(kernel::acquire(Domain::ServeHttp));
-    let (held_before, _, _, _) = kernel::stats(Domain::ServeHttp);
+    assert!(kernel::acquire(domain::serve_http()));
+    let (held_before, _, _, _) = kernel::stats(domain::serve_http());
     drop(ServeHttpLease);
-    let (held_after, _, _, _) = kernel::stats(Domain::ServeHttp);
+    let (held_after, _, _, _) = kernel::stats(domain::serve_http());
     assert_eq!(held_after, held_before - 1);
 }
 

--- a/crates/compiler/build.rs
+++ b/crates/compiler/build.rs
@@ -90,16 +90,39 @@ fn main() {
     // actually lives -- see the `find_link_search_dirs` doc comment below
     // for why `--print=native-static-libs` alone (just the bare names)
     // isn't enough.
-    let output = Command::new(&cargo)
-        .arg("rustc")
+    let mut cmd = Command::new(&cargo);
+    cmd.arg("rustc")
         .arg("-vv")
         .arg("--release")
         .arg("--manifest-path")
         .arg(&kernels_manifest)
         .arg("--target-dir")
-        .arg(&kernels_target_dir)
-        .arg("--")
-        .arg("--print=native-static-libs")
+        .arg(&kernels_target_dir);
+    // Windows only, root-causing a real multi-commit CI failure chain:
+    // `bundled` SQLite's C source (compiled by the `cc` crate's own
+    // `cl.exe` invocation) defaults to the *dynamic* CRT (`/MD`), which
+    // decorates its libc calls as DLL imports (`__imp_realloc`,
+    // `__imp__beginthreadex`, ...) -- while `codegen.rs`'s own generated
+    // LLVM IR `declare`s libc functions (`printf`, `malloc`, ...) as
+    // plain, non-`dllimport` externals, which only a *static*-CRT link
+    // (`libcmt.lib`) satisfies directly. Two halves of the same binary
+    // structurally expecting different CRT linkage models is exactly
+    // what no `/NODEFAULTLIB:<X>` combination could ever fix -- found
+    // the hard way, across several real Windows CI failures, each fixing
+    // one symbol set by excluding a library the *other* half needed.
+    // `+crt-static` makes `rustc` link its own generated code against
+    // `libcmt.lib` too, and the `cc` crate independently reads this same
+    // target feature (`CARGO_CFG_TARGET_FEATURE`) to pass `/MT` instead
+    // of `/MD` to `cl.exe` for `bundled` SQLite's build -- one consistent
+    // static-CRT model across the whole embedded archive, matching what
+    // `codegen.rs`'s plain `declare`s already assumed, rather than one
+    // more hand-picked `-Xlinker` flag reacting to whichever symbol
+    // happened to be missing this time.
+    cmd.arg("--").arg("--print=native-static-libs");
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
+        cmd.arg("-C").arg("target-feature=+crt-static");
+    }
+    let output = cmd
         .output()
         .expect(
             "failed to invoke `cargo rustc` to build ../runtime-kernels -- \

--- a/crates/compiler/build.rs
+++ b/crates/compiler/build.rs
@@ -118,9 +118,31 @@ fn main() {
     // `codegen.rs`'s plain `declare`s already assumed, rather than one
     // more hand-picked `-Xlinker` flag reacting to whichever symbol
     // happened to be missing this time.
+    //
+    // **Must be `RUSTFLAGS`, not a trailing `cargo rustc -- <flag>`** --
+    // a real, silent no-op found only by the identical six symbols still
+    // being unresolved on the very next Windows CI run after adding this
+    // exact flag the first time, in the wrong place. `cargo rustc --
+    // <extra-args>` forwards those args to the *root* package's own
+    // final `rustc` invocation only -- never to any dependency's build
+    // script or its own `rustc`/`cc` invocations. `libsqlite3-sys`'s
+    // build script reads `CARGO_CFG_TARGET_FEATURE` (an env var Cargo
+    // populates per-crate from `RUSTFLAGS`/the target's own feature set,
+    // not from another crate's trailing rustc args) to decide `/MT` vs
+    // `/MD` -- it never saw `crt-static` under the previous approach,
+    // so `cl.exe` kept defaulting to `/MD` regardless. `RUSTFLAGS` is a
+    // build-wide environment variable Cargo threads through to *every*
+    // crate's compilation uniformly, which is what actually reaches it.
+    // Appended to, not overwritten -- an outer build that already sets
+    // `RUSTFLAGS` (a custom lint config, say) keeps that intact.
     cmd.arg("--").arg("--print=native-static-libs");
     if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
-        cmd.arg("-C").arg("target-feature=+crt-static");
+        let mut rustflags = std::env::var("RUSTFLAGS").unwrap_or_default();
+        if !rustflags.is_empty() {
+            rustflags.push(' ');
+        }
+        rustflags.push_str("-C target-feature=+crt-static");
+        cmd.env("RUSTFLAGS", rustflags);
     }
     let output = cmd
         .output()

--- a/crates/compiler/src/ast.rs
+++ b/crates/compiler/src/ast.rs
@@ -1110,6 +1110,11 @@ pub enum Effect {
     Concurrent,
     /// `connect`/`listen`/`accept`, `tcp`'s `send`/`recv`/`stop`.
     Network,
+    /// `env` — reads a process environment variable. Unscoped (RFC 0011
+    /// §6: "Decided: `Effect::Env`... unscoped") — kept distinct from
+    /// `Io` because it reads process-local configuration state, not the
+    /// outside world.
+    Env,
 }
 
 impl Effect {
@@ -1119,6 +1124,7 @@ impl Effect {
             Effect::Io => "io",
             Effect::Concurrent => "concurrent",
             Effect::Network => "network",
+            Effect::Env => "env",
         }
     }
 }
@@ -2544,6 +2550,11 @@ pub const BUILTIN_NAMES: &[&str] = &[
     // hand-rolled, per docs/PROTOLANG_PORT.md's std_io §12 stance.
     "https_get",
     "https_post",
+    // rfcs/0011-uniform-service-provider-model.md §1/§2: the `call`-shape
+    // provider dispatch entrypoint -- `http://`/`https://` served by the
+    // same core path as the four builtins above, any other scheme
+    // falling through to a registered `call`-shape plugin at runtime.
+    "call_via",
     // Row 12: identity as a relying party. The runtime validates tokens
     // issued by external IdPs and returns an unforgeable-in-the-type-system
     // VerifiedIdentity. `oidc_validate_token` performs mock OIDC/JWT
@@ -2642,6 +2653,11 @@ pub const BUILTIN_NAMES: &[&str] = &[
     // `mq_connect`'s own hardcoded Redis backend -- see
     // `interpreter.rs`'s "mq_connect_via" arm.
     "mq_connect_via",
+    // RFC 0011 §1/§6: reads a process environment variable.
+    // `env(name: str) -> Result(str, str)` -- `Ok` when set, `Err` when
+    // unset. `Effect::Env`, unscoped (§6: "Decided"). No handle, no
+    // `Domain`, not resource-gated -- unlike `db`/`mq`/`http` above.
+    "env",
     // Row 12's deliberate mock-only exception to "the runtime never
     // mints tokens" -- see its own doc comment at the builtin's typeck
     // signature (`typeck.rs`) for why the `mock_` prefix is load-bearing.

--- a/crates/compiler/src/codegen.rs
+++ b/crates/compiler/src/codegen.rs
@@ -261,6 +261,7 @@ const DEC128_BUILTINS: &[&str] = &["dec_from_i64", "dec_to_str", "dec_round", "d
 const IDENTITY_BUILTINS: &[&str] = &[
     "check_role",
     "oidc_validate_token",
+    "mock_issue_token",
     "extract_claim",
     "identity_expired",
     "check_role_path",
@@ -1746,6 +1747,16 @@ fn emit_llvm_ir_impl<'a>(
     )
     .unwrap();
     writeln!(cg.out, "declare i32 @nir_extract_claim(ptr, i64, ptr, i64, ptr)").unwrap();
+    // `mock_issue_token` (`IDENTITY_BUILTINS`'s own doc comment) — the
+    // inverse of `oidc_validate_token`: signs a token instead of
+    // verifying one, HS256-only, `nir_mock_issue_token`'s own doc comment
+    // has the scope. `out_token`/`out_err` are `{ptr, i64}`-shaped, same
+    // as every other `str`-payload out-param above.
+    writeln!(
+        cg.out,
+        "declare i32 @nir_mock_issue_token(ptr, i64, ptr, i64, ptr, i64, i64, i64, ptr, i64, ptr, i64, ptr, ptr)"
+    )
+    .unwrap();
     // The rest of Row 12 (`docs/nirdosha_row12_functions_identity.md`,
     // `kernel::identity`'s own module doc has the full design): dotted-
     // path claim lookup, sessions, refresh tokens, revocation, API keys.
@@ -2683,6 +2694,9 @@ impl Codegen<'_> {
             }
             Expr::Call(name, _, _) if name == "oidc_validate_token" => {
                 Ty::Named("Result".to_string(), vec![Ty::Named("VerifiedIdentity".to_string(), vec![]), Ty::Str])
+            }
+            Expr::Call(name, _, _) if name == "mock_issue_token" => {
+                Ty::Named("Result".to_string(), vec![Ty::Str, Ty::Str])
             }
             Expr::Call(name, _, _) if name == "extract_claim" => {
                 Ty::Named("Result".to_string(), vec![Ty::Named("ClaimView".to_string(), vec![]), Ty::Str])
@@ -5489,6 +5503,9 @@ impl Codegen<'_> {
         if name == "oidc_validate_token" {
             return self.emit_oidc_validate_token(args, scopes);
         }
+        if name == "mock_issue_token" {
+            return self.emit_mock_issue_token(args, scopes);
+        }
         if name == "extract_claim" {
             return self.emit_extract_claim(args, scopes);
         }
@@ -5785,6 +5802,42 @@ impl Codegen<'_> {
 
         writeln!(self.out, "{merge_label}:").unwrap();
         Ok(dest)
+    }
+
+    /// `mock_issue_token(subject, issuer, audience, issued_at, ttl_secs,
+    /// claims_json, jwks_json) -> Result(str, str)` — the inverse of
+    /// `emit_oidc_validate_token` just above: a single `str` payload, not
+    /// a six-field struct, so this follows `emit_json_get_str`'s simpler
+    /// shape instead (`nir_mock_issue_token`'s own doc comment has the
+    /// real HS256-only scope).
+    fn emit_mock_issue_token(&mut self, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let result_ty = Ty::Named("Result".to_string(), vec![Ty::Str, Ty::Str]);
+        let (subject_ptr, subject_len) = self.str_parts(&args[0], scopes)?;
+        let (issuer_ptr, issuer_len) = self.str_parts(&args[1], scopes)?;
+        let (audience_ptr, audience_len) = self.str_parts(&args[2], scopes)?;
+        let issued_at = self.expr(&args[3], scopes)?;
+        let ttl_secs = self.expr(&args[4], scopes)?;
+        let (claims_ptr, claims_len) = self.str_parts(&args[5], scopes)?;
+        let (jwks_ptr, jwks_len) = self.str_parts(&args[6], scopes)?;
+
+        let token_scratch = self.fresh_reg("mock_issue_token_value_scratch");
+        self.emit_alloca(&token_scratch, "{ptr, i64}");
+        let err_scratch = self.fresh_reg("mock_issue_token_err_scratch");
+        self.emit_alloca(&err_scratch, "{ptr, i64}");
+        let found = self.fresh_reg("mock_issue_token_ok");
+        writeln!(
+            self.out,
+            "  {found} = call i32 @nir_mock_issue_token(ptr {subject_ptr}, i64 {subject_len}, ptr {issuer_ptr}, i64 {issuer_len}, \
+             ptr {audience_ptr}, i64 {audience_len}, i64 {issued_at}, i64 {ttl_secs}, ptr {claims_ptr}, i64 {claims_len}, \
+             ptr {jwks_ptr}, i64 {jwks_len}, ptr {token_scratch}, ptr {err_scratch})"
+        )
+        .unwrap();
+        let is_ok = self.icmp("ne", "i32", &found, "0")?;
+        let token_val = self.fresh_reg("mock_issue_token_value");
+        writeln!(self.out, "  {token_val} = load {{ptr, i64}}, ptr {token_scratch}").unwrap();
+        let err_val = self.fresh_reg("mock_issue_token_err_val");
+        writeln!(self.out, "  {err_val} = load {{ptr, i64}}, ptr {err_scratch}").unwrap();
+        self.emit_result_merge(&result_ty, &is_ok, "{ptr, i64}", &token_val, &err_val, "mock_issue_token")
     }
 
     /// `extract_claim(identity, name) -> Result(ClaimView, str)` — real

--- a/crates/compiler/src/codegen.rs
+++ b/crates/compiler/src/codegen.rs
@@ -10026,18 +10026,24 @@ fn build_impl(
             }
         }
     }
-    // Excludes the static CRT (`libcmt.lib`) clang would otherwise
-    // default to for this bare `.ll`/staticlib link, so the dynamic one
-    // `/defaultlib:msvcrt` above actually names wins outright instead of
-    // the two conflicting (`LNK4098`) and leaving `bundled` SQLite's
-    // `_beginthreadex`/`realloc`/`strcspn`/`strspn` unresolved either way
-    // — found on real Windows CI across two prior wrong turns in this
-    // same spot: dropping `/defaultlib:msvcrt` outright, then separately
-    // trying `/NODEFAULTLIB:MSVCRT` (excluding the library that's
-    // actually needed, not the one in the way) — both left the identical
-    // six symbols unresolved, proving neither was ever the real fix.
-    #[cfg(windows)]
-    clang_cmd.arg("-Xlinker").arg("/NODEFAULTLIB:LIBCMT");
+    // No `/NODEFAULTLIB:<X>` here, after three real wrong turns in this
+    // exact spot each fixing one missing-symbol set by excluding a
+    // library the *other* half of the link needed (`msvcrt` dropped
+    // outright, `/NODEFAULTLIB:MSVCRT`, `/NODEFAULTLIB:LIBCMT` — this
+    // last one traded `bundled` SQLite's unresolved externals for a
+    // freshly-unresolved `printf` from `codegen.rs`'s own generated
+    // `nir_main`). The actual root cause: `codegen.rs`'s plain
+    // (non-`dllimport`) `declare`s for libc functions structurally
+    // expect the *static* CRT, while `cc`-crate-compiled C code
+    // (`bundled` SQLite) defaults to the *dynamic* one — no
+    // `-Xlinker` flag on this side of the link can reconcile two
+    // objects built expecting different CRT models. `build.rs` fixes it
+    // at the source instead: `-C target-feature=+crt-static` on the
+    // nested `cargo rustc` build makes both `rustc`'s own generated code
+    // and (via the `cc` crate's own `CARGO_CFG_TARGET_FEATURE` check,
+    // switching `cl.exe` from `/MD` to `/MT`) SQLite's compiled object
+    // agree on the static CRT throughout — see that flag's own doc
+    // comment for the full story.
     let result = clang_cmd.arg("-o").arg(output_path).output();
     let _ = std::fs::remove_file(&ll_path); // best-effort cleanup either way
     let _ = std::fs::remove_file(&runtime_lib_path);

--- a/crates/compiler/src/codegen.rs
+++ b/crates/compiler/src/codegen.rs
@@ -9978,22 +9978,21 @@ fn build_impl(
     // entirely and does reach the linker's search path — so each
     // `foo.lib` token here is stripped to `foo` and passed as `-lfoo`
     // instead. rustc's list also has at least one token that isn't
-    // `.lib`-suffixed at all (`/defaultlib:msvcrt`) -- originally
-    // forwarded verbatim via `-Xlinker` on the theory that any raw linker
-    // flag rustc names must be needed, the same reason `-l` works for the
-    // others. **That theory turned out to be wrong for this specific
-    // flag**, found by a real third Windows CI failure once the first two
-    // were fixed: forcing the legacy, pre-UCRT `msvcrt` C runtime
-    // conflicts with `bundled` SQLite's real compiled C code (`sqlite3.o`,
-    // built expecting the modern UCRT/`vcruntime` split clang already
-    // links by default) -- `LNK4098`/multiple `LNK4217` "conflicts with
-    // use of other libs" warnings, then real `LNK2019` unresolved
-    // externals (`__imp_realloc`, `__imp_strcspn`, `__imp__beginthreadex`,
-    // ...) that clang's own default CRT choice would have resolved fine
-    // without this override. Every `/defaultlib:` token is dropped for
-    // exactly this reason -- clang already picks the correct default CRT
-    // for its own target, and forcing a different one is what breaks
-    // linking real C code, not something that could ever fix it.
+    // `.lib`-suffixed at all (`/defaultlib:msvcrt`) — forwarded verbatim
+    // via `-Xlinker`, the same reason `-l` works for the others: `msvcrt`
+    // (the *dynamic* CRT import lib, still the current, non-deprecated
+    // name in every post-2015 MSVC toolchain — not a "legacy" runtime, a
+    // theory a previous version of this comment wrongly asserted after
+    // a real Windows CI failure and then had to walk back after dropping
+    // it made the *same* unresolved symbols persist) is exactly what
+    // `bundled` SQLite's own compiled C code (`sqlite3.o`) needs for
+    // `_beginthreadex`/`_endthreadex`/`realloc`/`strcspn`/`strspn` — none
+    // of those live in `ucrt.lib` alone. The real conflict
+    // (`LNK4098: defaultlib 'msvcrt' conflicts with use of other libs`)
+    // is with clang's own *static*-CRT default (`libcmt.lib`) for a bare
+    // `.ll`/staticlib link with no explicit runtime flag — `libcmt` is
+    // excluded below so `msvcrt` (forwarded here) wins outright instead
+    // of the two fighting.
     // A handful of tokens above aren't genuine system-provided libs at
     // all — a crate-private import lib like `windows.0.52.0.lib` (the
     // `windows`/`windows-sys` family, at least) ships inside that crate's
@@ -10023,30 +10022,22 @@ fn build_impl(
                 }
             }
             None => {
-                if !token.to_ascii_lowercase().starts_with("/defaultlib:") {
-                    clang_cmd.arg("-Xlinker").arg(token);
-                }
+                clang_cmd.arg("-Xlinker").arg(token);
             }
         }
     }
-    // Dropping the `/defaultlib:msvcrt` *token* above wasn't the whole
-    // fix — found on real Windows CI, a real fourth failure in this same
-    // thread, identical `LNK4098`/`LNK2019` symptoms with the conflicting
-    // library now spelled `MSVCRT` (uppercase). That's the linker's own
-    // case-normalized name for a `/DEFAULTLIB:` directive embedded
-    // *inside one of the linked object files themselves* (an ordinary
-    // MSVC/`cl.exe` convention — a `.obj`/`.lib` can carry its own
-    // default-library preference, independent of anything on the command
-    // line), not something `NATIVE_STATIC_LIBS`/our own token list ever
-    // controlled at all. `bundled` SQLite's own compiled object is the
-    // most likely source (compiled by `cc`/`cl.exe` under whatever CRT
-    // linkage it defaults to on this toolchain), but the exact origin
-    // doesn't matter — the fix is the same one the linker's own `LNK4098`
-    // warning already names: explicitly tell it to ignore that embedded
-    // preference, the same way an explicit command-line `/defaultlib:`
-    // would have needed dropping if it *had* been the cause.
+    // Excludes the static CRT (`libcmt.lib`) clang would otherwise
+    // default to for this bare `.ll`/staticlib link, so the dynamic one
+    // `/defaultlib:msvcrt` above actually names wins outright instead of
+    // the two conflicting (`LNK4098`) and leaving `bundled` SQLite's
+    // `_beginthreadex`/`realloc`/`strcspn`/`strspn` unresolved either way
+    // — found on real Windows CI across two prior wrong turns in this
+    // same spot: dropping `/defaultlib:msvcrt` outright, then separately
+    // trying `/NODEFAULTLIB:MSVCRT` (excluding the library that's
+    // actually needed, not the one in the way) — both left the identical
+    // six symbols unresolved, proving neither was ever the real fix.
     #[cfg(windows)]
-    clang_cmd.arg("-Xlinker").arg("/NODEFAULTLIB:MSVCRT");
+    clang_cmd.arg("-Xlinker").arg("/NODEFAULTLIB:LIBCMT");
     let result = clang_cmd.arg("-o").arg(output_path).output();
     let _ = std::fs::remove_file(&ll_path); // best-effort cleanup either way
     let _ = std::fs::remove_file(&runtime_lib_path);

--- a/crates/compiler/src/codegen.rs
+++ b/crates/compiler/src/codegen.rs
@@ -282,6 +282,11 @@ const IDENTITY_BUILTINS: &[&str] = &[
 /// not silently dropped.
 const DB_BUILTINS: &[&str] = &["db_connect", "db_query", "db_execute"];
 
+/// `env` (RFC 0011 §1) — reads a process environment variable via
+/// `nir_env_get`. Not resource-gated: no `Domain`, no handle, no pool —
+/// unlike `DB_BUILTINS` right above.
+const ENV_BUILTINS: &[&str] = &["env"];
+
 /// `json_parse`/`json_get`/`json_get_str`/`json_get_i64`/`json_get_f64`/
 /// `json_get_bool`/`json_array_get`/`json_array_len`/`json_set_str` —
 /// real JSON navigation (`Ty::Json`'s own doc comment). Compiles
@@ -306,6 +311,17 @@ const MQ_BUILTINS: &[&str] = &["mq_connect", "mq_publish", "mq_consume"];
 /// struct, and every call here is a one-shot request/response, never a
 /// persisted connection handle.
 const HTTP_BUILTINS: &[&str] = &["http_get", "http_post", "https_get", "https_post"];
+
+/// `call_via` — rfcs/0011-uniform-service-provider-model.md §1/§2's
+/// `call`-shape provider dispatch entrypoint. Kept as its own const
+/// list, not folded into `HTTP_BUILTINS` above, since it isn't a fixed
+/// core-HTTP call the way those four are: `http://`/`https://` sniff
+/// straight through to the same core path, but any other scheme
+/// resolves at runtime against the plugin-provider table
+/// (`kernel::plugin_provider`) — a real, disclosed dispatch difference
+/// worth its own named list even though `emit_call_via`'s own codegen
+/// shape mirrors `emit_http_call`'s closely.
+const CALL_BUILTINS: &[&str] = &["call_via"];
 
 /// `workflow` Layer 1 (`docs/WORKFLOW.md`) — every builtin
 /// `workflow_lower.rs` desugars a `workflow` block's synthesized
@@ -1122,10 +1138,12 @@ fn check_expr(e: &Expr, plugin_names: &std::collections::HashSet<String>, regist
                 && !DEC128_BUILTINS.contains(&name.as_str())
                 && !IDENTITY_BUILTINS.contains(&name.as_str())
                 && !DB_BUILTINS.contains(&name.as_str())
+                && !ENV_BUILTINS.contains(&name.as_str())
                 && !JSON_BUILTINS.contains(&name.as_str())
                 && !SLEEP_BUILTINS.contains(&name.as_str())
                 && !MQ_BUILTINS.contains(&name.as_str())
                 && !HTTP_BUILTINS.contains(&name.as_str())
+                && !CALL_BUILTINS.contains(&name.as_str())
                 && !WORKFLOW_BUILTINS.contains(&name.as_str())
                 && !NOTIFY_BUILTINS.contains(&name.as_str())
             {
@@ -1560,6 +1578,9 @@ pub fn emit_llvm_ir_with_native_plugins<'a>(
             return unsupported(msg);
         }
     }
+    if let Err(msg) = crate::plugin::validate_plugin_roster(native_plugins) {
+        return unsupported(msg);
+    }
     emit_llvm_ir_impl(program, smt_report, native_plugins, reject_plugin_names)
 }
 
@@ -1789,6 +1810,10 @@ fn emit_llvm_ir_impl<'a>(
     writeln!(cg.out, "declare i32 @nir_json_get_f64(ptr, i64, ptr, i64, ptr, ptr)").unwrap();
     writeln!(cg.out, "declare i32 @nir_json_get_bool(ptr, i64, ptr, i64, ptr, ptr)").unwrap();
     writeln!(cg.out, "declare i32 @nir_json_set_str(ptr, i64, ptr, i64, ptr, i64, ptr, ptr)").unwrap();
+    // `env` (`ENV_BUILTINS`'s own doc comment, RFC 0011 §1) — reads a
+    // process environment variable. Not resource-gated (no `Domain`, no
+    // handle) — same reason `nir_json_get_str` isn't either.
+    writeln!(cg.out, "declare i32 @nir_env_get(ptr, i64, ptr, ptr)").unwrap();
     // `transact { ... }` (`docs/TRANSACT.md`, `Codegen::emit_transact`'s
     // own doc comment has the compiled-backend scope). `txn_id`'s real
     // implementation; `sleep_ms`, ordinary compiled `sleep_ms(ms)` (`B9`).
@@ -1818,6 +1843,12 @@ fn emit_llvm_ir_impl<'a>(
     writeln!(cg.out, "declare i32 @nir_http_post(ptr, i64, i64, ptr, i64, ptr, i64, ptr, ptr, ptr)").unwrap();
     writeln!(cg.out, "declare i32 @nir_https_get(ptr, i64, i64, ptr, i64, ptr, ptr, ptr)").unwrap();
     writeln!(cg.out, "declare i32 @nir_https_post(ptr, i64, i64, ptr, i64, ptr, i64, ptr, ptr, ptr)").unwrap();
+    // rfcs/0011-uniform-service-provider-model.md §1/§2's `call`-shape
+    // dispatch entrypoint (`CALL_BUILTINS`'s own doc comment) —
+    // `(url_ptr, url_len, path_ptr, path_len, body_ptr, body_len,
+    // out_status, out_body, out_err)`, `emit_call_via`'s own shape below
+    // mirrors `emit_http_call`'s `nir_http_post`-style call closely.
+    writeln!(cg.out, "declare i32 @nir_call_via(ptr, i64, ptr, i64, ptr, i64, ptr, ptr, ptr)").unwrap();
     // `workflow` Layer 1 (`docs/WORKFLOW.md`, `Codegen::emit_workflow_start`'s
     // own doc comment has the full scope) — the in-memory instance
     // table, SLA/escalation detection, and the four notification
@@ -1835,6 +1866,37 @@ fn emit_llvm_ir_impl<'a>(
     // in `ast::BUILTIN_NAMES` at all — there is no `Expr` that lowers to
     // a `call` to this).
     writeln!(cg.out, "declare void @nir_kernel_flight_recorder_dump()").unwrap();
+    // RFC 0011 §3's open domain registry bootstrap — `emit_c_main` emits
+    // exactly one call to this, at the very top of `main`, strictly
+    // before any user code, so the 7 built-in domains get their
+    // historical, stable ids 0-6. This declare, like the one above,
+    // carries zero knowledge of the built-in domain set or its order —
+    // that's `runtime-kernels`'s own `BUILTIN_DOMAINS` array, the only
+    // place that order is written down.
+    writeln!(cg.out, "declare void @nir_kernel_register_builtin_domains()").unwrap();
+    writeln!(cg.out, "declare void @nir_kernel_register_domain(ptr, i64, ptr, i64, i64)").unwrap();
+    // RFC 0011 §2/§4's plugin-provider dispatch table registration —
+    // `domain_name` matches the immediately-preceding `nir_kernel_
+    // register_domain` call's own `name` argument exactly (the kernel
+    // looks up that already-registered `DomainId` by name rather than
+    // re-deriving it), `scheme` is the compiler's own already-normalized
+    // scheme identifier (`plugin::normalize_scheme`'s output, not the
+    // raw declared scheme text). The four trailing `ptr`s are the
+    // provider's own function addresses, taken directly from the global
+    // symbols this file already `declare`s for every native plugin
+    // builtin (just below) — opaque `ptr`s here since their *real* LLVM
+    // signatures differ per shape (`_op`'s one `str` arg vs `_request`'s
+    // two); `is_call_shape` tells the kernel which one it's holding, so
+    // it can transmute it back to the correct `extern "C" fn` type on
+    // its own side rather than this call needing two mutually-exclusive
+    // parameters.
+    writeln!(cg.out, "declare void @nir_kernel_register_plugin_provider(ptr, i64, ptr, i64, ptr, ptr, ptr, ptr, i32)").unwrap();
+    // RFC 0011 §5's reaper bootstrap — `emit_c_main` emits exactly one
+    // call to this, immediately after the registration calls above,
+    // still strictly before any user code runs. Carries no arguments;
+    // `kernel::reaper::start` reads its own interval from
+    // `NIRDOSHA_KERNEL_REAPER_INTERVAL_SECS` on the kernel side.
+    writeln!(cg.out, "declare void @nir_kernel_start_reaper()").unwrap();
     // "%lld\n\0" — 6 bytes (%, l, l, d, \n, \0), not 5; LLVM's array
     // constant size has to match the literal exactly, byte for byte.
     writeln!(cg.out, "@.int_fmt = private unnamed_addr constant [6 x i8] c\"%lld\\0A\\00\"").unwrap();
@@ -1886,7 +1948,7 @@ fn emit_llvm_ir_impl<'a>(
         cg.function(f)?;
     }
 
-    cg.emit_c_main(program)?;
+    cg.emit_c_main(program, native_plugins)?;
     // See `string_globals`'s own doc — every `str` literal's backing
     // global constant, collected during function codegen since it can't
     // be written mid-function-body, appended here once at the end.
@@ -2721,6 +2783,13 @@ impl Codegen<'_> {
             Expr::Call(name, _, _) if name == "db_connect" => {
                 Ty::Named("Result".to_string(), vec![Ty::Db, Ty::Str])
             }
+            // RFC 0011 §1 -- same `Result(str, str)` shape as `json_get_str`
+            // below; needed here (not just in `emit_env`'s own dispatch)
+            // so a `match env(...)` scrutinee is correctly routed through
+            // the aggregate (`expr_ptr`) codegen path instead of falling
+            // through to `fn call`'s scalar-only dispatch and hitting its
+            // "typeck.rs already resolved this call" `expect` panic.
+            Expr::Call(name, _, _) if name == "env" => Ty::Named("Result".to_string(), vec![Ty::Str, Ty::Str]),
             Expr::Call(name, _, _) if name == "db_execute" => {
                 Ty::Named("Result".to_string(), vec![Ty::I64, Ty::Str])
             }
@@ -2754,7 +2823,9 @@ impl Codegen<'_> {
             Expr::Call(name, _, _) if name == "mq_consume" => {
                 Ty::Named("Result".to_string(), vec![Ty::Str, Ty::Str])
             }
-            Expr::Call(name, _, _) if name == "http_get" || name == "http_post" || name == "https_get" || name == "https_post" => {
+            Expr::Call(name, _, _)
+                if name == "http_get" || name == "http_post" || name == "https_get" || name == "https_post" || name == "call_via" =>
+            {
                 Ty::Named("Result".to_string(), vec![Ty::Named("HttpResponse".to_string(), vec![]), Ty::Str])
             }
             // `workflow` Layer 1 (`WORKFLOW_BUILTINS`/`NOTIFY_BUILTINS`'
@@ -5536,6 +5607,9 @@ impl Codegen<'_> {
         if name == "db_connect" {
             return self.emit_db_connect(args, scopes);
         }
+        if name == "env" {
+            return self.emit_env(args, scopes);
+        }
         if name == "db_execute" {
             return self.emit_db_execute(args, scopes);
         }
@@ -5589,6 +5663,9 @@ impl Codegen<'_> {
         }
         if name == "https_post" {
             return self.emit_http_call("nir_https_post", args, true, scopes);
+        }
+        if name == "call_via" {
+            return self.emit_call_via(args, scopes);
         }
         if name == "__workflow_start" {
             return self.emit_workflow_start(args, scopes);
@@ -6435,6 +6512,37 @@ impl Codegen<'_> {
     }
 
     /// `db_connect(path) -> Result(db, str)`.
+    /// `env(name) -> Result(str, str)` (RFC 0011 §1) — `Ok(value)` when
+    /// the process environment variable is set, `Err(_)` when unset. Not
+    /// resource-gated: no `Domain`, no handle, unlike `db_connect` right
+    /// below — same shape as `emit_json_get_str`, just one `str` arg
+    /// instead of two.
+    fn emit_env(&mut self, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let result_ty = Ty::Named("Result".to_string(), vec![Ty::Str, Ty::Str]);
+        let (name_ptr, name_len) = self.str_parts(&args[0], scopes)?;
+        let value_scratch = self.fresh_reg("env_value_scratch");
+        self.emit_alloca(&value_scratch, "{ptr, i64}");
+        let err_scratch = self.fresh_reg("env_err_scratch");
+        self.emit_alloca(&err_scratch, "{ptr, i64}");
+        // Named `env_found`, not `env_ok` -- `emit_result_merge`'s own
+        // `label_prefix` below is `"env"`, which mints labels literally
+        // named `env_ok`/`env_err`/`env_merge`. `fresh_reg`/`fresh_label`
+        // keep separate counters, so a register also named `env_ok` can
+        // land on the same numeric suffix as the label on a second call
+        // to `env(...)` in the same function -- `%env_ok.9` bound once as
+        // an `i32` value and again as a branch target is a genuine LLVM
+        // parse error ("not a basic block"), caught by compiling a
+        // program with two `env(...)` calls, not by the single-call case.
+        let found = self.fresh_reg("env_found");
+        writeln!(self.out, "  {found} = call i32 @nir_env_get(ptr {name_ptr}, i64 {name_len}, ptr {value_scratch}, ptr {err_scratch})").unwrap();
+        let is_ok = self.icmp("ne", "i32", &found, "0")?;
+        let value_val = self.fresh_reg("env_value");
+        writeln!(self.out, "  {value_val} = load {{ptr, i64}}, ptr {value_scratch}").unwrap();
+        let err_val = self.fresh_reg("env_err_val");
+        writeln!(self.out, "  {err_val} = load {{ptr, i64}}, ptr {err_scratch}").unwrap();
+        self.emit_result_merge(&result_ty, &is_ok, "{ptr, i64}", &value_val, &err_val, "env")
+    }
+
     fn emit_db_connect(&mut self, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
         let result_ty = Ty::Named("Result".to_string(), vec![Ty::Db, Ty::Str]);
         let (path_ptr, path_len) = self.str_parts(&args[0], scopes)?;
@@ -6819,6 +6927,88 @@ impl Codegen<'_> {
         let ok_label = self.fresh_label("http_ok");
         let err_label = self.fresh_label("http_err");
         let merge_label = self.fresh_label("http_merge");
+        writeln!(self.out, "  br i1 {is_ok}, label %{ok_label}, label %{err_label}").unwrap();
+
+        writeln!(self.out, "{ok_label}:").unwrap();
+        writeln!(self.out, "  store i64 0, ptr {tag_ptr}").unwrap();
+        let http_bytes = agg_byte_size_operand(&http_response_ty, &self.registry);
+        writeln!(self.out, "  call void @llvm.memcpy.p0.p0.i64(ptr {payload_ptr}, ptr {http_scratch}, i64 {http_bytes}, i1 false)").unwrap();
+        writeln!(self.out, "  br label %{merge_label}").unwrap();
+
+        writeln!(self.out, "{err_label}:").unwrap();
+        writeln!(self.out, "  store i64 1, ptr {tag_ptr}").unwrap();
+        writeln!(self.out, "  store {{ptr, i64}} {err_val}, ptr {payload_ptr}").unwrap();
+        writeln!(self.out, "  br label %{merge_label}").unwrap();
+
+        writeln!(self.out, "{merge_label}:").unwrap();
+        Ok(dest)
+    }
+
+    /// `call_via(url, path, body) -> Result(HttpResponse, str)` —
+    /// rfcs/0011-uniform-service-provider-model.md §1/§2's `call`-shape
+    /// dispatch entrypoint. Structurally the same result-merge shape as
+    /// [`Codegen::emit_http_call`] (same `HttpResponse`/`Result` layout,
+    /// same ok/err/merge label pattern) — kept as its own function
+    /// rather than folded into `emit_http_call` because the call-site
+    /// argument shape genuinely differs (`(url, path, body)`, no
+    /// separate `host`/`port`, and always exactly 3 args — `call_via`
+    /// has no bodyless-GET-shaped sibling the way `http_get`/`http_post`
+    /// do).
+    fn emit_call_via(&mut self, args: &[Expr], scopes: &mut Scopes) -> Result<String, CodegenError> {
+        let http_response_ty = Ty::Named("HttpResponse".to_string(), vec![]);
+        let result_ty = Ty::Named("Result".to_string(), vec![http_response_ty.clone(), Ty::Str]);
+
+        let (url_ptr, url_len) = self.str_parts(&args[0], scopes)?;
+        let (path_ptr, path_len) = self.str_parts(&args[1], scopes)?;
+        let (body_ptr, body_len) = self.str_parts(&args[2], scopes)?;
+
+        let status_scratch = self.fresh_reg("call_via_status_scratch");
+        self.emit_alloca(&status_scratch, "i64");
+        let body_scratch = self.fresh_reg("call_via_body_scratch");
+        self.emit_alloca(&body_scratch, "{ptr, i64}");
+        let err_scratch = self.fresh_reg("call_via_err_scratch");
+        self.emit_alloca(&err_scratch, "{ptr, i64}");
+
+        let found = self.fresh_reg("call_via_ok");
+        writeln!(
+            self.out,
+            "  {found} = call i32 @nir_call_via(ptr {url_ptr}, i64 {url_len}, ptr {path_ptr}, i64 {path_len}, \
+             ptr {body_ptr}, i64 {body_len}, ptr {status_scratch}, ptr {body_scratch}, ptr {err_scratch})"
+        )
+        .unwrap();
+        let is_ok = self.icmp("ne", "i32", &found, "0")?;
+
+        let http_llty = self.llvm_ty(&http_response_ty)?;
+        let http_scratch = self.fresh_reg("call_via_response_scratch");
+        self.emit_alloca(&http_scratch, &http_llty);
+        let (status_idx, _) =
+            self.field_index_and_ty(&http_response_ty, "status").expect("HttpResponse always has status, ast::prelude_structs");
+        let (body_idx, _) = self.field_index_and_ty(&http_response_ty, "body").expect("HttpResponse always has body, ast::prelude_structs");
+        let status_field_ptr = self.fresh_reg("call_via_status_field_ptr");
+        writeln!(self.out, "  {status_field_ptr} = getelementptr inbounds {http_llty}, ptr {http_scratch}, i32 0, i32 {status_idx}").unwrap();
+        let status_val = self.fresh_reg("call_via_status_val");
+        writeln!(self.out, "  {status_val} = load i64, ptr {status_scratch}").unwrap();
+        writeln!(self.out, "  store i64 {status_val}, ptr {status_field_ptr}").unwrap();
+        let body_field_ptr = self.fresh_reg("call_via_body_field_ptr");
+        writeln!(self.out, "  {body_field_ptr} = getelementptr inbounds {http_llty}, ptr {http_scratch}, i32 0, i32 {body_idx}").unwrap();
+        let body_val = self.fresh_reg("call_via_body_val");
+        writeln!(self.out, "  {body_val} = load {{ptr, i64}}, ptr {body_scratch}").unwrap();
+        writeln!(self.out, "  store {{ptr, i64}} {body_val}, ptr {body_field_ptr}").unwrap();
+
+        let err_val = self.fresh_reg("call_via_err_val");
+        writeln!(self.out, "  {err_val} = load {{ptr, i64}}, ptr {err_scratch}").unwrap();
+
+        let result_llty = self.llvm_ty(&result_ty)?;
+        let dest = self.fresh_reg("call_via_result_addr");
+        self.emit_alloca(&dest, &result_llty);
+        let tag_ptr = self.fresh_reg("call_via_tag_ptr");
+        writeln!(self.out, "  {tag_ptr} = getelementptr inbounds {result_llty}, ptr {dest}, i32 0, i32 0").unwrap();
+        let payload_ptr = self.fresh_reg("call_via_payload_ptr");
+        writeln!(self.out, "  {payload_ptr} = getelementptr inbounds {result_llty}, ptr {dest}, i32 0, i32 1").unwrap();
+
+        let ok_label = self.fresh_label("call_via_ok");
+        let err_label = self.fresh_label("call_via_err");
+        let merge_label = self.fresh_label("call_via_merge");
         writeln!(self.out, "  br i1 {is_ok}, label %{ok_label}, label %{err_label}").unwrap();
 
         writeln!(self.out, "{ok_label}:").unwrap();
@@ -9614,7 +9804,7 @@ impl Codegen<'_> {
     /// one truncates/extends its result to `i32`, the same "the returned
     /// value is the program's result" convention `main.rs`'s CLI already
     /// uses for the interpreter.
-    fn emit_c_main(&mut self, program: &Program) -> Result<(), CodegenError> {
+    fn emit_c_main(&mut self, program: &Program, native_plugins: &[crate::plugin::NativePluginBuiltin]) -> Result<(), CodegenError> {
         let main_fn = program.fns.iter().find(|f| f.name == "main").expect("typeck.rs already required a main");
         if main_fn.ret.is_aggregate() {
             // There's no sensible "exit code" for a raw Vector/Matrix
@@ -9633,6 +9823,77 @@ impl Codegen<'_> {
         }
         writeln!(self.out, "define i32 @main() {{").unwrap();
         writeln!(self.out, "entry:").unwrap();
+        // RFC 0011 §3's open domain registry bootstrap — strictly first,
+        // before durability/transact replay and `nfr` registration below,
+        // so every built-in domain accessor (`domain::db()`, etc.) any of
+        // that setup might reach is already resolved to a stable id.
+        writeln!(self.out, "  call void @nir_kernel_register_builtin_domains()").unwrap();
+        // RFC 0011 §4's per-provider registration: one `nir_kernel_
+        // register_domain(...)` call per distinct validated plugin
+        // provider in `native_plugins`, in the order given, immediately
+        // after the built-in bootstrap call above and still strictly
+        // before any user code runs. A provider's identity is
+        // self-describing (its own normalized scheme), so — unlike the
+        // built-ins' fixed 0-6 order — there's no positional-order
+        // drift risk here to worry about; codegen just walks the list
+        // it was given.
+        let native_plugin_names: std::collections::HashSet<&str> = native_plugins.iter().map(|p| p.name.as_str()).collect();
+        for np in native_plugins {
+            let Some((shape, scheme)) = crate::plugin::provider_shape_and_scheme(&np.name) else { continue };
+            let domain_name = format!("{shape}_provider_{scheme}");
+            let env_var = np.env_var.map(str::to_string).unwrap_or_else(|| format!("NIRDOSHA_KERNEL_MAX_{}_{}", shape.to_ascii_uppercase(), scheme.to_ascii_uppercase()));
+            let default_max = np.default_max.unwrap_or(10_000);
+
+            let name_global = self.fresh_global("plugin_domain_name");
+            writeln!(self.string_globals, "{name_global} = private unnamed_addr constant [{} x i8] c\"{}\"", domain_name.len(), llvm_escape_bytes(domain_name.as_bytes())).unwrap();
+            let env_var_global = self.fresh_global("plugin_domain_env_var");
+            writeln!(self.string_globals, "{env_var_global} = private unnamed_addr constant [{} x i8] c\"{}\"", env_var.len(), llvm_escape_bytes(env_var.as_bytes())).unwrap();
+
+            writeln!(
+                self.out,
+                "  call void @nir_kernel_register_domain(ptr {name_global}, i64 {}, ptr {env_var_global}, i64 {}, i64 {default_max})",
+                domain_name.len(),
+                env_var.len(),
+            )
+            .unwrap();
+
+            // RFC 0011 §2/§4: the dispatch-table registration, right
+            // after this same provider's domain registration above.
+            // `validate_plugin_roster` (Phase 3) already proved exactly
+            // one of `_op`/`_request` exists for this `_connect` — same
+            // "shape isn't a separate declared field, inferred from
+            // which sibling is present" rule, re-applied here rather
+            // than threaded through as new state.
+            let prefix = np.name.trim_end_matches("_connect");
+            let op_name = format!("{prefix}_op");
+            let request_name = format!("{prefix}_request");
+            let is_valid_name = format!("{prefix}_is_valid");
+            let close_name = format!("{prefix}_close");
+            let (op_or_request_name, is_call_shape) = if native_plugin_names.contains(request_name.as_str()) {
+                (request_name.as_str(), 1)
+            } else {
+                (op_name.as_str(), 0)
+            };
+
+            let scheme_global = self.fresh_global("plugin_scheme");
+            writeln!(self.string_globals, "{scheme_global} = private unnamed_addr constant [{} x i8] c\"{}\"", scheme.len(), llvm_escape_bytes(scheme.as_bytes())).unwrap();
+
+            writeln!(
+                self.out,
+                "  call void @nir_kernel_register_plugin_provider(ptr {name_global}, i64 {}, ptr {scheme_global}, i64 {}, ptr @{}, ptr @{op_or_request_name}, ptr @{is_valid_name}, ptr @{close_name}, i32 {is_call_shape})",
+                domain_name.len(),
+                scheme.len(),
+                np.name,
+            )
+            .unwrap();
+        }
+        // RFC 0011 §5's reaper — one call, after every domain/plugin-
+        // provider registration above (so a pool-backed registry that
+        // self-registers with the reaper on first use, e.g.
+        // `db.rs`/`http.rs`/`plugin_provider.rs`'s own registries, has
+        // whatever it needs already resolved), still strictly before any
+        // user code runs.
+        writeln!(self.out, "  call void @nir_kernel_start_reaper()").unwrap();
         // Durability log init + crash replay — strictly before any user
         // code (including `nfr` registration, harmless either order, but
         // definitely before `nir_main`) runs, and strictly after every

--- a/crates/compiler/src/codegen.rs
+++ b/crates/compiler/src/codegen.rs
@@ -9925,10 +9925,22 @@ fn build_impl(
     // entirely and does reach the linker's search path — so each
     // `foo.lib` token here is stripped to `foo` and passed as `-lfoo`
     // instead. rustc's list also has at least one token that isn't
-    // `.lib`-suffixed at all (`/defaultlib:msvcrt`, already a raw linker
-    // flag) — that one is forwarded verbatim via `-Xlinker`, which routes
-    // it straight to the linker unexamined, the same reason `-l` works
-    // for the others.
+    // `.lib`-suffixed at all (`/defaultlib:msvcrt`) -- originally
+    // forwarded verbatim via `-Xlinker` on the theory that any raw linker
+    // flag rustc names must be needed, the same reason `-l` works for the
+    // others. **That theory turned out to be wrong for this specific
+    // flag**, found by a real third Windows CI failure once the first two
+    // were fixed: forcing the legacy, pre-UCRT `msvcrt` C runtime
+    // conflicts with `bundled` SQLite's real compiled C code (`sqlite3.o`,
+    // built expecting the modern UCRT/`vcruntime` split clang already
+    // links by default) -- `LNK4098`/multiple `LNK4217` "conflicts with
+    // use of other libs" warnings, then real `LNK2019` unresolved
+    // externals (`__imp_realloc`, `__imp_strcspn`, `__imp__beginthreadex`,
+    // ...) that clang's own default CRT choice would have resolved fine
+    // without this override. Every `/defaultlib:` token is dropped for
+    // exactly this reason -- clang already picks the correct default CRT
+    // for its own target, and forcing a different one is what breaks
+    // linking real C code, not something that could ever fix it.
     // A handful of tokens above aren't genuine system-provided libs at
     // all — a crate-private import lib like `windows.0.52.0.lib` (the
     // `windows`/`windows-sys` family, at least) ships inside that crate's
@@ -9958,7 +9970,9 @@ fn build_impl(
                 }
             }
             None => {
-                clang_cmd.arg("-Xlinker").arg(token);
+                if !token.to_ascii_lowercase().starts_with("/defaultlib:") {
+                    clang_cmd.arg("-Xlinker").arg(token);
+                }
             }
         }
     }

--- a/crates/compiler/src/codegen.rs
+++ b/crates/compiler/src/codegen.rs
@@ -9977,22 +9977,22 @@ fn build_impl(
     // ordinary, cross-target library flag) skips that preflight check
     // entirely and does reach the linker's search path — so each
     // `foo.lib` token here is stripped to `foo` and passed as `-lfoo`
-    // instead. rustc's list also has at least one token that isn't
-    // `.lib`-suffixed at all (`/defaultlib:msvcrt`) — forwarded verbatim
-    // via `-Xlinker`, the same reason `-l` works for the others: `msvcrt`
-    // (the *dynamic* CRT import lib, still the current, non-deprecated
-    // name in every post-2015 MSVC toolchain — not a "legacy" runtime, a
-    // theory a previous version of this comment wrongly asserted after
-    // a real Windows CI failure and then had to walk back after dropping
-    // it made the *same* unresolved symbols persist) is exactly what
-    // `bundled` SQLite's own compiled C code (`sqlite3.o`) needs for
-    // `_beginthreadex`/`_endthreadex`/`realloc`/`strcspn`/`strspn` — none
-    // of those live in `ucrt.lib` alone. The real conflict
-    // (`LNK4098: defaultlib 'msvcrt' conflicts with use of other libs`)
-    // is with clang's own *static*-CRT default (`libcmt.lib`) for a bare
-    // `.ll`/staticlib link with no explicit runtime flag — `libcmt` is
-    // excluded below so `msvcrt` (forwarded here) wins outright instead
-    // of the two fighting.
+    // instead. A non-`.lib` token (e.g. `/defaultlib:...`, on a
+    // dynamic-CRT build) is forwarded verbatim via `-Xlinker` instead,
+    // the same reason `-l` works for the others.
+    //
+    // `build.rs`'s own `+crt-static` flag (its doc comment on the
+    // `RUSTFLAGS` it sets has the full story: `bundled` SQLite's C code
+    // and this compiler's own generated `declare`s for libc functions
+    // structurally expect different CRT linkage models otherwise) means
+    // this list shouldn't even contain a `msvcrt`-style dynamic-CRT
+    // `/defaultlib:` token on a correctly-configured Windows build
+    // anymore — three real, wrong `-Xlinker`/`NODEFAULTLIB` guesses were
+    // tried and disproven in this exact spot before finding that real
+    // root cause, each fixing one symbol set by excluding a library the
+    // *other* half of the link needed. Nothing platform-specific is
+    // hand-picked here anymore; every token is just forwarded as
+    // `rustc` itself reports it.
     // A handful of tokens above aren't genuine system-provided libs at
     // all — a crate-private import lib like `windows.0.52.0.lib` (the
     // `windows`/`windows-sys` family, at least) ships inside that crate's

--- a/crates/compiler/src/codegen.rs
+++ b/crates/compiler/src/codegen.rs
@@ -10029,6 +10029,24 @@ fn build_impl(
             }
         }
     }
+    // Dropping the `/defaultlib:msvcrt` *token* above wasn't the whole
+    // fix — found on real Windows CI, a real fourth failure in this same
+    // thread, identical `LNK4098`/`LNK2019` symptoms with the conflicting
+    // library now spelled `MSVCRT` (uppercase). That's the linker's own
+    // case-normalized name for a `/DEFAULTLIB:` directive embedded
+    // *inside one of the linked object files themselves* (an ordinary
+    // MSVC/`cl.exe` convention — a `.obj`/`.lib` can carry its own
+    // default-library preference, independent of anything on the command
+    // line), not something `NATIVE_STATIC_LIBS`/our own token list ever
+    // controlled at all. `bundled` SQLite's own compiled object is the
+    // most likely source (compiled by `cc`/`cl.exe` under whatever CRT
+    // linkage it defaults to on this toolchain), but the exact origin
+    // doesn't matter — the fix is the same one the linker's own `LNK4098`
+    // warning already names: explicitly tell it to ignore that embedded
+    // preference, the same way an explicit command-line `/defaultlib:`
+    // would have needed dropping if it *had* been the cause.
+    #[cfg(windows)]
+    clang_cmd.arg("-Xlinker").arg("/NODEFAULTLIB:MSVCRT");
     let result = clang_cmd.arg("-o").arg(output_path).output();
     let _ = std::fs::remove_file(&ll_path); // best-effort cleanup either way
     let _ = std::fs::remove_file(&runtime_lib_path);

--- a/crates/compiler/src/effects.rs
+++ b/crates/compiler/src/effects.rs
@@ -28,6 +28,7 @@
 //! `mq_connect`/`mq_publish`/`mq_consume`; `db_connect` when its
 //! connection-string argument is (or might be, per `db_connect_effect`)
 //! Postgres |
+//! | `env` | `env` (RFC 0011 §1) — unscoped (§6: "Decided") |
 //!
 //! `spawn`/`sandbox` also inherit whatever the spawned function's own
 //! effect set is (transitively) — the *caller* triggered that work, even
@@ -213,7 +214,7 @@ pub(crate) fn builtin_effect(name: &str) -> EffectSet {
         // Same effect `connect`/`listen`/`accept`/`tcp`'s `send`/`recv`/
         // `stop` already get -- `http_get`/`http_post` are a real TCP
         // connection under the hood.
-        "http_get" | "http_post" | "https_get" | "https_post" => {
+        "http_get" | "http_post" | "https_get" | "https_post" | "call_via" => {
             s.insert(Effect::Network);
         }
         // `json_*` builtins are pure: they only ever read the already-
@@ -255,6 +256,12 @@ pub(crate) fn builtin_effect(name: &str) -> EffectSet {
         // `Io` (`Ty::Mq`'s doc comment).
         "mq_connect" | "mq_publish" | "mq_consume" | "mq_connect_via" => {
             s.insert(Effect::Network);
+        }
+        // RFC 0011 §6: "Decided: `Effect::Env`... unscoped" -- a plain
+        // by-name tag, no argument-dependent widening like `db_connect`
+        // gets, since there's no scheme/backend distinction to make.
+        "env" => {
+            s.insert(Effect::Env);
         }
         _ => {}
     }

--- a/crates/compiler/src/ownership.rs
+++ b/crates/compiler/src/ownership.rs
@@ -277,7 +277,7 @@ fn builtin_return_ty(name: &str) -> Option<Ty> {
         "json_get_i64" | "json_array_len" => Some(result_of(Ty::I64)),
         "json_get_f64" => Some(result_of(Ty::F64)),
         "json_get_bool" => Some(result_of(Ty::Bool)),
-        "http_get" | "http_post" | "https_get" | "https_post" => {
+        "http_get" | "http_post" | "https_get" | "https_post" | "call_via" => {
             Some(result_of(Ty::Named("HttpResponse".to_string(), vec![])))
         }
         // Row 12: identity builtins all return Result(_, str) over a prelude
@@ -296,6 +296,9 @@ fn builtin_return_ty(name: &str) -> Option<Ty> {
         "mq_publish" => Some(result_of(Ty::Unit)),
         "mq_consume" => Some(result_of(Ty::Str)),
         "mock_issue_token" => Some(result_of(Ty::Str)),
+        // RFC 0011 §1: `Result(str, str)`, non-affine -- same shape as
+        // `json_get_str`/`mq_consume` right above, no `Ty::Handle` involved.
+        "env" => Some(result_of(Ty::Str)),
         _ => None,
     }
 }

--- a/crates/compiler/src/plugin.rs
+++ b/crates/compiler/src/plugin.rs
@@ -76,6 +76,20 @@ pub struct NativePluginBuiltin {
     /// invocation alongside the generated `.ll` — see
     /// `codegen::build_with_native_plugins`.
     pub static_lib: &'static [u8],
+    /// rfcs/0011-uniform-service-provider-model.md §2/§5's
+    /// convention-plus-override rule: a `<shape>_provider_<scheme>_connect`
+    /// registration's admission ceiling is normally derived from its
+    /// scheme (`NIRDOSHA_KERNEL_MAX_<SCHEME>`-shaped default), but a
+    /// provider may pin its own env var name here instead. `None` for
+    /// every non-provider native builtin (the vast majority — anything
+    /// not named `..._connect`), and for a provider willing to accept the
+    /// convention default.
+    pub env_var: Option<&'static str>,
+    /// Same convention-plus-override pairing as `env_var`, for the
+    /// numeric ceiling itself (§5's `default_max`) rather than the env
+    /// var that can override it at runtime. `None` means "use this
+    /// registry's generic default," not "unlimited."
+    pub default_max: Option<i64>,
 }
 
 impl NativePluginBuiltin {
@@ -143,5 +157,201 @@ impl NativePluginBuiltin {
             ));
         }
         Ok(())
+    }
+}
+
+/// rfcs/0011-uniform-service-provider-model.md §2, "Scheme → identifier
+/// normalization, spelled out exactly": take the substring before
+/// `://`, lowercase it, map `+`/`.`/`-` to `_`. `mysql+tls://...` →
+/// `mysql_tls`; `POSTGRESQL://...` → `postgresql`. This exact function
+/// is duplicated verbatim in `runtime-kernels` (§2's own "one function,
+/// not two independent implementations that could drift" — there is no
+/// shared crate between `compiler` and `runtime-kernels` to put a single
+/// copy in), used there for the identical purpose: turning a runtime
+/// `.nir` string into the same identifier this function computes at
+/// build time from a plugin's declared scheme. Keep both copies in sync
+/// by hand if this one ever changes.
+pub fn normalize_scheme(scheme: &str) -> String {
+    let bare = scheme.split("://").next().unwrap_or(scheme);
+    bare.to_ascii_lowercase().chars().map(|c| if c == '+' || c == '.' || c == '-' { '_' } else { c }).collect()
+}
+
+/// Splits a native plugin builtin's name into `(shape, normalized_scheme)`
+/// when it's a provider's `_connect` entry (`"db_provider_mysql_connect"`
+/// -> `("db", "mysql")`), or `None` for any other native builtin (the
+/// common case — an ordinary scalar-ABI function with no provider shape,
+/// e.g. `plugin_shout`). Used by `codegen.rs`'s Phase 4 eager-registration
+/// pass to derive `register_domain`'s `name`/`env_var` arguments per
+/// rfcs/0011 §3 ("for a plugin provider, `<shape>_provider_<normalized_
+/// scheme>`") and §2 ("`NIRDOSHA_KERNEL_MAX_<SHAPE>_<NORMALIZED_SCHEME>`
+/// convention default"). Deliberately re-derives the same
+/// `_provider_`/`_connect` parse `validate_plugin_roster` already does
+/// rather than sharing state with it, since that function only returns
+/// pass/fail, not the parsed pieces.
+pub fn provider_shape_and_scheme(name: &str) -> Option<(&str, String)> {
+    let connect_prefix = name.strip_suffix("_connect")?;
+    let provider_at = connect_prefix.find("_provider_")?;
+    let shape = &connect_prefix[..provider_at];
+    let scheme_raw = &connect_prefix[provider_at + "_provider_".len()..];
+    if scheme_raw.is_empty() {
+        return None;
+    }
+    Some((shape, normalize_scheme(scheme_raw)))
+}
+
+/// rfcs/0011 §2: "Built-in scheme identifiers, pinned exactly rather
+/// than left implicit (this is the set a plugin may *not* register)."
+/// `sqlite` has no `://` to strip (a bare path or `:memory:` — a
+/// fallback rule, not a normalized scheme) but is still a reserved
+/// identifier a plugin scheme must not collide with.
+pub const BUILTIN_SCHEME_IDENTIFIERS: &[&str] = &["sqlite", "postgres", "postgresql", "redis", "http", "https"];
+
+/// rfcs/0011 §2: "A shape's plugin contract is four functions or none,
+/// checked at build time" + the two scheme-collision rules. Operates on
+/// the whole registered roster (unlike [`NativePluginBuiltin::validate`],
+/// which only checks one builtin's own ABI shape) because both checks
+/// here are inherently cross-plugin: whether a `_connect` function's
+/// siblings exist, and whether two providers' normalized schemes
+/// collide. Only names containing `_provider_` and ending in `_connect`
+/// participate — every other native plugin builtin (the common case:
+/// an ordinary scalar-ABI function with no provider shape at all, e.g.
+/// `plugin_shout`) is untouched by this check.
+pub fn validate_plugin_roster(plugins: &[NativePluginBuiltin]) -> Result<(), String> {
+    let names: std::collections::HashSet<&str> = plugins.iter().map(|p| p.name.as_str()).collect();
+
+    let mut seen_schemes: std::collections::HashMap<String, &str> = std::collections::HashMap::new();
+    for name in plugins.iter().map(|p| p.name.as_str()) {
+        let Some(connect_prefix) = name.strip_suffix("_connect") else { continue };
+        let Some(provider_at) = connect_prefix.find("_provider_") else { continue };
+        let scheme_raw = &connect_prefix[provider_at + "_provider_".len()..];
+        if scheme_raw.is_empty() {
+            continue;
+        }
+        let scheme = normalize_scheme(scheme_raw);
+
+        if BUILTIN_SCHEME_IDENTIFIERS.contains(&scheme.as_str()) {
+            return Err(format!(
+                "native plugin provider `{name}`: scheme `{scheme}` collides with a built-in identifier \
+                 ({BUILTIN_SCHEME_IDENTIFIERS:?}) -- a plugin may not register a built-in scheme (rfcs/0011 §2)"
+            ));
+        }
+        if let Some(other) = seen_schemes.get(&scheme) {
+            return Err(format!(
+                "native plugin providers `{other}` and `{name}`: both normalize to scheme `{scheme}` -- \
+                 two plugins may not register the same identifier (rfcs/0011 §2)"
+            ));
+        }
+        seen_schemes.insert(scheme, name);
+
+        // "Four functions or none": `_connect` requires `_is_valid`,
+        // `_close`, and either `_op` (conn/stream shape) or `_request`
+        // (call shape) — the shape isn't a separate declared field, it's
+        // inferred from which sibling is present.
+        let prefix = connect_prefix; // e.g. "db_provider_mysql"
+        let has_op = names.contains(format!("{prefix}_op").as_str());
+        let has_request = names.contains(format!("{prefix}_request").as_str());
+        if !has_op && !has_request {
+            return Err(format!(
+                "native plugin provider `{name}`: registered `_connect` without a matching `{prefix}_op` \
+                 (conn/stream shape) or `{prefix}_request` (call shape) -- a shape's plugin contract is four \
+                 functions or none (rfcs/0011 §2)"
+            ));
+        }
+        if !names.contains(format!("{prefix}_is_valid").as_str()) {
+            return Err(format!(
+                "native plugin provider `{name}`: registered `_connect` without a matching `{prefix}_is_valid` \
+                 -- a shape's plugin contract is four functions or none (rfcs/0011 §2)"
+            ));
+        }
+        if !names.contains(format!("{prefix}_close").as_str()) {
+            return Err(format!(
+                "native plugin provider `{name}`: registered `_connect` without a matching `{prefix}_close` \
+                 -- a shape's plugin contract is four functions or none (rfcs/0011 §2)"
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn provider(name: &str) -> NativePluginBuiltin {
+        NativePluginBuiltin { name: name.to_string(), params: vec![Ty::Str], ret: Ty::I64, static_lib: &[], env_var: None, default_max: None }
+    }
+
+    #[test]
+    fn normalize_scheme_matches_the_rfc_examples() {
+        assert_eq!(normalize_scheme("mysql+tls://host"), "mysql_tls");
+        assert_eq!(normalize_scheme("POSTGRESQL://host"), "postgresql");
+        assert_eq!(normalize_scheme("s3.compat-v2://host"), "s3_compat_v2");
+    }
+
+    #[test]
+    fn a_well_formed_four_function_conn_shape_set_passes() {
+        let plugins = vec![
+            provider("db_provider_fakescheme_connect"),
+            provider("db_provider_fakescheme_op"),
+            provider("db_provider_fakescheme_is_valid"),
+            provider("db_provider_fakescheme_close"),
+        ];
+        validate_plugin_roster(&plugins).expect("a well-formed four-function set must validate");
+    }
+
+    #[test]
+    fn a_well_formed_four_function_call_shape_set_passes() {
+        let plugins = vec![
+            provider("authedhttp_provider_authedhttp_connect"),
+            provider("authedhttp_provider_authedhttp_request"),
+            provider("authedhttp_provider_authedhttp_is_valid"),
+            provider("authedhttp_provider_authedhttp_close"),
+        ];
+        validate_plugin_roster(&plugins).expect("a well-formed call-shape four-function set must validate");
+    }
+
+    #[test]
+    fn a_connect_missing_close_fails_with_the_named_function() {
+        let plugins = vec![
+            provider("db_provider_fakescheme_connect"),
+            provider("db_provider_fakescheme_op"),
+            provider("db_provider_fakescheme_is_valid"),
+        ];
+        let err = validate_plugin_roster(&plugins).expect_err("a missing _close must fail");
+        assert!(err.contains("db_provider_fakescheme_close"), "expected the missing function named, got: {err}");
+    }
+
+    #[test]
+    fn two_plugins_normalizing_to_the_same_identifier_fail_with_the_named_collision() {
+        let plugins = vec![
+            provider("db_provider_mysql_connect"),
+            provider("db_provider_mysql_op"),
+            provider("db_provider_mysql_is_valid"),
+            provider("db_provider_mysql_close"),
+            provider("mq_provider_mysql_connect"),
+            provider("mq_provider_mysql_op"),
+            provider("mq_provider_mysql_is_valid"),
+            provider("mq_provider_mysql_close"),
+        ];
+        let err = validate_plugin_roster(&plugins).expect_err("colliding normalized schemes must fail");
+        assert!(err.contains("mysql"), "expected the colliding identifier named, got: {err}");
+    }
+
+    #[test]
+    fn a_plugin_scheme_colliding_with_postgres_fails() {
+        let plugins = vec![
+            provider("db_provider_postgres_connect"),
+            provider("db_provider_postgres_op"),
+            provider("db_provider_postgres_is_valid"),
+            provider("db_provider_postgres_close"),
+        ];
+        let err = validate_plugin_roster(&plugins).expect_err("a built-in scheme collision must fail");
+        assert!(err.contains("postgres"), "expected the built-in identifier named, got: {err}");
+    }
+
+    #[test]
+    fn non_provider_native_builtins_are_untouched_by_roster_validation() {
+        let plugins = vec![provider("plugin_shout")];
+        validate_plugin_roster(&plugins).expect("a plain native builtin with no _provider_..._connect shape must pass untouched");
     }
 }

--- a/crates/compiler/src/typeck.rs
+++ b/crates/compiler/src/typeck.rs
@@ -4506,6 +4506,26 @@ impl<'a> Checker<'a> {
                 self.check(&args[2], &Ty::Str, expected_ret, scopes); // path
                 result_of(Ty::Named("HttpResponse".to_string(), vec![]))
             }
+            // rfcs/0011-uniform-service-provider-model.md §1/§2: the
+            // `call`-shape's `.nir`-facing entrypoint (named `call_via`,
+            // not `https_request_via` -- that name baked an http-shaped
+            // bias into a generic scheme-dispatched builtin, corrected
+            // in the RFC itself before this landed). `url` carries the
+            // scheme this dispatches on at runtime (§2's whole point:
+            // the scheme isn't known until the program runs, so this
+            // can't be a compile-time match); `http://`/`https://` stay
+            // served by the exact same core path `http_get`/`http_post`
+            // already use, anything else falls through to a registered
+            // `call`-shape plugin. Reuses `HttpResponse` as a
+            // lowest-common-denominator return shape (§1's own
+            // disclosure: a non-HTTP provider's `{status, body}` isn't a
+            // claim that the response is HTTP underneath).
+            ("call_via", 3) => {
+                self.check(&args[0], &Ty::Str, expected_ret, scopes); // url
+                self.check(&args[1], &Ty::Str, expected_ret, scopes); // path
+                self.check(&args[2], &Ty::Str, expected_ret, scopes); // body
+                result_of(Ty::Named("HttpResponse".to_string(), vec![]))
+            }
             // Row 12: identity as a relying party.
             ("oidc_validate_token", 4) => {
                 self.check(&args[0], &Ty::Str, expected_ret, scopes); // token
@@ -4688,6 +4708,13 @@ impl<'a> Checker<'a> {
             ("mq_connect_via", 1) => {
                 self.check(&args[0], &Ty::Str, expected_ret, scopes);
                 result_of(Ty::Mq)
+            }
+            // RFC 0011 §1: reads a process environment variable. `Ok(value)`
+            // when set, `Err(_)` when unset -- same `Result(_, str)`
+            // convention as `db`/`mq`/HTTP above.
+            ("env", 1) => {
+                self.check(&args[0], &Ty::Str, expected_ret, scopes); // var name
+                result_of(Ty::Str)
             }
             ("mq_publish", 3) => {
                 self.check(&args[0], &Ty::Mq, expected_ret, scopes);

--- a/crates/compiler/tests/codegen.rs
+++ b/crates/compiler/tests/codegen.rs
@@ -2697,6 +2697,40 @@ fn db_connect_execute_query_round_trips_real_sqlite_rows() {
     assert_eq!(stdout, "ada\n1\n");
 }
 
+/// `env(name) -> Result(str, str)` (RFC 0011 §1) — `Ok(value)` when the
+/// process environment variable is set at the compiled binary's own
+/// runtime (not at compile time), `Err(_)` when unset. Uniquely-named
+/// vars, same reasoning `unique_temp_path`'s own doc comment gives for
+/// SQLite files: a generic name here could collide with something real
+/// in whatever environment `cargo test` itself happens to run under.
+#[test]
+fn env_round_trips_ok_when_set_and_err_when_unset() {
+    // `describe`-as-a-fn would need `str` in its own signature -- banned
+    // (`typeck::TypeErrorKind::StrInFnSignature`, `result_of`'s own doc
+    // comment: builtins are exempt from this ban, plain user fns aren't)
+    // -- so both matches are inlined directly in `main` instead, same as
+    // `json_accessors_...`'s own `let name: str = match json_get_str(...)`
+    // shape just above.
+    let src = r#"
+        fn main() {
+            let set_var: str = match env("NIRDOSHA_RFC0011_ENV_TEST_SET_VAR") {
+                Err(e) => "MISSING",
+                Ok(v) => v,
+            }
+            print(set_var)
+            let unset_var: str = match env("NIRDOSHA_RFC0011_ENV_TEST_UNSET_VAR") {
+                Err(e) => "MISSING",
+                Ok(v) => v,
+            }
+            print(unset_var)
+        }
+    "#;
+    let (stdout, code) =
+        compile_and_run_with_env(src, codegen::OptLevel::O2, &[("NIRDOSHA_RFC0011_ENV_TEST_SET_VAR", "hello-rfc-0011")]);
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "hello-rfc-0011\nMISSING\n");
+}
+
 /// The rest of the `json_*` accessor surface `27_database.nir` doesn't
 /// happen to exercise — `json_get_i64`/`json_get_f64`/`json_get_bool`/
 /// `json_array_len` read out of a real `db_query` row (SQLite has no

--- a/crates/compiler/tests/codegen.rs
+++ b/crates/compiler/tests/codegen.rs
@@ -2610,6 +2610,78 @@ fn oidc_validate_token_verifies_a_real_jwt_and_drives_check_role_and_extract_cla
     );
 }
 
+/// `mock_issue_token`'s real implementation, round-tripped through the
+/// exact same `oidc_validate_token`/`check_role`/`extract_claim` pipeline
+/// the test just above already proves against a hand-written fixture
+/// token -- this one signs its own token instead, against the same
+/// `kid:"key1"`/`kty:"oct"` JWKS, and feeds it straight back in. Real
+/// HMAC-SHA256 signing, not an echo: a wrong audience is still rejected
+/// by real signature/claim verification, and a JWKS with no usable
+/// signing key is a real `Err`, never a trap.
+#[test]
+fn mock_issue_token_signs_a_real_jwt_that_oidc_validate_token_accepts() {
+    let src = r#"
+        struct Text {
+            value: str,
+        }
+
+        fn main() {
+            let jwks: str = "{\"keys\":[{\"kid\":\"key1\",\"kty\":\"oct\",\"k\":\"bXktc2VjcmV0LWtleQ\"}]}"
+
+            let token: Text = match mock_issue_token("alice", "https://example.com", "my-app", 1700000000, 3600, "{\"roles\":[\"physician\"],\"department\":\"cardiology\"}", jwks) {
+                Err(e) => Text(e),
+                Ok(t) => Text(t),
+            }
+            print(len(token.value) > 0)
+
+            let identity: VerifiedIdentity = match oidc_validate_token(token.value, "https://example.com", "my-app", jwks) {
+                Err(e) => VerifiedIdentity("", "", "", 0, 0, "{}"),
+                Ok(id) => id,
+            }
+            print(identity.subject)
+            print(identity.issuer)
+            print(identity.audience)
+            print(identity.expires_at - identity.issued_at == 3600)
+
+            let has_physician: bool = match check_role(identity, "physician") {
+                Err(e) => false,
+                Ok(proof) => true,
+            }
+            print(has_physician)
+
+            let department: Text = match extract_claim(identity, "department") {
+                Err(e) => Text(e),
+                Ok(claim) => Text(claim.value),
+            }
+            print(department.value)
+
+            // Wrong audience is rejected by real claim verification, not
+            // just echoed back -- proves this is a real signed check, not
+            // a no-op stand-in.
+            let wrong_audience_rejected: bool = match oidc_validate_token(token.value, "https://example.com", "wrong-app", jwks) {
+                Err(e) => true,
+                Ok(id) => false,
+            }
+            print(wrong_audience_rejected)
+
+            // A JWKS with no usable (`oct`) signing key can't issue a
+            // token at all -- a real `Err`, never a trap.
+            let no_key_jwks: str = "{\"keys\":[]}"
+            let no_key_rejected: bool = match mock_issue_token("alice", "https://example.com", "my-app", 1700000000, 3600, "{}", no_key_jwks) {
+                Err(e) => true,
+                Ok(t) => false,
+            }
+            print(no_key_rejected)
+        }
+    "#;
+    let (stdout, code) = compile_and_run(src);
+    assert_eq!(code, 0);
+    assert_eq!(
+        stdout,
+        "1\nalice\nhttps://example.com\nmy-app\n1\n1\ncardiology\n1\n1\n"
+    );
+}
+
 /// Phase 2 (`db`, SQLite via `rusqlite`): a real, unmodified copy of
 /// `examples/features/27_database.nir` — `db_connect`/`db_execute`/
 /// `db_query`/`json_array_get`/`json_get_str`/`stop`, compiled and run

--- a/crates/compiler/tests/native_plugin_codegen.rs
+++ b/crates/compiler/tests/native_plugin_codegen.rs
@@ -86,7 +86,14 @@ fn a_native_plugin_call_compiles_and_the_native_binary_runs_correctly() {
     "#;
 
     let native_plugin =
-        NativePluginBuiltin { name: "plugin_scale".to_string(), params: vec![Ty::I64], ret: Ty::I64, static_lib: Box::leak(lib_bytes.into_boxed_slice()) };
+        NativePluginBuiltin {
+            name: "plugin_scale".to_string(),
+            params: vec![Ty::I64],
+            ret: Ty::I64,
+            static_lib: Box::leak(lib_bytes.into_boxed_slice()),
+            env_var: None,
+            default_max: None,
+        };
     native_plugin.validate().expect("a scalar i64->i64 signature must validate");
 
     let program = typecheck_and_own_with_plugins(src, std::slice::from_ref(&native_plugin));
@@ -126,7 +133,8 @@ fn a_native_plugin_call_compiles_and_the_native_binary_runs_correctly() {
 /// inside a malformed `declare`.
 #[test]
 fn a_json_typed_native_plugin_is_rejected_by_validate_not_left_to_fail_in_clang() {
-    let native_plugin = NativePluginBuiltin { name: "bad_plugin".to_string(), params: vec![Ty::Json], ret: Ty::I64, static_lib: &[] };
+    let native_plugin =
+        NativePluginBuiltin { name: "bad_plugin".to_string(), params: vec![Ty::Json], ret: Ty::I64, static_lib: &[], env_var: None, default_max: None };
     let err = native_plugin.validate().expect_err("a json parameter must be rejected");
     assert!(err.contains("bad_plugin") && err.contains("value"), "expected a named, actionable reason, got: {err}");
 }
@@ -172,9 +180,22 @@ fn a_str_typed_native_plugin_crosses_the_boundary_in_both_directions() {
         }
     "#;
 
-    let shout = NativePluginBuiltin { name: "plugin_shout".to_string(), params: vec![Ty::Str], ret: Ty::Str, static_lib: lib_bytes };
-    let first_byte =
-        NativePluginBuiltin { name: "plugin_str_first_byte".to_string(), params: vec![Ty::Str], ret: Ty::I64, static_lib: lib_bytes };
+    let shout = NativePluginBuiltin {
+        name: "plugin_shout".to_string(),
+        params: vec![Ty::Str],
+        ret: Ty::Str,
+        static_lib: lib_bytes,
+        env_var: None,
+        default_max: None,
+    };
+    let first_byte = NativePluginBuiltin {
+        name: "plugin_str_first_byte".to_string(),
+        params: vec![Ty::Str],
+        ret: Ty::I64,
+        static_lib: lib_bytes,
+        env_var: None,
+        default_max: None,
+    };
     shout.validate().expect("a str->str signature must validate now");
     first_byte.validate().expect("a str->i64 signature must validate");
 
@@ -230,12 +251,16 @@ fn a_handle_typed_native_plugin_crosses_the_boundary_as_a_plain_i64() {
         params: vec![],
         ret: Ty::Handle("Counter".to_string()),
         static_lib: lib_bytes,
+        env_var: None,
+        default_max: None,
     };
     let close = NativePluginBuiltin {
         name: "plugin_counter_close".to_string(),
         params: vec![Ty::Handle("Counter".to_string())],
         ret: Ty::I64,
         static_lib: lib_bytes,
+        env_var: None,
+        default_max: None,
     };
     open.validate().expect("a ()->handle signature must validate now");
     close.validate().expect("a handle->i64 signature must validate");
@@ -296,14 +321,30 @@ fn a_borrowed_native_plugin_handle_can_be_read_any_number_of_times_before_one_fi
     "#;
 
     let counter_kind = || Ty::Handle("Counter".to_string());
-    let open = NativePluginBuiltin { name: "plugin_counter_open".to_string(), params: vec![], ret: counter_kind(), static_lib: lib_bytes };
+    let open = NativePluginBuiltin {
+        name: "plugin_counter_open".to_string(),
+        params: vec![],
+        ret: counter_kind(),
+        static_lib: lib_bytes,
+        env_var: None,
+        default_max: None,
+    };
     let peek = NativePluginBuiltin {
         name: "plugin_counter_peek".to_string(),
         params: vec![Ty::Ref(Box::new(counter_kind()))],
         ret: Ty::I64,
         static_lib: lib_bytes,
+        env_var: None,
+        default_max: None,
     };
-    let close = NativePluginBuiltin { name: "plugin_counter_close".to_string(), params: vec![counter_kind()], ret: Ty::I64, static_lib: lib_bytes };
+    let close = NativePluginBuiltin {
+        name: "plugin_counter_close".to_string(),
+        params: vec![counter_kind()],
+        ret: Ty::I64,
+        static_lib: lib_bytes,
+        env_var: None,
+        default_max: None,
+    };
     open.validate().expect("a ()->handle signature must validate");
     peek.validate().expect("a &handle->i64 signature must validate now");
     close.validate().expect("a handle->i64 signature must validate");
@@ -348,12 +389,16 @@ fn a_native_plugin_handle_used_twice_is_a_compile_time_ownership_error() {
         params: vec![],
         ret: Ty::Handle("Counter".to_string()),
         static_lib: &[],
+        env_var: None,
+        default_max: None,
     };
     let close = NativePluginBuiltin {
         name: "plugin_counter_close".to_string(),
         params: vec![Ty::Handle("Counter".to_string())],
         ret: Ty::I64,
         static_lib: &[],
+        env_var: None,
+        default_max: None,
     };
     let plugins = [open, close];
 
@@ -363,5 +408,436 @@ fn a_native_plugin_handle_used_twice_is_a_compile_time_ownership_error() {
     let err = check_ownership(&program).expect_err("using a handle twice must be rejected");
     let msg = format!("{err:?}");
     assert!(msg.contains("h") || msg.to_lowercase().contains("moved"), "expected a use-after-move ownership error, got: {msg}");
+}
+
+/// rfcs/0011 §4's actual claim: registration is eager, at process
+/// startup, over the full set the compiler linked — not lazy,
+/// deferred to first use. Two synthetic `conn`-shape providers are
+/// linked (each with all four required functions, so
+/// `validate_plugin_roster` accepts them) but **never called** from
+/// the `.nir` program at all; if registration happened before `nir_
+/// main` runs the way Phase 4 requires, both providers' domains show
+/// up in the flight-recorder dump printed automatically at process
+/// exit, alongside the 7 built-ins -- proving the registration calls
+/// codegen emits in `main`'s preamble actually ran, not that the
+/// providers merely linked successfully.
+#[test]
+fn eager_plugin_registration_shows_up_in_the_flight_recorder_dump_before_any_user_code_runs() {
+    let lib_bytes = compile_native_plugin_staticlib(
+        "plugin_two_conn_providers",
+        r#"
+            #[no_mangle]
+            pub extern "C" fn db_provider_fakeschemea_connect(host: i64) -> i64 { host }
+            #[no_mangle]
+            pub extern "C" fn db_provider_fakeschemea_op(conn: i64) -> i64 { conn }
+            #[no_mangle]
+            pub extern "C" fn db_provider_fakeschemea_is_valid(conn: i64) -> i64 { let _ = conn; 1 }
+            #[no_mangle]
+            pub extern "C" fn db_provider_fakeschemea_close(conn: i64) -> i64 { conn }
+
+            #[no_mangle]
+            pub extern "C" fn db_provider_fakeschemeb_connect(host: i64) -> i64 { host }
+            #[no_mangle]
+            pub extern "C" fn db_provider_fakeschemeb_op(conn: i64) -> i64 { conn }
+            #[no_mangle]
+            pub extern "C" fn db_provider_fakeschemeb_is_valid(conn: i64) -> i64 { let _ = conn; 1 }
+            #[no_mangle]
+            pub extern "C" fn db_provider_fakeschemeb_close(conn: i64) -> i64 { conn }
+        "#,
+    );
+    let lib_bytes: &'static [u8] = Box::leak(lib_bytes.into_boxed_slice());
+
+    fn provider_fns(scheme: &str, lib_bytes: &'static [u8]) -> [NativePluginBuiltin; 4] {
+        [
+            NativePluginBuiltin {
+                name: format!("db_provider_{scheme}_connect"),
+                params: vec![Ty::I64],
+                ret: Ty::I64,
+                static_lib: lib_bytes,
+                env_var: None,
+                default_max: None,
+            },
+            NativePluginBuiltin {
+                name: format!("db_provider_{scheme}_op"),
+                params: vec![Ty::I64],
+                ret: Ty::I64,
+                static_lib: lib_bytes,
+                env_var: None,
+                default_max: None,
+            },
+            NativePluginBuiltin {
+                name: format!("db_provider_{scheme}_is_valid"),
+                params: vec![Ty::I64],
+                ret: Ty::I64,
+                static_lib: lib_bytes,
+                env_var: None,
+                default_max: None,
+            },
+            NativePluginBuiltin {
+                name: format!("db_provider_{scheme}_close"),
+                params: vec![Ty::I64],
+                ret: Ty::I64,
+                static_lib: lib_bytes,
+                env_var: None,
+                default_max: None,
+            },
+        ]
+    }
+
+    let mut plugins = Vec::new();
+    plugins.extend(provider_fns("fakeschemea", lib_bytes));
+    plugins.extend(provider_fns("fakeschemeb", lib_bytes));
+    for p in &plugins {
+        p.validate().expect("every provider function's ABI shape must validate");
+    }
+
+    // Deliberately calls neither provider -- registration must not
+    // depend on any `.nir` call site reaching it (rfcs/0011 §4).
+    let src = r#"
+        fn main() -> i64 {
+            return 0
+        }
+    "#;
+
+    let program = typecheck_and_own_with_plugins(src, &plugins);
+    let report = analyze(&program);
+
+    let out_dir = std::env::temp_dir().join(format!("nirdosha_eager_plugin_registration_test_bin_{}", std::process::id()));
+    std::fs::create_dir_all(&out_dir).unwrap();
+    let out_path = out_dir.join("eager_plugin_registration_test_bin");
+
+    codegen::build_with_native_plugins(&program, &report, &out_path, codegen::OptLevel::O2, &plugins, &Default::default())
+        .expect("build_with_native_plugins should compile and link cleanly");
+
+    let output = Command::new(&out_path).output().expect("running the compiled binary should succeed");
+    assert_eq!(output.status.code(), Some(0), "compiled binary's exit code: {output:?}");
+
+    // `nir_kernel_flight_recorder_dump` prints to stderr (this file's
+    // sibling tests' own established convention, see
+    // `nirdosha_ops_console.rs`'s identical assumption).
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    for expected in [
+        "db_provider_fakeschemea: held=0 grants=0 denials=0 stale_rehydrated=0",
+        "db_provider_fakeschemeb: held=0 grants=0 denials=0 stale_rehydrated=0",
+        "db: held=0 grants=0 denials=0 stale_rehydrated=0",
+        "http: held=0 grants=0 denials=0 stale_rehydrated=0",
+    ] {
+        assert!(stderr.contains(expected), "expected flight-recorder dump to contain {expected:?}, got:\n{stderr}");
+    }
+
+    let _ = std::fs::remove_dir_all(out_dir);
+}
+
+/// Phase 6's actual claim: `db_connect`'s runtime scheme dispatch
+/// (rfcs/0011-uniform-service-provider-model.md §2) really calls
+/// through to a registered plugin provider, and — the RFC's own
+/// structural-safety property — a handle connected through one
+/// provider only ever dispatches through *that* provider's own
+/// function pointers, never a different provider's, even though both
+/// share one process-wide dispatch table. Two synthetic `conn`-shape
+/// providers, each returning a JSON array of a distinguishable length
+/// from `_op`; a `.nir` program connects to both and multiplies the two
+/// lengths together into one exit code that could only come out right
+/// if each handle reached its own provider's `_op`, not the other's.
+#[test]
+fn db_connect_dispatches_to_a_registered_plugin_provider_and_never_crosses_providers() {
+    let lib_bytes = compile_native_plugin_staticlib(
+        "plugin_two_conn_providers_real",
+        r#"
+            #[repr(C)]
+            pub struct NirStr { pub ptr: *const u8, pub len: i64 }
+
+            fn leak_str(s: &'static str) -> NirStr {
+                NirStr { ptr: s.as_ptr(), len: s.len() as i64 }
+            }
+
+            #[no_mangle]
+            pub extern "C" fn db_provider_fakeschemea_connect(_host: NirStr) -> i64 { 1 }
+            #[no_mangle]
+            pub extern "C" fn db_provider_fakeschemea_op(_conn: i64, _arg: NirStr) -> NirStr { leak_str("[0,0,0]") }
+            #[no_mangle]
+            pub extern "C" fn db_provider_fakeschemea_is_valid(_conn: i64) -> i64 { 1 }
+            #[no_mangle]
+            pub extern "C" fn db_provider_fakeschemea_close(_conn: i64) -> i64 { 0 }
+
+            #[no_mangle]
+            pub extern "C" fn db_provider_fakeschemeb_connect(_host: NirStr) -> i64 { 1 }
+            #[no_mangle]
+            pub extern "C" fn db_provider_fakeschemeb_op(_conn: i64, _arg: NirStr) -> NirStr { leak_str("[0,0]") }
+            #[no_mangle]
+            pub extern "C" fn db_provider_fakeschemeb_is_valid(_conn: i64) -> i64 { 1 }
+            #[no_mangle]
+            pub extern "C" fn db_provider_fakeschemeb_close(_conn: i64) -> i64 { 0 }
+        "#,
+    );
+    let lib_bytes: &'static [u8] = Box::leak(lib_bytes.into_boxed_slice());
+
+    fn provider_fns(scheme: &str, lib_bytes: &'static [u8]) -> [NativePluginBuiltin; 4] {
+        [
+            NativePluginBuiltin {
+                name: format!("db_provider_{scheme}_connect"),
+                params: vec![Ty::Str],
+                ret: Ty::I64,
+                static_lib: lib_bytes,
+                env_var: None,
+                default_max: None,
+            },
+            NativePluginBuiltin {
+                name: format!("db_provider_{scheme}_op"),
+                params: vec![Ty::I64, Ty::Str],
+                ret: Ty::Str,
+                static_lib: lib_bytes,
+                env_var: None,
+                default_max: None,
+            },
+            NativePluginBuiltin {
+                name: format!("db_provider_{scheme}_is_valid"),
+                params: vec![Ty::I64],
+                ret: Ty::I64,
+                static_lib: lib_bytes,
+                env_var: None,
+                default_max: None,
+            },
+            NativePluginBuiltin {
+                name: format!("db_provider_{scheme}_close"),
+                params: vec![Ty::I64],
+                ret: Ty::I64,
+                static_lib: lib_bytes,
+                env_var: None,
+                default_max: None,
+            },
+        ]
+    }
+
+    let mut plugins = Vec::new();
+    plugins.extend(provider_fns("fakeschemea", lib_bytes));
+    plugins.extend(provider_fns("fakeschemeb", lib_bytes));
+    for p in &plugins {
+        p.validate().expect("every provider function's ABI shape must validate");
+    }
+
+    let src = r#"
+        fn query_len_inner(conn: db) -> i64 {
+            let len: i64 = match db_query(conn, "irrelevant") {
+                Err(e) => -2,
+                Ok(rows) => match json_array_len(rows) {
+                    Err(e) => -3,
+                    Ok(n) => n,
+                },
+            }
+            stop conn
+            return len
+        }
+
+        fn connect_a() -> i64 {
+            return match db_connect("fakeschemea://user@host/dba") {
+                Err(e) => -1,
+                Ok(conn) => query_len_inner(conn),
+            }
+        }
+
+        fn connect_b() -> i64 {
+            return match db_connect("fakeschemeb://user@host/dbb") {
+                Err(e) => -1,
+                Ok(conn) => query_len_inner(conn),
+            }
+        }
+
+        fn main() -> i64 {
+            let la: i64 = connect_a()
+            let lb: i64 = connect_b()
+            return la * 10 + lb
+        }
+    "#;
+
+    let program = typecheck_and_own_with_plugins(src, &plugins);
+    let report = analyze(&program);
+
+    let out_dir = std::env::temp_dir().join(format!("nirdosha_db_connect_plugin_dispatch_test_bin_{}", std::process::id()));
+    std::fs::create_dir_all(&out_dir).unwrap();
+    let out_path = out_dir.join("db_connect_plugin_dispatch_test_bin");
+
+    codegen::build_with_native_plugins(&program, &report, &out_path, codegen::OptLevel::O2, &plugins, &Default::default())
+        .expect("build_with_native_plugins should compile and link cleanly");
+
+    let output = Command::new(&out_path).output().expect("running the compiled binary should succeed");
+    // `fakeschemea`'s `_op` returns a 3-element array, `fakeschemeb`'s a
+    // 2-element one -- `3 * 10 + 2 = 32`. A cross-provider mixup (either
+    // handle reaching the *other* provider's `_op`) would produce `33`,
+    // `22`, or some other value, never `32`.
+    assert_eq!(output.status.code(), Some(32), "compiled binary's exit code: {output:?}");
+
+    let _ = std::fs::remove_dir_all(out_dir);
+}
+
+/// The disclosed "no provider registered for scheme X" error path
+/// (rfcs/0011 §2 step 1) — a scheme with no matching built-in and no
+/// registered plugin must fail cleanly at runtime, not panic or hang.
+#[test]
+fn db_connect_against_an_unregistered_scheme_is_a_clean_runtime_error_not_a_panic() {
+    let src = r#"
+        fn close_and_zero(conn: db) -> i64 {
+            stop conn
+            return 0
+        }
+
+        fn main() -> i64 {
+            return match db_connect("totallyunregisteredscheme://user@host/db") {
+                Err(e) => 7,
+                Ok(conn) => close_and_zero(conn),
+            }
+        }
+    "#;
+
+    let toks = Lexer::new(src).tokenize().expect("lex should succeed");
+    let program = Parser::new(toks).parse_program().expect("parse should succeed");
+    typecheck_with_native_plugins(&program, &[]).expect("typecheck_with_native_plugins should accept this program");
+    check_ownership(&program).expect("ownership check should accept this program");
+    let report = analyze(&program);
+
+    let out_dir = std::env::temp_dir().join(format!("nirdosha_db_connect_unregistered_scheme_test_bin_{}", std::process::id()));
+    std::fs::create_dir_all(&out_dir).unwrap();
+    let out_path = out_dir.join("db_connect_unregistered_scheme_test_bin");
+
+    codegen::build_with_native_plugins(&program, &report, &out_path, codegen::OptLevel::O2, &[], &Default::default())
+        .expect("build_with_native_plugins should compile and link cleanly");
+
+    let output = Command::new(&out_path).output().expect("running the compiled binary should succeed");
+    assert_eq!(output.status.code(), Some(7), "an unregistered scheme must be a clean Err, not a hang/panic: {output:?}");
+
+    let _ = std::fs::remove_dir_all(out_dir);
+}
+
+/// `call_via`'s plugin fallback, and specifically rfcs/0011 §2's
+/// corrected `call`-shape admission scope: "`kernel::acquire(domain)`
+/// brackets *each `_request` call's* own internal checkout... not held
+/// across multiple calls the way `conn`/`stream`'s session-scoped
+/// bracketing is." A synthetic `call`-shape provider is registered with
+/// `default_max: Some(1)` (its domain's admission ceiling is exactly
+/// one concurrently-held checkout), and `call_via` is called **twice,
+/// sequentially** against it. `call_via` never hands back a `.nir`-level
+/// handle to `stop` — there is no other release point in this program at
+/// all — so the second call can only succeed if the first call's
+/// admission was released the moment its `_request` returned, proving
+/// per-request (not session-scoped) bracketing. If release were
+/// accidentally held across calls (the session-scoped bug this test
+/// exists to catch), the second call would be denied immediately
+/// (`kernel::acquire` is non-blocking CAS, never a hang) and its
+/// response body would be the `Err` fallback, not the plugin's real
+/// echo.
+#[test]
+fn call_via_brackets_admission_per_request_not_per_session() {
+    let lib_bytes = compile_native_plugin_staticlib(
+        "plugin_authedhttp_provider",
+        r#"
+            #[repr(C)]
+            pub struct NirStr { pub ptr: *const u8, pub len: i64 }
+
+            fn leak_str(s: String) -> NirStr {
+                let leaked: &'static str = Box::leak(s.into_boxed_str());
+                NirStr { ptr: leaked.as_ptr(), len: leaked.len() as i64 }
+            }
+
+            #[no_mangle]
+            pub extern "C" fn authedhttp_provider_authedhttp_connect(_host: NirStr) -> i64 { 1 }
+
+            #[no_mangle]
+            pub extern "C" fn authedhttp_provider_authedhttp_request(_conn: i64, path: NirStr, _body: NirStr) -> NirStr {
+                let path_str = unsafe {
+                    std::str::from_utf8(std::slice::from_raw_parts(path.ptr, path.len as usize)).unwrap_or("")
+                };
+                leak_str(format!("resp:{path_str}"))
+            }
+
+            #[no_mangle]
+            pub extern "C" fn authedhttp_provider_authedhttp_is_valid(_conn: i64) -> i64 { 1 }
+
+            #[no_mangle]
+            pub extern "C" fn authedhttp_provider_authedhttp_close(_conn: i64) -> i64 { 0 }
+        "#,
+    );
+    let lib_bytes: &'static [u8] = Box::leak(lib_bytes.into_boxed_slice());
+
+    let plugins = [
+        NativePluginBuiltin {
+            name: "authedhttp_provider_authedhttp_connect".to_string(),
+            params: vec![Ty::Str],
+            ret: Ty::I64,
+            static_lib: lib_bytes,
+            env_var: None,
+            // Forces this provider's domain ceiling to exactly 1
+            // concurrently-held checkout -- the whole point of this
+            // test.
+            default_max: Some(1),
+        },
+        NativePluginBuiltin {
+            name: "authedhttp_provider_authedhttp_request".to_string(),
+            params: vec![Ty::I64, Ty::Str, Ty::Str],
+            ret: Ty::Str,
+            static_lib: lib_bytes,
+            env_var: None,
+            default_max: None,
+        },
+        NativePluginBuiltin {
+            name: "authedhttp_provider_authedhttp_is_valid".to_string(),
+            params: vec![Ty::I64],
+            ret: Ty::I64,
+            static_lib: lib_bytes,
+            env_var: None,
+            default_max: None,
+        },
+        NativePluginBuiltin {
+            name: "authedhttp_provider_authedhttp_close".to_string(),
+            params: vec![Ty::I64],
+            ret: Ty::I64,
+            static_lib: lib_bytes,
+            env_var: None,
+            default_max: None,
+        },
+    ];
+    for p in &plugins {
+        p.validate().expect("every provider function's ABI shape must validate");
+    }
+
+    let src = r#"
+        fn main() -> i64 {
+            let r1: str = match call_via("authedhttp://host", "/p1", "b1") {
+                Err(e) => "ERR1",
+                Ok(resp) => resp.body,
+            }
+            let r2: str = match call_via("authedhttp://host", "/p2", "b2") {
+                Err(e) => "ERR2",
+                Ok(resp) => resp.body,
+            }
+            let ok1: bool = r1 == "resp:/p1"
+            let ok2: bool = r2 == "resp:/p2"
+            if ok1 {
+                if ok2 {
+                    return 1
+                }
+            }
+            return 0
+        }
+    "#;
+
+    let program = typecheck_and_own_with_plugins(src, &plugins);
+    let report = analyze(&program);
+
+    let out_dir = std::env::temp_dir().join(format!("nirdosha_call_via_per_request_admission_test_bin_{}", std::process::id()));
+    std::fs::create_dir_all(&out_dir).unwrap();
+    let out_path = out_dir.join("call_via_per_request_admission_test_bin");
+
+    codegen::build_with_native_plugins(&program, &report, &out_path, codegen::OptLevel::O2, &plugins, &Default::default())
+        .expect("build_with_native_plugins should compile and link cleanly");
+
+    let output = Command::new(&out_path).output().expect("running the compiled binary should succeed");
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "both call_via calls must succeed with the correct per-call response, even at a domain ceiling of 1, \
+         proving admission is released after each _request rather than held across calls: {output:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(out_dir);
 }
 

--- a/crates/compiler/tests/native_plugin_examples.rs
+++ b/crates/compiler/tests/native_plugin_examples.rs
@@ -83,16 +83,32 @@ fn the_shipped_example_plugin_crates_compile_and_run_correctly() {
     let kv_store_kind = || Ty::Handle("KvStore".to_string());
     let kv_store_ref = || Ty::Ref(Box::new(kv_store_kind()));
     let plugins = vec![
-        NativePluginBuiltin { name: "plugin_shout".to_string(), params: vec![Ty::Str], ret: Ty::Str, static_lib: shout_lib },
-        NativePluginBuiltin { name: "kv_open".to_string(), params: vec![], ret: kv_store_kind(), static_lib: kv_lib },
+        NativePluginBuiltin { name: "plugin_shout".to_string(), params: vec![Ty::Str], ret: Ty::Str, static_lib: shout_lib, env_var: None, default_max: None },
+        NativePluginBuiltin { name: "kv_open".to_string(), params: vec![], ret: kv_store_kind(), static_lib: kv_lib, env_var: None, default_max: None },
         NativePluginBuiltin {
             name: "kv_set".to_string(),
             params: vec![kv_store_ref(), Ty::Str, Ty::Str],
             ret: Ty::I64,
             static_lib: kv_lib,
+            env_var: None,
+            default_max: None,
         },
-        NativePluginBuiltin { name: "kv_get".to_string(), params: vec![kv_store_ref(), Ty::Str], ret: Ty::Str, static_lib: kv_lib },
-        NativePluginBuiltin { name: "kv_close".to_string(), params: vec![kv_store_kind()], ret: Ty::I64, static_lib: kv_lib },
+        NativePluginBuiltin {
+            name: "kv_get".to_string(),
+            params: vec![kv_store_ref(), Ty::Str],
+            ret: Ty::Str,
+            static_lib: kv_lib,
+            env_var: None,
+            default_max: None,
+        },
+        NativePluginBuiltin {
+            name: "kv_close".to_string(),
+            params: vec![kv_store_kind()],
+            ret: Ty::I64,
+            static_lib: kv_lib,
+            env_var: None,
+            default_max: None,
+        },
     ];
     for p in &plugins {
         p.validate().unwrap_or_else(|e| panic!("{e}"));
@@ -130,6 +146,123 @@ fn the_shipped_example_plugin_crates_compile_and_run_correctly() {
     // something non-empty came back -> kv_set/kv_close both report
     // success (1) -> 1*10 + 1 == 11.
     assert_eq!(output.status.code(), Some(11), "compiled binary's exit code: {output:?}");
+
+    let _ = std::fs::remove_dir_all(out_dir);
+}
+
+/// rfcs/0011-uniform-service-provider-model.md Phase 8's own closing
+/// checklist item, proven the same way the test above proves Phases 1/4
+/// of rfcs/0008: not a synthetic inline plugin (`native_plugin_codegen.rs`'s
+/// own tests use those, for speed), but the real, separately-compiled
+/// `crates/plugin-example-native-authed-http` crate, linked into a real
+/// `nirdosha build` output and run as a real process — against a real
+/// local HTTP server, on an ephemeral port, observing a real
+/// `Authorization: Bearer <token>` header that only the plugin (reading
+/// `AUTHEDHTTP_BEARER_TOKEN` from the process environment at connect
+/// time) could have set.
+#[test]
+fn the_shipped_authed_http_plugin_compiles_and_makes_a_real_authenticated_request() {
+    build_release("nirdosha-plugin-native-authed-http");
+    let authedhttp_lib = read_staticlib("nirdosha-plugin-native-authed-http");
+
+    let plugins = vec![
+        NativePluginBuiltin {
+            name: "authedhttp_provider_authedhttp_connect".to_string(),
+            params: vec![Ty::Str],
+            ret: Ty::I64,
+            static_lib: authedhttp_lib,
+            env_var: None,
+            default_max: None,
+        },
+        NativePluginBuiltin {
+            name: "authedhttp_provider_authedhttp_request".to_string(),
+            params: vec![Ty::I64, Ty::Str, Ty::Str],
+            ret: Ty::Str,
+            static_lib: authedhttp_lib,
+            env_var: None,
+            default_max: None,
+        },
+        NativePluginBuiltin {
+            name: "authedhttp_provider_authedhttp_is_valid".to_string(),
+            params: vec![Ty::I64],
+            ret: Ty::I64,
+            static_lib: authedhttp_lib,
+            env_var: None,
+            default_max: None,
+        },
+        NativePluginBuiltin {
+            name: "authedhttp_provider_authedhttp_close".to_string(),
+            params: vec![Ty::I64],
+            ret: Ty::I64,
+            static_lib: authedhttp_lib,
+            env_var: None,
+            default_max: None,
+        },
+    ];
+    for p in &plugins {
+        p.validate().unwrap_or_else(|e| panic!("{e}"));
+    }
+
+    // A real local HTTP server, bound to an ephemeral port (`:0`) --
+    // never a fixed port, to avoid CI collisions -- whose only job is to
+    // observe the incoming request's `Authorization` header and echo a
+    // fixed body back.
+    let server = tiny_http::Server::http("127.0.0.1:0").expect("binding an ephemeral local test server should succeed");
+    let port = server.server_addr().to_ip().expect("this test only binds an IP address, not a unix socket").port();
+
+    const EXPECTED_TOKEN: &str = "rfc0011-phase8-secret-token";
+    let observed_auth_header: std::sync::Arc<std::sync::Mutex<Option<String>>> = std::sync::Arc::new(std::sync::Mutex::new(None));
+    let observed_auth_header_for_server = observed_auth_header.clone();
+    let server_thread = std::thread::spawn(move || {
+        // Exactly one request is expected -- `call_via` is called once
+        // in the `.nir` program below.
+        let request = server.recv().expect("the test server should receive exactly one request");
+        let auth = request.headers().iter().find(|h| h.field.equiv("Authorization")).map(|h| h.value.as_str().to_string());
+        *observed_auth_header_for_server.lock().unwrap() = auth;
+        let response = tiny_http::Response::from_string("authed-ok".to_string());
+        request.respond(response).expect("responding to the test request should succeed");
+    });
+
+    let src = r#"
+        fn main() -> i64 {
+            let result: str = match call_via("authedhttp://127.0.0.1:PORT_PLACEHOLDER", "/secure", "payload") {
+                Err(e) => "ERR",
+                Ok(resp) => resp.body,
+            }
+            if result == "authed-ok" {
+                return 1
+            }
+            return 0
+        }
+    "#
+    .replace("PORT_PLACEHOLDER", &port.to_string());
+
+    let program = typecheck_and_own_with_plugins(&src, &plugins);
+    let report = analyze(&program);
+
+    let out_dir = std::env::temp_dir().join(format!("nirdosha_authed_http_plugin_example_bin_{}", std::process::id()));
+    std::fs::create_dir_all(&out_dir).unwrap();
+    let out_path = out_dir.join("authed_http_plugin_example_bin");
+
+    codegen::build_with_native_plugins(&program, &report, &out_path, codegen::OptLevel::O2, &plugins, &Default::default())
+        .expect("build_with_native_plugins should compile and link cleanly");
+
+    // The bearer token is set on the *compiled binary's own* process
+    // environment (not this test process's) -- `_connect` reads it via
+    // `std::env::var` at connect time, inside that child process.
+    let output = Command::new(&out_path)
+        .env("AUTHEDHTTP_BEARER_TOKEN", EXPECTED_TOKEN)
+        .output()
+        .expect("running the compiled binary should succeed");
+
+    server_thread.join().expect("the test server thread should not panic");
+
+    assert_eq!(output.status.code(), Some(1), "compiled binary's exit code (1 == the plugin's response body round-tripped correctly): {output:?}");
+    assert_eq!(
+        observed_auth_header.lock().unwrap().as_deref(),
+        Some(format!("Bearer {EXPECTED_TOKEN}").as_str()),
+        "the real local server must have observed exactly the Authorization header the plugin was told to send via env(...)"
+    );
 
     let _ = std::fs::remove_dir_all(out_dir);
 }

--- a/crates/compiler/tests/nirdosha_ops_console_v2.rs
+++ b/crates/compiler/tests/nirdosha_ops_console_v2.rs
@@ -179,10 +179,62 @@ fn nirdosha_ops_console_v2_answers_real_http_requests_with_real_auth_workflow_an
 
     // The `Disbursement` workflow, wired to a real route: starts a real
     // instance, advances Draft -> Approved, which really calls the mock
-    // webhook and really writes a durable `disbursements` row.
-    let approved = request("POST", "/api/purchase_orders/approve", &format!("Authorization: Bearer {admin_token}\r\n"), "{}");
+    // webhook and really writes a durable `disbursements` row. This PO
+    // is below the escalation threshold, so a plain admin token suffices.
+    let approved = request("POST", "/api/purchase_orders/approve", &format!("Authorization: Bearer {admin_token}\r\n"), &format!("{{\"id\":{id}}}"));
     let approved_body = json_body(&approved);
     assert_eq!(approved_body["value"], "approved", "approve response: {approved_body}");
+
+    // Real dual control: a purchase order at/above the escalation
+    // threshold refuses a plain admin token and only accepts a real
+    // finance_director one -- a structurally different `acquire`d
+    // callable, not an `if` inside the same function.
+    let large_created = request(
+        "POST",
+        "/api/create",
+        &format!("Authorization: Bearer {admin_token}\r\n"),
+        "{\"vendor\":\"Big Ticket Vendor\",\"amount_cents\":15000000}",
+    );
+    let large_created_body = json_body(&large_created);
+    assert_eq!(large_created_body["value"], "Big Ticket Vendor", "large create response: {large_created_body}");
+    let large_list = request("POST", "/api/purchase_orders/list", "", "{\"q\":\"Big Ticket\",\"offset\":0,\"limit\":10}");
+    let large_id = json_body(&large_list).as_array().unwrap()[0]["id"].as_i64().expect("large row should have a real id");
+
+    let admin_denied_large = request(
+        "POST",
+        "/api/purchase_orders/approve",
+        &format!("Authorization: Bearer {admin_token}\r\n"),
+        &format!("{{\"id\":{large_id}}}"),
+    );
+    let admin_denied_large_body = json_body(&admin_denied_large);
+    assert!(
+        admin_denied_large_body["value"].as_str().unwrap_or("").contains("finance_director"),
+        "a plain admin token must not be able to approve a large PO: {admin_denied_large_body}"
+    );
+
+    let director_login = request("POST", "/api/login", "", "{\"role\":\"finance_director\"}");
+    let director_token = json_body(&director_login)["value"].as_str().expect("director login should return a real token").to_string();
+    let director_approved_large = request(
+        "POST",
+        "/api/purchase_orders/approve",
+        &format!("Authorization: Bearer {director_token}\r\n"),
+        &format!("{{\"id\":{large_id}}}"),
+    );
+    let director_approved_large_body = json_body(&director_approved_large);
+    assert_eq!(director_approved_large_body["value"], "approved", "director approve response: {director_approved_large_body}");
+
+    // Real REJECT: the workflow's other real branch out of Draft.
+    let rejected = request("POST", "/api/purchase_orders/reject", &format!("Authorization: Bearer {admin_token}\r\n"), "{}");
+    let rejected_body = json_body(&rejected);
+    assert_eq!(rejected_body["value"], "rejected", "reject response: {rejected_body}");
+
+    // Real overdue detection (`list_disbursement_overdue`, driven by
+    // `Draft`'s own `sla_seconds`) -- nothing should be stale yet at
+    // test speed, but the route itself must answer with a real JSON
+    // array, not an error.
+    let overdue = request("GET", "/api/disbursements/overdue", "", "");
+    let overdue_rows = json_body(&overdue);
+    assert!(overdue_rows.is_array(), "overdue response should be a real JSON array: {overdue_rows}");
 
     // Real DELETE.
     let deleted = request(

--- a/crates/compiler/tests/nirdosha_ops_console_v2.rs
+++ b/crates/compiler/tests/nirdosha_ops_console_v2.rs
@@ -236,6 +236,30 @@ fn nirdosha_ops_console_v2_answers_real_http_requests_with_real_auth_workflow_an
     let overdue_rows = json_body(&overdue);
     assert!(overdue_rows.is_array(), "overdue response should be a real JSON array: {overdue_rows}");
 
+    // Three genuinely different per-role dashboards, each a real SQL
+    // aggregate over the same rows this test already created/mutated
+    // above -- not the same query answering all three.
+    let admin_dashboard = request("GET", "/api/dashboard/admin", "", "");
+    let admin_dashboard_rows = json_body(&admin_dashboard);
+    assert!(
+        admin_dashboard_rows.as_array().is_some_and(|rows| rows.iter().any(|r| r["vendor"] == "Big Ticket Vendor" && r["amount_cents"] == 15000000)),
+        "admin dashboard should show real spend-by-vendor, including the large PO's own real amount (proves the SUM(...)::bigint cast really works, not a null): {admin_dashboard_rows}"
+    );
+
+    let finance_dashboard = request("GET", "/api/dashboard/finance", "", "");
+    let finance_dashboard_rows = json_body(&finance_dashboard);
+    assert!(
+        finance_dashboard_rows.as_array().is_some_and(|rows| !rows.is_empty()),
+        "finance dashboard should show at least the disbursements this test already approved: {finance_dashboard_rows}"
+    );
+
+    let director_dashboard = request("GET", "/api/dashboard/finance_director", "", "");
+    let director_dashboard_rows = json_body(&director_dashboard);
+    assert!(
+        director_dashboard_rows.as_array().is_some_and(|rows| rows.iter().all(|r| r["amount_cents"].as_i64().unwrap_or(0) >= 10000000)),
+        "finance_director dashboard should only ever contain POs at/above the real escalation threshold: {director_dashboard_rows}"
+    );
+
     // Real DELETE.
     let deleted = request(
         "POST",

--- a/crates/compiler/tests/nirdosha_ops_console_v2.rs
+++ b/crates/compiler/tests/nirdosha_ops_console_v2.rs
@@ -1,0 +1,203 @@
+//! End-to-end verification for
+//! `examples/features/57_nirdosha_ops_console_server_v2.nir` — the
+//! strengthened companion to `56_nirdosha_ops_console_server.nir`: real
+//! signed-JWT auth (`mock_issue_token`/`oidc_validate_token`, not a
+//! forgeable header), the `Disbursement` workflow wired to a real route,
+//! and UPDATE/DELETE/search/pagination. Same "real client sockets
+//! against a real long-running compiled server process" pattern
+//! `nirdosha_ops_console.rs`'s own server test already established, plus
+//! a real mock-webhook listener (that file's own pattern too) since this
+//! file's `approve` route really calls one.
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::process::Command;
+
+use nirdosha::ast::Program;
+use nirdosha::codegen;
+use nirdosha::ownership::check_ownership;
+use nirdosha::parser::Parser;
+use nirdosha::smt::analyze;
+use nirdosha::token::Lexer;
+use nirdosha::typeck::typecheck;
+
+const SRC: &str = include_str!("../../../examples/features/57_nirdosha_ops_console_server_v2.nir");
+
+fn parse_checked(src: &str) -> Program {
+    let toks = Lexer::new(src).tokenize().expect("lex should succeed");
+    let program = Parser::new(toks).parse_program().expect("parse should succeed");
+    typecheck(&program).expect("should typecheck cleanly");
+    check_ownership(&program).expect("should ownership-check cleanly");
+    program
+}
+
+fn unique_suffix() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    COUNTER.fetch_add(1, Ordering::Relaxed)
+}
+
+fn unique_temp_path(label: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!("nirdosha_opsconsole_v2_{label}_{}_{}", std::process::id(), unique_suffix()));
+    p
+}
+
+/// Same real webhook stand-in `nirdosha_ops_console.rs::start_mock_webhook`
+/// uses, on this file's own fixed port (`18101`, distinct from `55_...`'s
+/// `18099` so both test files can run in the same `cargo test` process).
+fn start_mock_webhook(port: u16) {
+    let listener = TcpListener::bind(("127.0.0.1", port)).expect("mock webhook should bind its fixed port");
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { continue };
+            std::thread::spawn(move || {
+                let mut buf = [0u8; 4096];
+                let _ = stream.read(&mut buf);
+                let _ = stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+                let _ = stream.flush();
+            });
+        }
+    });
+}
+
+/// Real, but requires a real local Postgres at
+/// `postgres://postgres@127.0.0.1:5432/postgres` -- `#[ignore]`-gated,
+/// same convention `nirdosha_ops_console.rs` already established. Run
+/// locally with:
+/// `cargo test --release --test nirdosha_ops_console_v2 -- --ignored`
+#[test]
+#[ignore]
+fn nirdosha_ops_console_v2_answers_real_http_requests_with_real_auth_workflow_and_crud() {
+    start_mock_webhook(18101);
+
+    let program = parse_checked(SRC);
+    let report = analyze(&program);
+    let bin = unique_temp_path("server_bin");
+    codegen::build(&program, &report, &bin, codegen::OptLevel::O2).expect("codegen::build should succeed for this program");
+    let mut child = Command::new(&bin).spawn().expect("compiled server should start");
+
+    let request = |method: &str, path: &str, headers: &str, body: &str| -> String {
+        let mut attempt = 0;
+        let mut conn = loop {
+            match TcpStream::connect(("127.0.0.1", 8091)) {
+                Ok(s) => break s,
+                Err(_) if attempt < 100 => {
+                    attempt += 1;
+                    std::thread::sleep(std::time::Duration::from_millis(20));
+                }
+                Err(e) => panic!("could not connect to the compiled server: {e}"),
+            }
+        };
+        let req = format!("{method} {path} HTTP/1.1\r\nHost: x\r\nContent-Length: {}\r\n{headers}\r\n{body}", body.len());
+        conn.write_all(req.as_bytes()).unwrap();
+        let mut buf = Vec::new();
+        conn.read_to_end(&mut buf).unwrap();
+        String::from_utf8_lossy(&buf).into_owned()
+    };
+
+    let json_body = |response: &str| -> serde_json::Value {
+        let sep = response.find("\r\n\r\n").expect("response should have a header/body separator");
+        serde_json::from_str(&response[sep + 4..]).unwrap_or_else(|e| panic!("response body should be valid JSON: {e}\nresponse: {response}"))
+    };
+
+    // Real signed-JWT login, both roles.
+    let admin_login = request("POST", "/api/login", "", "{\"role\":\"admin\"}");
+    let admin_token = json_body(&admin_login)["value"].as_str().expect("admin login should return a real token").to_string();
+    assert!(admin_token.split('.').count() == 3, "should look like a real JWT (header.payload.signature): {admin_token}");
+
+    let finance_login = request("POST", "/api/login", "", "{\"role\":\"finance\"}");
+    let finance_token = json_body(&finance_login)["value"].as_str().expect("finance login should return a real token").to_string();
+
+    // No bearer token at all -- real rejection, not a silent pass-through.
+    let no_auth = request("POST", "/api/create", "", "{\"vendor\":\"No Auth Co\",\"amount_cents\":1}");
+    let no_auth_body = json_body(&no_auth);
+    assert!(
+        no_auth_body["value"].as_str().unwrap_or("").contains("missing"),
+        "a request with no bearer token should be refused: {no_auth_body}"
+    );
+
+    // Real RBAC: a finance token is a real, verified identity, but still
+    // denied by `check_role`/`acquire` for an admin-gated route.
+    let finance_denied = request(
+        "POST",
+        "/api/create",
+        &format!("Authorization: Bearer {finance_token}\r\n"),
+        "{\"vendor\":\"Denied Co\",\"amount_cents\":1}",
+    );
+    let finance_denied_body = json_body(&finance_denied);
+    assert!(
+        !finance_denied_body["value"].as_str().unwrap_or("").contains("Denied Co"),
+        "a finance-role token must not be able to create a purchase order: {finance_denied_body}"
+    );
+
+    // Real admin create.
+    let created = request(
+        "POST",
+        "/api/create",
+        &format!("Authorization: Bearer {admin_token}\r\n"),
+        "{\"vendor\":\"Browser Test Vendor\",\"amount_cents\":31337}",
+    );
+    let created_body = json_body(&created);
+    assert_eq!(created_body["value"], "Browser Test Vendor", "create response: {created_body}");
+
+    // Search finds it; an unrelated query doesn't.
+    let search_hit = request("POST", "/api/purchase_orders/list", "", "{\"q\":\"Browser Test\",\"offset\":0,\"limit\":10}");
+    let search_hit_rows = json_body(&search_hit);
+    assert!(
+        search_hit_rows.as_array().is_some_and(|rows| rows.iter().any(|r| r["vendor"] == "Browser Test Vendor")),
+        "search for a real substring should find the row: {search_hit_rows}"
+    );
+    let search_miss = request("POST", "/api/purchase_orders/list", "", "{\"q\":\"Definitely Not A Vendor\",\"offset\":0,\"limit\":10}");
+    let search_miss_rows = json_body(&search_miss);
+    assert!(search_miss_rows.as_array().is_some_and(|rows| rows.is_empty()), "search for a nonexistent vendor should find nothing: {search_miss_rows}");
+
+    let id = search_hit_rows
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["vendor"] == "Browser Test Vendor")
+        .expect("just asserted this exists")["id"]
+        .as_i64()
+        .expect("row should have a real integer id");
+
+    // Real UPDATE.
+    let updated = request(
+        "POST",
+        "/api/purchase_orders/update",
+        &format!("Authorization: Bearer {admin_token}\r\n"),
+        &format!("{{\"id\":{id},\"vendor\":\"Renamed Vendor\",\"amount_cents\":40000}}"),
+    );
+    let updated_body = json_body(&updated);
+    assert_eq!(updated_body["value"], "Renamed Vendor", "update response: {updated_body}");
+    let after_update = request("POST", "/api/purchase_orders/list", "", &format!("{{\"q\":\"Renamed\",\"offset\":0,\"limit\":10}}"));
+    let after_update_rows = json_body(&after_update);
+    assert!(
+        after_update_rows.as_array().is_some_and(|rows| rows.iter().any(|r| r["amount_cents"] == 40000)),
+        "the update should really have changed the row: {after_update_rows}"
+    );
+
+    // The `Disbursement` workflow, wired to a real route: starts a real
+    // instance, advances Draft -> Approved, which really calls the mock
+    // webhook and really writes a durable `disbursements` row.
+    let approved = request("POST", "/api/purchase_orders/approve", &format!("Authorization: Bearer {admin_token}\r\n"), "{}");
+    let approved_body = json_body(&approved);
+    assert_eq!(approved_body["value"], "approved", "approve response: {approved_body}");
+
+    // Real DELETE.
+    let deleted = request(
+        "POST",
+        "/api/purchase_orders/delete",
+        &format!("Authorization: Bearer {admin_token}\r\n"),
+        &format!("{{\"id\":{id}}}"),
+    );
+    let deleted_body = json_body(&deleted);
+    assert_eq!(deleted_body["value"], "true", "delete response: {deleted_body}");
+    let after_delete = request("POST", "/api/purchase_orders/list", "", &format!("{{\"q\":\"Renamed\",\"offset\":0,\"limit\":10}}"));
+    let after_delete_rows = json_body(&after_delete);
+    assert!(after_delete_rows.as_array().is_some_and(|rows| rows.is_empty()), "the deleted row should really be gone: {after_delete_rows}");
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = std::fs::remove_file(&bin);
+}

--- a/crates/plugin-example-native-authed-http/Cargo.toml
+++ b/crates/plugin-example-native-authed-http/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+name = "nirdosha-plugin-native-authed-http"
+version = "0.1.0"
+edition = "2024"
+description = "Reference native (compiled-path) Nirdosha plugin (rfcs/0011-uniform-service-provider-model.md Phase 8): a real call-shape provider -- authedhttp_provider_authedhttp_{connect,request,is_valid,close} -- demonstrating the concrete gap the RFC's own Motivation names (no way to set a custom Authorization header from .nir today) by making a real HTTP/1.1 request with a bearer token sourced from the process environment at connect time, injected as `Authorization: Bearer <token>`."
+
+[package.metadata.nirdosha]
+kind = "native-compiled"
+builtins = [
+    # `_connect(host: str) -> i64` -- `host` here is the *whole* dial
+    # string call_via's plugin fallback passes through
+    # (`kernel::plugin_provider::call_via`'s own `host = url.to_string()`),
+    # e.g. `authedhttp://127.0.0.1:54321`, not a stripped `host:port` --
+    # this plugin parses the scheme off itself. Per RFC 0011 §2's
+    # negative-sentinel convention, a connect failure (most commonly: no
+    # `AUTHEDHTTP_BEARER_TOKEN` set) returns a negative `i64`, never a
+    # panic.
+    { name = "authedhttp_provider_authedhttp_connect", params = ["str"], ret = "i64" },
+    # `_request(raw_conn: i64, path: str, body: str) -> str` -- RFC 0011
+    # §2's corrected `call`-shape contract. Makes one real HTTP/1.1
+    # request per call (no keep-alive/pooling on this side; that's the
+    # kernel's own `PoolRegistry<PluginManagedConnection>` job, Phase 5),
+    # with the bearer token stashed at `_connect` time set as
+    # `Authorization: Bearer <token>`. Returns the response body as
+    # plain `str` -- no status code crosses this ABI (RFC 0011's own
+    # disclosed cost, `nir_call_via`'s doc comment: a successful
+    # plugin-routed `call_via` always reports `status: 200`).
+    { name = "authedhttp_provider_authedhttp_request", params = ["i64", "str", "str"], ret = "str" },
+    { name = "authedhttp_provider_authedhttp_is_valid", params = ["i64"], ret = "i64" },
+    { name = "authedhttp_provider_authedhttp_close", params = ["i64"], ret = "i64" },
+]
+
+# Same "zero dependency on the `nirdosha` crate, std only" story as
+# `plugin-example-native-shout`/`plugin-example-native-kv` -- see either
+# crate's own Cargo.toml comment. The HTTP/1.1 request/response framing
+# below is hand-rolled over `std::net::TcpStream`, the same minimal
+# approach `runtime-kernels::kernel::http` uses for its own client-side
+# requests (this plugin crate cannot depend on `runtime-kernels` either
+# -- no shared crate exists between `compiler`/`runtime-kernels` and a
+# plugin crate, this RFC's own Context section), not a new external HTTP
+# client dependency.
+[dependencies]
+
+[lib]
+crate-type = ["staticlib"]
+
+# No `[profile.release]` here -- see `plugin-example-native-shout/Cargo.toml`'s
+# identical comment: a workspace member's own copy is silently ignored by
+# Cargo.

--- a/crates/plugin-example-native-authed-http/README.md
+++ b/crates/plugin-example-native-authed-http/README.md
@@ -1,0 +1,62 @@
+# nirdosha-plugin-native-authed-http
+
+The RFC 0011 reference for a real `call`-shape plugin
+(rfcs/0011-uniform-service-provider-model.md §2/§4/§8): a provider for
+the `authedhttp://` scheme, registered via `call_via`'s runtime plugin
+fallback, that makes a genuine HTTP/1.1 request with an
+`Authorization: Bearer <token>` header — the concrete gap the RFC's own
+Motivation names (`http_get`/`http_post`/`call_via`'s two core-served
+schemes have no way to set a custom header from `.nir` at all).
+
+## Try it
+
+```sh
+AUTHEDHTTP_BEARER_TOKEN=some-secret cargo build --release -p nirdosha-plugin-native-authed-http
+# produces target/release/libnirdosha_plugin_native_authed_http.a
+```
+
+`crates/compiler/tests/native_plugin_examples.rs` builds this exact
+crate, spins up a real local `tiny_http` server on an ephemeral port,
+links this plugin into a real `nirdosha build` output, compiles a `.nir`
+program that calls `call_via("authedhttp://127.0.0.1:<port>", ...)`, and
+asserts the server actually observed the expected `Authorization`
+header — `cargo test -p nirdosha --test native_plugin_examples`.
+
+## The four functions
+
+```toml
+[package.metadata.nirdosha]
+kind = "native-compiled"
+builtins = [
+    { name = "authedhttp_provider_authedhttp_connect", params = ["str"], ret = "i64" },
+    { name = "authedhttp_provider_authedhttp_request", params = ["i64", "str", "str"], ret = "str" },
+    { name = "authedhttp_provider_authedhttp_is_valid", params = ["i64"], ret = "i64" },
+    { name = "authedhttp_provider_authedhttp_close", params = ["i64"], ret = "i64" },
+]
+```
+
+`_connect` reads `AUTHEDHTTP_BEARER_TOKEN` from the process environment
+once, at connect time, and stashes it (with the target `host:port`)
+against a fresh handle — the credential-at-connect-time shape RFC 0011
+§2 specifies for `conn`/`call`-shape providers alike. `_request` makes
+one real `TcpStream`-backed HTTP/1.1 request per call (no keep-alive on
+this side — that's the kernel's own `PoolRegistry<
+PluginManagedConnection>` job, Phase 5), with the stashed token set as
+`Authorization: Bearer <token>`, and returns the response body as plain
+`str` (no separate status-code channel — `call_via`'s own disclosed
+cost, see `nir_call_via`'s doc comment in `runtime-kernels`).
+
+## What's honestly not covered
+
+- **No `Result`/status-code crossing** — same `str`-only ABI limit every
+  other native plugin in this repo has (`plugin-example-native-kv`'s own
+  README, "What's honestly not covered"). A transport failure comes back
+  as an `"ERR: ..."`-prefixed body string, not a distinguishable error
+  channel.
+- **No connection reuse inside the plugin itself** — deliberate; see
+  `src/lib.rs`'s own module doc for why pooling belongs one layer up, in
+  the kernel.
+
+## Full design
+
+rfcs/0011-uniform-service-provider-model.md.

--- a/crates/plugin-example-native-authed-http/src/lib.rs
+++ b/crates/plugin-example-native-authed-http/src/lib.rs
@@ -1,0 +1,190 @@
+//! `authedhttp_provider_authedhttp_{connect,request,is_valid,close}` —
+//! rfcs/0011-uniform-service-provider-model.md Phase 8's real, shipped
+//! `call`-shape plugin. Demonstrates the concrete gap the RFC's own
+//! Motivation names: `call_via`'s two core-HTTP-served schemes
+//! (`http://`/`https://`) have no way to attach a custom `Authorization`
+//! header from `.nir` code today — this plugin fills that gap for one
+//! specific scheme (`authedhttp://`) by sourcing a bearer token from the
+//! process environment at connect time and injecting it into every
+//! request it makes on that connection's behalf.
+//!
+//! ## Same hand-rolled state story as `plugin-example-native-kv`
+//!
+//! See that crate's own module doc for why: no compiled-path
+//! `HandleRegistry<T>` equivalent exists yet, so `CONNS`/`next_handle`
+//! below are the same ~15-line pattern every stateful compiled plugin
+//! currently writes by hand.
+//!
+//! ## Hand-rolled HTTP/1.1 client, not a dependency
+//!
+//! This crate cannot depend on `runtime-kernels` (no shared crate exists
+//! between it, `compiler`, and a plugin crate — this RFC's own Context
+//! section) or on any external HTTP client crate (the same "zero
+//! dependency beyond `std`" convention `plugin-example-native-shout`/
+//! `-kv` already establish, this crate's own `Cargo.toml` comment). The
+//! request/response framing below is the same minimal
+//! `std::net::TcpStream` + hand-written `Connection: close` request
+//! `runtime-kernels::kernel::http`'s own client path uses internally —
+//! this plugin doesn't need pooling or keep-alive itself, since that's
+//! already the kernel's job one layer up (`PoolRegistry<
+//! PluginManagedConnection>`, Phase 5): one real TCP connection per
+//! `_request` call is the correct scope here.
+
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+/// Must match every other plugin crate's own copy field-for-field (RFC
+/// 0011 §2, `kernel::pool::NirStr`'s own doc comment) — each plugin
+/// crate declares its own rather than sharing one, same as
+/// `plugin-example-native-kv`'s identical doc note.
+#[repr(C)]
+pub struct NirStr {
+    pub ptr: *const u8,
+    pub len: i64,
+}
+
+unsafe fn nir_str_to_string(s: &NirStr) -> String {
+    let bytes = unsafe { std::slice::from_raw_parts(s.ptr, s.len as usize) };
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+fn string_to_nir_str(s: String) -> NirStr {
+    let leaked: &'static mut [u8] = Box::leak(s.into_bytes().into_boxed_slice());
+    NirStr { ptr: leaked.as_ptr(), len: leaked.len() as i64 }
+}
+
+/// One live "connection" — really just the target `host:port` and the
+/// bearer token resolved once, at `_connect` time, per RFC 0011 §2's
+/// "the plugin's four functions never see a kernel id, only ever the
+/// raw handle it was given" contract. No actual TCP socket is held open
+/// between calls — see this module's own doc comment for why one fresh
+/// `TcpStream` per `_request` is the right scope here, not a gap.
+struct ConnState {
+    addr: String,
+    token: String,
+}
+
+fn conns() -> &'static Mutex<HashMap<i64, ConnState>> {
+    static CONNS: OnceLock<Mutex<HashMap<i64, ConnState>>> = OnceLock::new();
+    CONNS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn next_handle() -> i64 {
+    static NEXT: AtomicI64 = AtomicI64::new(1);
+    NEXT.fetch_add(1, Ordering::Relaxed)
+}
+
+/// `host` is the *whole* dial string `call_via`'s plugin fallback passes
+/// through unmodified (`kernel::plugin_provider::call_via`'s own `host =
+/// url.to_string()`), e.g. `authedhttp://127.0.0.1:54321` — this
+/// function strips the `authedhttp://` prefix itself rather than
+/// expecting it pre-stripped.
+///
+/// Reads the bearer token from `AUTHEDHTTP_BEARER_TOKEN` in the process
+/// environment once, here, at connect time — exactly the credential-at-
+/// connect-time pattern RFC 0011's own Phase 8 description names (the
+/// same env-var-sourced-credential shape `.nir`'s own `env(...)` builtin,
+/// Phase 1, exists to support — a real plugin reads its config via the
+/// process environment directly in its own Rust code, the same way any
+/// other native process would, rather than calling back into a `.nir`
+/// builtin).
+///
+/// Returns a negative `i64` on failure (RFC 0011 §2's own "0/1/negative
+/// sentinels every other kernel boundary already uses" convention) — no
+/// token set is the only failure mode this function has.
+#[unsafe(no_mangle)]
+pub extern "C" fn authedhttp_provider_authedhttp_connect(host: NirStr) -> i64 {
+    let url = unsafe { nir_str_to_string(&host) };
+    let addr = url.strip_prefix("authedhttp://").unwrap_or(url.as_str()).to_string();
+    let Ok(token) = std::env::var("AUTHEDHTTP_BEARER_TOKEN") else {
+        return -1;
+    };
+    let h = next_handle();
+    conns().lock().unwrap().insert(h, ConnState { addr, token });
+    h
+}
+
+/// One real HTTP/1.1 request per call, `Connection: close` (no keep-
+/// alive on this side — see this module's own doc comment), with
+/// `Authorization: Bearer <token>` set from the token stashed at
+/// `_connect` time. Returns the response body as plain `str` — RFC 0011
+/// §2's `_request` ABI has no separate status-code channel
+/// (`nir_call_via`'s own doc comment discloses this cost already), so a
+/// transport-level failure (host unreachable, connection refused) is
+/// reported by returning an `"ERR: ..."`-prefixed body rather than
+/// panicking or aborting the process; `nir_call_via` always reports
+/// `status: 200` for any plugin-routed response body regardless of this
+/// prefix, so a real caller has to check for it — the same lowest-
+/// common-denominator cost every `call_via` consumer already accepts.
+#[unsafe(no_mangle)]
+pub extern "C" fn authedhttp_provider_authedhttp_request(raw_conn: i64, path: NirStr, body: NirStr) -> NirStr {
+    let path = unsafe { nir_str_to_string(&path) };
+    let body = unsafe { nir_str_to_string(&body) };
+
+    let (addr, token) = {
+        let guard = conns().lock().unwrap();
+        match guard.get(&raw_conn) {
+            Some(c) => (c.addr.clone(), c.token.clone()),
+            None => return string_to_nir_str("ERR: connection not open".to_string()),
+        }
+    };
+
+    match do_request(&addr, &path, &token, &body) {
+        Ok(response_body) => string_to_nir_str(response_body),
+        Err(e) => string_to_nir_str(format!("ERR: {e}")),
+    }
+}
+
+fn do_request(addr: &str, path: &str, token: &str, body: &str) -> Result<String, String> {
+    let mut stream = TcpStream::connect(addr).map_err(|e| e.to_string())?;
+    let host_header = addr.split(':').next().unwrap_or(addr);
+    let request = format!(
+        "POST {path} HTTP/1.1\r\n\
+         Host: {host_header}\r\n\
+         Authorization: Bearer {token}\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\
+         \r\n\
+         {body}",
+        body.len()
+    );
+    stream.write_all(request.as_bytes()).map_err(|e| e.to_string())?;
+    let mut raw = Vec::new();
+    stream.read_to_end(&mut raw).map_err(|e| e.to_string())?;
+    let raw = String::from_utf8_lossy(&raw);
+    match raw.split_once("\r\n\r\n") {
+        Some((_headers, body)) => Ok(body.to_string()),
+        None => Ok(String::new()),
+    }
+}
+
+/// `1` if `raw_conn` still names a stashed connection, `0` otherwise —
+/// r2d2's own `test_on_check_out` default (`true`, never overridden by
+/// `PoolConfig::apply`, `pool.rs`'s own doc comment) means this runs on
+/// every checkout; always-valid here since no real socket is held open
+/// to go stale (this module's own doc comment) — the only way this
+/// returns `0` is a handle that's already been `_close`d.
+#[unsafe(no_mangle)]
+pub extern "C" fn authedhttp_provider_authedhttp_is_valid(raw_conn: i64) -> i64 {
+    if conns().lock().unwrap().contains_key(&raw_conn) {
+        1
+    } else {
+        0
+    }
+}
+
+/// Returns `1` on success, `0` if `raw_conn` was already closed (or
+/// never opened) — same double-close-is-defense-in-depth-only story as
+/// `plugin-example-native-kv::kv_close`'s own doc comment (a well-typed
+/// `.nir` program can never trigger the `0` case; `ownership.rs`'s
+/// affine tracking already rejects that at compile time).
+#[unsafe(no_mangle)]
+pub extern "C" fn authedhttp_provider_authedhttp_close(raw_conn: i64) -> i64 {
+    match conns().lock().unwrap().remove(&raw_conn) {
+        Some(_) => 1,
+        None => 0,
+    }
+}

--- a/crates/runtime-kernels/src/kernel/db.rs
+++ b/crates/runtime-kernels/src/kernel/db.rs
@@ -35,9 +35,9 @@
 
 use r2d2::ManageConnection;
 use std::str::FromStr;
-use std::sync::OnceLock;
+use std::sync::{Once, OnceLock};
 
-use super::pool::{PoolConfig, PoolRegistry};
+use super::pool::{self, PoolConfig, PoolRegistry};
 
 // ---- SQLite: a minimal custom manager, not `r2d2_sqlite` -----------
 //
@@ -83,7 +83,7 @@ impl ManageConnection for SqliteManager {
     fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
         let result = conn.query_row("SELECT 1", [], |_| Ok(())).map(|_| ());
         if result.is_err() {
-            super::record_stale_rehydrated(super::Domain::Db);
+            super::record_stale_rehydrated(super::domain::db());
         }
         result
     }
@@ -95,7 +95,14 @@ impl ManageConnection for SqliteManager {
 
 fn sqlite_pool_registry() -> &'static PoolRegistry<SqliteManager> {
     static REGISTRY: OnceLock<PoolRegistry<SqliteManager>> = OnceLock::new();
-    REGISTRY.get_or_init(PoolRegistry::new)
+    static REGISTERED: Once = Once::new();
+    let registry = REGISTRY.get_or_init(PoolRegistry::new);
+    // RFC 0011 §5: every pool-backed registry registers itself with the
+    // reaper once, the first time it's actually reached — a lazily-built
+    // process, same posture `domain::db()`'s own self-registration
+    // already has (Phase 2a).
+    REGISTERED.call_once(|| pool::register_for_reaping(registry));
+    registry
 }
 
 // ---- Postgres --------------------------------------------------------
@@ -126,7 +133,7 @@ impl ManageConnection for PostgresManager {
     fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
         let result = conn.simple_query("SELECT 1").map(|_| ());
         if result.is_err() {
-            super::record_stale_rehydrated(super::Domain::Db);
+            super::record_stale_rehydrated(super::domain::db());
         }
         result
     }
@@ -138,7 +145,10 @@ impl ManageConnection for PostgresManager {
 
 fn postgres_pool_registry() -> &'static PoolRegistry<PostgresManager> {
     static REGISTRY: OnceLock<PoolRegistry<PostgresManager>> = OnceLock::new();
-    REGISTRY.get_or_init(PoolRegistry::new)
+    static REGISTERED: Once = Once::new();
+    let registry = REGISTRY.get_or_init(PoolRegistry::new);
+    REGISTERED.call_once(|| pool::register_for_reaping(registry));
+    registry
 }
 
 fn is_local_host(host: &postgres::config::Host) -> bool {
@@ -216,11 +226,11 @@ impl DbConn {
 }
 
 /// `env_var`/`default_max` pair this phase's pool sizing follows —
-/// `pool.max_size` must be `≥` `Domain::Db`'s own admission ceiling
+/// `pool.max_size` must be `≥` the `db` domain's own admission ceiling
 /// (this phase's own review: admission never blocks, but `Pool::get()`
 /// does, so the ceiling — not a smaller pool — has to stay the one real
-/// choke point). `Domain::Db`'s default ceiling is 10,000
-/// (`kernel/mod.rs::Domain::default_max`) — deliberately generous, not
+/// choke point). The `db` domain's default ceiling is 10,000
+/// (`kernel/mod.rs::BUILTIN_DOMAINS`) — deliberately generous, not
 /// production-tuned, so this phase's own pool default follows the same
 /// posture rather than silently becoming the tighter constraint.
 fn db_pool_config() -> PoolConfig {
@@ -237,6 +247,32 @@ fn db_pool_config() -> PoolConfig {
 /// the validation round-trip, not just the connect (this phase's own
 /// review): the default budget now covers connect *plus* the mandatory
 /// `SELECT 1` above, not connect alone.
+///
+/// **This function itself never calls `kernel::acquire`/`release`** —
+/// don't mistake that for the `db` domain's ceiling being unenforced.
+/// The admission gate lives one layer up, around this function's only
+/// two callers: `lib.rs`'s `nir_db_connect` (`kernel::acquire(domain::db())`
+/// before calling this, released on error) and `nir_db_stop`
+/// (`kernel::release(domain::db())` on handle close) — the
+/// connect-to-stop session lifecycle is bracketed there, not here,
+/// because the affine `db` handle (and thus the session's true end) is
+/// a `HandleTable` concept `lib.rs` owns, not something this module
+/// tracks. A grep of this file alone for `acquire` will find nothing;
+/// check `lib.rs`'s `nir_db_connect`/`nir_db_stop` before concluding the
+/// ceiling is decorative.
+/// RFC 0011 §2 step 1: "check built-in schemes first... if none match,"
+/// fall through to the plugin provider table. `lib.rs`'s `nir_db_connect`
+/// needs this *before* it can decide which domain to
+/// `kernel::acquire` — a bare path/`:memory:`/`postgres[ql]://` always
+/// means the built-in `db` domain and this module's own `connect`
+/// below; anything else means a plugin's own registered domain and
+/// `plugin_provider::connect_conn_shape` instead. Kept in sync with
+/// `connect`'s own scheme matching by construction: both read this one
+/// function's result rather than duplicating the scheme list.
+pub fn is_builtin_scheme(conn_str: &str) -> bool {
+    conn_str.starts_with("postgres://") || conn_str.starts_with("postgresql://") || !conn_str.contains("://")
+}
+
 pub fn connect(conn_str: &str) -> Result<DbConn, String> {
     if conn_str.starts_with("postgres://") || conn_str.starts_with("postgresql://") {
         let pool = postgres_pool_registry().get_or_create(conn_str, db_pool_config(), || build_postgres_manager(conn_str))?;
@@ -528,7 +564,7 @@ mod tests {
         // already observed the close by the time this call returns.
         std::thread::sleep(std::time::Duration::from_millis(200));
 
-        let before = super::super::stats(super::super::Domain::Db).3;
+        let before = super::super::stats(super::super::domain::db()).3;
         // The pooled connection killer's own checkout is now itself
         // stale for the *next* caller too, in general -- but the one
         // under test here is the original, now-terminated backend:
@@ -538,7 +574,7 @@ mod tests {
         let row = conn.query_one("SELECT 1", &[]).expect("the rehydrated connection must actually work");
         let one: i32 = row.get(0);
         assert_eq!(one, 1);
-        let after = super::super::stats(super::super::Domain::Db).3;
+        let after = super::super::stats(super::super::domain::db()).3;
         assert!(after > before, "record_stale_rehydrated must have fired for the killed connection");
     }
 }

--- a/crates/runtime-kernels/src/kernel/http.rs
+++ b/crates/runtime-kernels/src/kernel/http.rs
@@ -32,11 +32,11 @@
 
 use std::io::{Read, Write};
 use std::net::TcpStream;
-use std::sync::OnceLock;
+use std::sync::{Once, OnceLock};
 
 use r2d2::ManageConnection;
 
-use super::pool::{PoolConfig, PoolRegistry};
+use super::pool::{self, PoolConfig, PoolRegistry};
 
 pub struct HttpParsed {
     pub status: i64,
@@ -317,7 +317,7 @@ impl ManageConnection for HttpManager {
         };
         let _ = conn.stream.set_nonblocking(false);
         if result.is_err() {
-            super::record_stale_rehydrated(super::Domain::Http);
+            super::record_stale_rehydrated(super::domain::http());
         }
         result.map_err(HttpError)
     }
@@ -329,7 +329,12 @@ impl ManageConnection for HttpManager {
 
 fn http_pool_registry() -> &'static PoolRegistry<HttpManager> {
     static REGISTRY: OnceLock<PoolRegistry<HttpManager>> = OnceLock::new();
-    REGISTRY.get_or_init(PoolRegistry::new)
+    static REGISTERED: Once = Once::new();
+    let registry = REGISTRY.get_or_init(PoolRegistry::new);
+    // RFC 0011 §5: every pool-backed registry registers itself with the
+    // reaper once, lazily, the first time it's reached.
+    REGISTERED.call_once(|| pool::register_for_reaping(registry));
+    registry
 }
 
 // ---- HTTPS ---------------------------------------------------------------
@@ -376,11 +381,14 @@ impl ManageConnection for HttpsManager {
 
 fn https_pool_registry() -> &'static PoolRegistry<HttpsManager> {
     static REGISTRY: OnceLock<PoolRegistry<HttpsManager>> = OnceLock::new();
-    REGISTRY.get_or_init(PoolRegistry::new)
+    static REGISTERED: Once = Once::new();
+    let registry = REGISTRY.get_or_init(PoolRegistry::new);
+    REGISTERED.call_once(|| pool::register_for_reaping(registry));
+    registry
 }
 
 /// Same reasoning as `kernel::db::db_pool_config` -- `pool.max_size`
-/// must stay `≥` `Domain::Http`'s own admission ceiling, so the
+/// must stay `≥` the `http` domain's own admission ceiling, so the
 /// ceiling (not a smaller pool) stays the one real, observable choke
 /// point.
 fn http_pool_config() -> PoolConfig {
@@ -417,12 +425,12 @@ fn send_and_read(stream: &mut (impl Read + Write), req_bytes: &[u8], leftover: V
 }
 
 /// One request, over a pooled, keep-alive connection. Admission
-/// (`kernel::acquire(Domain::Http)`/`release`) is held for exactly the
+/// (`kernel::acquire(domain::http())`/`release`) is held for exactly the
 /// duration of this one call (both attempts, if a retry happens) --
 /// unlike `db`'s affine handle, an HTTP client call has no
 /// caller-visible session to hold it open across.
 pub fn request_http(host: &str, port: i64, path: &str, method: &str, body: Option<&str>, bearer_token: Option<&str>) -> Result<HttpParsed, String> {
-    if !super::acquire(super::Domain::Http) {
+    if !super::acquire(super::domain::http()) {
         return Err("too many open http connections".to_string());
     }
     let result = (|| {
@@ -455,12 +463,12 @@ pub fn request_http(host: &str, port: i64, path: &str, method: &str, body: Optio
             }
         }
     })();
-    super::release(super::Domain::Http);
+    super::release(super::domain::http());
     result
 }
 
 pub fn request_https(host: &str, port: i64, path: &str, method: &str, body: Option<&str>) -> Result<HttpParsed, String> {
-    if !super::acquire(super::Domain::Http) {
+    if !super::acquire(super::domain::http()) {
         return Err("too many open http connections".to_string());
     }
     let result = (|| {
@@ -490,7 +498,7 @@ pub fn request_https(host: &str, port: i64, path: &str, method: &str, body: Opti
             }
         }
     })();
-    super::release(super::Domain::Http);
+    super::release(super::domain::http());
     result
 }
 

--- a/crates/runtime-kernels/src/kernel/mod.rs
+++ b/crates/runtime-kernels/src/kernel/mod.rs
@@ -120,106 +120,229 @@ pub mod identity;
 pub mod instance_lock;
 pub mod mailbox;
 pub mod nfr;
+pub mod plugin_provider;
 pub mod pool;
+pub mod reaper;
 pub mod recorder;
 pub mod thread_pool;
 pub mod transact;
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicI64, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
 
-/// One resource domain the kernel admits/tracks. Deliberately a closed,
-/// explicit enum (not a string or an open trait) — the same "notation
-/// with nothing to check" argument `ast::Effect`'s own doc comment
-/// makes for why *that* set is closed too: a domain with no kernel
-/// logic behind it yet would be a variant nothing exercises. Add one
-/// here, and its own two entries in `counters_for`/`Domain::env_var`,
-/// exactly when a real resource (a `json` handle table, a `db`
-/// connection pool) needs it — not speculatively ahead of that.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum Domain {
-    Tcp,
-    File,
-    /// One outstanding `thread` handle (between `spawn` and its
-    /// matching `join`) — the same ceiling-on-concurrently-held
-    /// resources tcp/file already get, now that `spawn`/`join` are real
-    /// (`nir_thread_spawn`/`nir_thread_join`, `lib.rs`'s "chan/spawn/
-    /// join kernels" section). `chan` deliberately has no domain here:
-    /// unlike a thread handle, a channel handle is never released
-    /// (`Ty::Channel` has no `stop` case — `nir_chan_new`'s own doc
-    /// comment), so a concurrently-*held* ceiling doesn't fit its
-    /// lifecycle the way it fits an affine handle's acquire/release
-    /// pair; a total-ever-created cap would be a different, not-yet-
-    /// asked-for kind of limit.
-    Thread,
-    /// One outstanding `db` connection (between `db_connect` and its
-    /// matching `stop`) — same ceiling-on-concurrently-held-affine-
-    /// handles shape as `Tcp`/`File` above, now that a real SQLite
-    /// backend exists (`nir_db_connect`, `lib.rs`'s "db kernels"
-    /// section). Appended after `Thread`, not inserted earlier, so
-    /// every existing `Domain as u8` discriminant this module's own
-    /// flight-recorder encoding (`kernel::recorder::domain_name`)
-    /// depends on stays stable.
-    Db,
-    /// One outstanding `mq` (Redis) connection — same shape as `Db`
-    /// just above, appended after it for the same "existing `Domain as
-    /// u8` discriminants stay stable" reason.
-    Mq,
-    /// One outstanding `http`/`https` connection (between `http_get`/
-    /// `http_post`/`https_get`/`https_post`'s pooled checkout and its
-    /// return) — same shape as `Db`/`Mq`, appended last for the same
-    /// discriminant-stability reason. Unlike `Db`, `http`/`https` has
-    /// no user-visible affine handle to hold this ceiling open across
-    /// (a client call is one request, not an open-then-`stop` session)
-    /// — admission is held for the duration of one pooled checkout,
-    /// released as soon as that request's connection returns to (or is
-    /// evicted from) the pool.
-    Http,
-    /// One outstanding compiled-`serve` (ROADMAP B8, `crates/compiled-serve`)
-    /// connection-handling thread — held for the whole life of a
-    /// keep-alive HTTP connection, including idle time between
-    /// requests, not just the time spent actually handling one. A
-    /// deliberately **separate** domain from `Thread`, not a reuse of
-    /// it: sharing `Thread`'s ceiling would mean a few hundred idle
-    /// browser tabs (each holding one keep-alive connection open,
-    /// ordinary behavior, not an attack) could fill it and start
-    /// denying user `spawn` calls inside request handlers — and since a
-    /// denied `spawn` returns a bare `-1` with no `Result` (a real,
-    /// separately-tracked language gap, not fixed here), a handler with
-    /// no way to notice would wedge on a `chan.recv()` that never
-    /// answers, invisibly, instead of failing fast. A dedicated domain
-    /// keeps "server saturated" and "compute saturated" distinguishable
-    /// in the flight recorder, and keeps one from starving the other.
-    ServeHttp,
+/// A resource domain the kernel admits/tracks, identified by a plain
+/// `u32` index into [`DOMAIN_SLOTS`] rather than a closed enum variant —
+/// **RFC 0011 §3's open registry**, replacing the old closed `enum
+/// Domain` (7 hardcoded variants) so a future plugin-registered domain
+/// (a `db`/`call`-shape provider's own scheme, RFC 0011 §2) can mint a
+/// domain at runtime instead of needing a recompile of this crate. `0`
+/// is a valid id here (unlike [`HandleTable`]'s reserved-`0` convention)
+/// — the first domain [`domain::register_builtin_domains`] registers
+/// (`tcp`) legitimately gets id `0`.
+pub type DomainId = u32;
+
+/// Hard ceiling on how many domains this process can ever register —
+/// 7 built-ins plus however many plugin providers a program links in
+/// (RFC 0011 §2/§4). 4096 is deliberately generous headroom over any
+/// realistic plugin count, chosen so [`recorder::Event`]'s `u16` domain
+/// field (65536 range) stays comfortably larger than this ceiling with
+/// room to spare, per this phase's own recorder-widening rationale.
+/// Exceeding it is a loud startup-time panic in [`register_domain`],
+/// never silent truncation or wraparound.
+const MAX_DOMAINS: usize = 4096;
+
+static NEXT_DOMAIN: AtomicU32 = AtomicU32::new(0);
+
+/// Per-domain metadata captured at registration time — the env-var name
+/// and default ceiling `max_for` needs to lazily resolve a domain's
+/// ceiling on first `acquire`, now that these aren't compile-time enum
+/// methods (`Domain::env_var`/`Domain::default_max`) anymore.
+struct DomainMeta {
+    env_var: &'static str,
+    default_max: i64,
 }
 
-impl Domain {
-    /// Read once per domain, lazily, on first `acquire` — an operator
-    /// can raise or lower the ceiling per deployment without a
-    /// recompile, the same override-by-env-var convention
-    /// `crates/compiler/src/pool.rs`'s `PoolConfig` already
-    /// establishes for the interpreter's own (now-removed) DB pooling.
-    fn env_var(self) -> &'static str {
-        match self {
-            Domain::Tcp => "NIRDOSHA_KERNEL_MAX_TCP",
-            Domain::File => "NIRDOSHA_KERNEL_MAX_FILE",
-            Domain::Thread => "NIRDOSHA_KERNEL_MAX_THREAD",
-            Domain::Db => "NIRDOSHA_KERNEL_MAX_DB",
-            Domain::Mq => "NIRDOSHA_KERNEL_MAX_MQ",
-            Domain::Http => "NIRDOSHA_KERNEL_MAX_HTTP",
-            Domain::ServeHttp => "NIRDOSHA_KERNEL_MAX_SERVE_HTTP",
-        }
+static DOMAIN_META: [OnceLock<DomainMeta>; MAX_DOMAINS] = [const { OnceLock::new() }; MAX_DOMAINS];
+static DOMAIN_NAMES: [OnceLock<&'static str>; MAX_DOMAINS] = [const { OnceLock::new() }; MAX_DOMAINS];
+
+/// Name → id, so [`register_domain`] can be idempotent by name (calling
+/// it twice for the same name — e.g. `domain::register_builtin_domains()`
+/// running more than once, see that function's own doc comment — returns
+/// the same [`DomainId`] rather than minting a second one).
+static NAME_INDEX: OnceLock<Mutex<HashMap<&'static str, DomainId>>> = OnceLock::new();
+
+/// Registers one resource domain, minting a fresh [`DomainId`] the first
+/// time `name` is seen and returning the existing one on any later call
+/// with the same `name` — registration is rare (startup-time only, never
+/// on any hot path), so this serializes on one lock for the whole
+/// operation rather than trying to be lock-free, unlike [`acquire`]/
+/// [`release`] which very much need to be.
+///
+/// `env_var`/`default_max` follow the same override-by-env-var
+/// convention `crates/compiler/src/pool.rs`'s `PoolConfig` already
+/// establishes: `env_var` is read once, lazily, on this domain's first
+/// `acquire` (`max_for`), falling back to `default_max` if unset,
+/// unparseable, or `<= 0`.
+///
+/// Panics loudly if registering a genuinely new name would exceed
+/// [`MAX_DOMAINS`] — a startup-time configuration error, never something
+/// a well-behaved running program should silently truncate or wrap
+/// around on.
+pub fn register_domain(name: &'static str, env_var: &'static str, default_max: i64) -> DomainId {
+    let index = NAME_INDEX.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut map = index.lock().unwrap();
+    if let Some(&existing) = map.get(name) {
+        return existing;
+    }
+    let id = NEXT_DOMAIN.fetch_add(1, Ordering::Relaxed);
+    if (id as usize) >= MAX_DOMAINS {
+        // Drop the lock *before* panicking, deliberately -- panicking
+        // while still holding a `std::sync::Mutex` guard poisons it
+        // permanently, which would make every future `register_domain`
+        // call (even for an already-registered name, whose lookup above
+        // also needs this same lock) panic too, forever, for the rest of
+        // the process. In real production use this panic is meant to be
+        // fatal anyway (a startup-time configuration error), so it
+        // wouldn't matter -- but it does matter to anything that catches
+        // this panic and keeps running (this module's own test for this
+        // exact case), so this is cleaned up regardless of who's asking.
+        drop(map);
+        panic!(
+            "nirdosha kernel: MAX_DOMAINS ({MAX_DOMAINS}) exceeded registering domain {name:?} -- \
+             raise MAX_DOMAINS or investigate a domain-registration loop/leak"
+        );
+    }
+    DOMAIN_META[id as usize].set(DomainMeta { env_var, default_max }).ok().expect("a freshly-minted DomainId's slot must be unclaimed");
+    DOMAIN_NAMES[id as usize].set(name).ok().expect("a freshly-minted DomainId's slot must be unclaimed");
+    map.insert(name, id);
+    id
+}
+
+/// Looks up an already-registered domain's id by name, without
+/// registering anything — RFC 0011 §2's plugin-provider dispatch table
+/// registration (`plugin_provider::register`) needs a provider's
+/// `DomainId` to store alongside its function pointers, and by the time
+/// that call happens (`codegen.rs` always emits `nir_kernel_register_
+/// domain` for a given provider immediately before `nir_kernel_register_
+/// plugin_provider` for the same one, in the same preamble loop
+/// iteration), the domain is already registered — so this is a plain
+/// lookup, not a second registration path. `None` would mean codegen
+/// emitted these calls out of order or for mismatched providers, a
+/// compiler bug, not a runtime condition to recover from gracefully.
+pub fn domain_id_for_name(name: &str) -> Option<DomainId> {
+    let index = NAME_INDEX.get_or_init(|| Mutex::new(HashMap::new()));
+    index.lock().unwrap_or_else(|e| e.into_inner()).get(name).copied()
+}
+
+/// Domain ids/names actually registered so far, in registration order —
+/// [`dump_report`] and [`recorder::domain_name`] both need this instead
+/// of a fixed 7-entry list now that the domain set is open.
+fn registered_domains() -> Vec<(DomainId, &'static str)> {
+    let n = (NEXT_DOMAIN.load(Ordering::Relaxed) as usize).min(MAX_DOMAINS) as u32;
+    (0..n).filter_map(|id| DOMAIN_NAMES[id as usize].get().map(|&name| (id, name))).collect()
+}
+
+/// Looks up the name for one domain id — `None` for an id past whatever
+/// has been registered so far (e.g. a corrupt/foreign value), in which
+/// case the caller (`recorder::domain_name`) falls back to `"unknown"`
+/// the same way it always has.
+fn registered_domain_name(id: DomainId) -> Option<&'static str> {
+    DOMAIN_NAMES.get(id as usize).and_then(|cell| cell.get().copied())
+}
+
+/// The 7 built-in resource domains this kernel has always tracked —
+/// `(name, env_var, default_max)`, in the fixed order `tcp, file,
+/// thread, db, mq, http, serve_http`. **This one array is the only
+/// place that order is written down** — it both drives
+/// [`domain::register_builtin_domains`]'s registration loop and, via
+/// that same loop, is what fills [`domain`]'s 7 `OnceLock<DomainId>`
+/// cells. `codegen.rs` emits exactly one call to
+/// `nir_kernel_register_builtin_domains` (→ `domain::
+/// register_builtin_domains`) in every compiled program's `main`
+/// preamble, strictly before any user code — it carries zero knowledge
+/// of this set or its order, unlike an earlier design this phase
+/// replaced (codegen emitting one `register_domain(...)` call per
+/// built-in, a second, driftable copy of this exact list).
+const BUILTIN_DOMAINS: [(&str, &str, i64); 7] = [
+    ("tcp", "NIRDOSHA_KERNEL_MAX_TCP", 10_000),
+    ("file", "NIRDOSHA_KERNEL_MAX_FILE", 10_000),
+    ("thread", "NIRDOSHA_KERNEL_MAX_THREAD", 10_000),
+    ("db", "NIRDOSHA_KERNEL_MAX_DB", 10_000),
+    ("mq", "NIRDOSHA_KERNEL_MAX_MQ", 10_000),
+    ("http", "NIRDOSHA_KERNEL_MAX_HTTP", 10_000),
+    ("serve_http", "NIRDOSHA_KERNEL_MAX_SERVE_HTTP", 10_000),
+];
+
+/// Stable, non-compile-time-constant handles to the 7 built-in domains
+/// — replaces the old closed `enum Domain`'s variants. Every accessor
+/// here (`tcp()`, `file()`, ...) reads an `OnceLock<DomainId>` cell
+/// filled once by [`register_builtin_domains`], instead of being a bare
+/// compile-time constant the way `domain::tcp()` used to be — a real,
+/// documented precondition this phase introduces (see each accessor's
+/// own doc comment) where none existed before.
+pub mod domain {
+    use super::{register_domain, DomainId, BUILTIN_DOMAINS};
+    use std::sync::{Once, OnceLock};
+
+    static TCP: OnceLock<DomainId> = OnceLock::new();
+    static FILE: OnceLock<DomainId> = OnceLock::new();
+    static THREAD: OnceLock<DomainId> = OnceLock::new();
+    static DB: OnceLock<DomainId> = OnceLock::new();
+    static MQ: OnceLock<DomainId> = OnceLock::new();
+    static HTTP: OnceLock<DomainId> = OnceLock::new();
+    static SERVE_HTTP: OnceLock<DomainId> = OnceLock::new();
+
+    static INIT: Once = Once::new();
+
+    /// Registers all 7 built-in domains, in [`BUILTIN_DOMAINS`]'s fixed
+    /// order, filling this module's 7 cells so `tcp()`/`file()`/...
+    /// resolve to stable ids for the rest of the process's life.
+    /// Idempotent (`Once`-guarded): safe to call more than once, from
+    /// more than one thread — later calls are no-ops. `codegen.rs`
+    /// emits exactly one call to this (via `nir_kernel_register_builtin_
+    /// domains`) at the very top of every compiled program's `main`,
+    /// strictly before any user code, which is what actually gives the
+    /// 7 built-ins their historical, stable ids 0-6 in a compiled
+    /// binary (nothing else can have registered a domain first). Each
+    /// accessor below also calls this itself before reading its cell —
+    /// a deliberate self-healing safety net for callers that reach a
+    /// domain accessor outside a compiled program's `main` (this
+    /// crate's own unit tests, `compiled-serve`'s tests, any future
+    /// direct library use) rather than a hard "you forgot to call this"
+    /// panic — `Once` makes the net free after the first real call.
+    pub fn register_builtin_domains() {
+        INIT.call_once(|| {
+            let cells = [&TCP, &FILE, &THREAD, &DB, &MQ, &HTTP, &SERVE_HTTP];
+            for (cell, (name, env_var, default_max)) in cells.into_iter().zip(BUILTIN_DOMAINS.iter()) {
+                let id = register_domain(name, env_var, *default_max);
+                cell.set(id).ok().expect("register_builtin_domains must only ever run its registration body once (Once-guarded)");
+            }
+        });
     }
 
-    /// Deliberately generous, not a production-tuned ceiling — this
-    /// exists to prove the admission mechanism is real and load-bearing,
-    /// not to actually constrain a well-behaved program today. Tighten
-    /// per-deployment via the env var above once there's a real reason
-    /// to.
-    fn default_max(self) -> i64 {
-        10_000
+    macro_rules! accessor {
+        ($name:ident, $cell:ident, $doc:literal) => {
+            #[doc = $doc]
+            ///
+            /// Precondition: [`register_builtin_domains`] must have run
+            /// at least once in this process before this is called (it
+            /// self-registers on demand if not, so this is a safety net
+            /// rather than a hard requirement — see that function's own
+            /// doc comment).
+            pub fn $name() -> DomainId {
+                register_builtin_domains();
+                *$cell.get().expect("register_builtin_domains just ran unconditionally above; the cell must be set")
+            }
+        };
     }
+    accessor!(tcp, TCP, "The built-in `tcp` domain.");
+    accessor!(file, FILE, "The built-in `file` domain.");
+    accessor!(thread, THREAD, "The built-in `thread` domain.");
+    accessor!(db, DB, "The built-in `db` domain.");
+    accessor!(mq, MQ, "The built-in `mq` domain.");
+    accessor!(http, HTTP, "The built-in `http` domain.");
+    accessor!(serve_http, SERVE_HTTP, "The built-in `serve_http` domain.");
 }
 
 struct DomainCounters {
@@ -250,34 +373,40 @@ impl DomainCounters {
 /// code. Deliberately separate from [`acquire`]/[`release`]: rehydration
 /// is a pool-level event, not an admission decision — a rehydrated
 /// checkout still went through a real `acquire` either way.
-pub fn record_stale_rehydrated(domain: Domain) {
+pub fn record_stale_rehydrated(domain: DomainId) {
     counters_for(domain).stale_rehydrated.fetch_add(1, Ordering::Relaxed);
 }
 
-static TCP: DomainCounters = DomainCounters::new();
-static FILE: DomainCounters = DomainCounters::new();
-static THREAD: DomainCounters = DomainCounters::new();
-static DB: DomainCounters = DomainCounters::new();
-static MQ: DomainCounters = DomainCounters::new();
-static HTTP: DomainCounters = DomainCounters::new();
-static SERVE_HTTP: DomainCounters = DomainCounters::new();
+/// Every domain's counters, indexed directly by [`DomainId`] — the open-
+/// registry replacement for the old 7 named `static`s + `counters_for`
+/// match. A plain array index, same as before: this is the load-bearing
+/// non-blocking property (this module's own doc comment, point 2) —
+/// `acquire`/`release` must stay zero-lock, zero-allocation, zero-syscall
+/// reads/writes into this array, exactly as they were against the old
+/// named statics.
+static DOMAIN_SLOTS: [DomainCounters; MAX_DOMAINS] = [const { DomainCounters::new() }; MAX_DOMAINS];
 
-fn counters_for(domain: Domain) -> &'static DomainCounters {
-    match domain {
-        Domain::Tcp => &TCP,
-        Domain::File => &FILE,
-        Domain::Thread => &THREAD,
-        Domain::Db => &DB,
-        Domain::Mq => &MQ,
-        Domain::Http => &HTTP,
-        Domain::ServeHttp => &SERVE_HTTP,
-    }
+fn counters_for(domain: DomainId) -> &'static DomainCounters {
+    &DOMAIN_SLOTS[domain as usize]
 }
 
-fn max_for(domain: Domain, counters: &DomainCounters) -> i64 {
+fn max_for(domain: DomainId, counters: &DomainCounters) -> i64 {
     *counters.max.get_or_init(|| {
-        std::env::var(domain.env_var()).ok().and_then(|s| s.parse::<i64>().ok()).filter(|&n| n > 0).unwrap_or_else(|| domain.default_max())
+        let meta = DOMAIN_META[domain as usize].get().expect("max_for called for a DomainId that was never registered");
+        std::env::var(meta.env_var).ok().and_then(|s| s.parse::<i64>().ok()).filter(|&n| n > 0).unwrap_or(meta.default_max)
     })
+}
+
+/// Public wrapper around a domain's resolved admission ceiling —
+/// RFC 0011 §5's "what the ceiling actually bounds": `pool.rs`'s
+/// registration-time enforcement (`get_or_create_within_ceiling`) reads
+/// this to refuse building a provider's pool if its own
+/// `PoolConfig::max_size` would exceed it, rather than letting r2d2
+/// silently grow physical connections past a ceiling nothing consults.
+/// Reuses `max_for`'s own env-var-resolution/caching rather than a
+/// second copy of that logic.
+pub fn ceiling_for(domain: DomainId) -> i64 {
+    max_for(domain, counters_for(domain))
 }
 
 /// Attempts to admit one more concurrently-held resource in `domain`.
@@ -288,7 +417,7 @@ fn max_for(domain: Domain, counters: &DomainCounters) -> i64 {
 /// return `-1` uniformly today — this is deliberately not yet a
 /// distinct error code; that's real future work, not a gap to route
 /// around today, see this module's own doc comment).
-pub fn acquire(domain: Domain) -> bool {
+pub fn acquire(domain: DomainId) -> bool {
     let counters = counters_for(domain);
     let max = max_for(domain, counters);
     let mut current = counters.held.load(Ordering::Relaxed);
@@ -315,7 +444,7 @@ pub fn acquire(domain: Domain) -> bool {
 /// runs at most once per handle in a well-typed program (this crate's
 /// own "the checker is the real gate" convention), so a matched
 /// acquire/release pair per handle is a real invariant, not a hope.
-pub fn release(domain: Domain) {
+pub fn release(domain: DomainId) {
     counters_for(domain).held.fetch_sub(1, Ordering::AcqRel);
     recorder::record(domain, recorder::EventKind::Release);
 }
@@ -324,7 +453,7 @@ pub fn release(domain: Domain) {
 /// principle, in its smallest form: no exporter, no aggregation, just
 /// the numbers. `(currently_held, total_grants, total_denials,
 /// total_stale_rehydrated)`.
-pub fn stats(domain: Domain) -> (i64, u64, u64, u64) {
+pub fn stats(domain: DomainId) -> (i64, u64, u64, u64) {
     let c = counters_for(domain);
     (c.held.load(Ordering::Relaxed), c.grants.load(Ordering::Relaxed), c.denials.load(Ordering::Relaxed), c.stale_rehydrated.load(Ordering::Relaxed))
 }
@@ -350,10 +479,17 @@ pub fn stats(domain: Domain) -> (i64, u64, u64, u64) {
 /// it's ever seen, not just a diagnostic curiosity.
 pub fn dump_report() -> String {
     let mut out = String::from("nirdosha kernel flight recorder:\n");
-    for (name, domain) in [("tcp", Domain::Tcp), ("file", Domain::File), ("thread", Domain::Thread), ("db", Domain::Db), ("mq", Domain::Mq), ("http", Domain::Http), ("serve_http", Domain::ServeHttp)] {
-        let (held, grants, denials, stale_rehydrated) = stats(domain);
+    for (id, name) in registered_domains() {
+        let (held, grants, denials, stale_rehydrated) = stats(id);
         out.push_str(&format!("  {name}: held={held} grants={grants} denials={denials} stale_rehydrated={stale_rehydrated}\n"));
     }
+    // RFC 0011 §5: "a broken reaper is a visible number going up, not a
+    // silent absence" — appended as a trailing line, not folded into the
+    // per-domain loop above (it isn't a domain), so existing consumers
+    // asserting on a `{name}: held=... grants=...` substring (this
+    // module's own regression tests, `nirdosha_ops_console.rs`) are
+    // unaffected by this new line's presence.
+    out.push_str(&format!("  reaper_panics={}\n", reaper::reaper_panics()));
     out
 }
 
@@ -367,8 +503,7 @@ pub fn dump_report() -> String {
 /// crate can't depend on the compiler crate at all, this file's own
 /// module doc). **Doc-drift fix**: this comment used to say "not wired
 /// to any `nir_*` kernel yet" — `lib.rs`'s `db_table()` is a real,
-/// working `HandleTable<...>` today (`db`'s own `Domain::Db` doc
-/// comment above already reflects this; this one hadn't been updated).
+/// working `HandleTable<...>` today.
 pub struct HandleTable<T> {
     next_id: AtomicI64,
     handles: Mutex<HashMap<i64, T>>,
@@ -382,7 +517,27 @@ impl<T> Default for HandleTable<T> {
 
 impl<T> HandleTable<T> {
     pub fn new() -> Self {
-        HandleTable { next_id: AtomicI64::new(1), handles: Mutex::new(HashMap::new()) }
+        Self::new_starting_at(1)
+    }
+
+    /// Same as [`HandleTable::new`], except minted ids start at `start`
+    /// instead of `1`. RFC 0011 §2's plugin-conn `HandleTable` needs
+    /// this: `.nir`'s `handle(Db)` type is minted by either `lib.rs`'s
+    /// core `db_table()` (a separate `HandleTable<DbConn>`) or
+    /// `plugin_provider::plugin_conn_table()` (`HandleTable<PluginConn>`)
+    /// — two independent `next_id` counters that, both starting at `1`,
+    /// could otherwise both mint the same numeric id, and step 2's
+    /// "check `db_table()` first, then `HandleTable<PluginConn>` on a
+    /// miss" priority would then resolve a plugin-table id that
+    /// collides with an unrelated, still-live core `db` id to the
+    /// *wrong* connection instead of falling through correctly. Starting
+    /// the plugin table at a disjoint, high range (`1 << 62`) makes that
+    /// collision structurally impossible rather than merely unlikely —
+    /// the same "closed by construction, not by convention" posture §2
+    /// already argues for `next_id`'s own never-reused-once-removed
+    /// property within a single table.
+    pub fn new_starting_at(start: i64) -> Self {
+        HandleTable { next_id: AtomicI64::new(start), handles: Mutex::new(HashMap::new()) }
     }
 
     /// Takes ownership of `value`, mints a fresh id (never `0` —
@@ -606,12 +761,12 @@ mod tests {
 
     #[test]
     fn acquire_then_release_returns_to_zero_held() {
-        let (held_before, _, _, _) = stats(Domain::File);
-        assert!(acquire(Domain::File));
-        let (held_after_acquire, _, _, _) = stats(Domain::File);
+        let (held_before, _, _, _) = stats(domain::file());
+        assert!(acquire(domain::file()));
+        let (held_after_acquire, _, _, _) = stats(domain::file());
         assert_eq!(held_after_acquire, held_before + 1);
-        release(Domain::File);
-        let (held_after_release, _, _, _) = stats(Domain::File);
+        release(domain::file());
+        let (held_after_release, _, _, _) = stats(domain::file());
         assert_eq!(held_after_release, held_before);
     }
 
@@ -624,15 +779,15 @@ mod tests {
         // the first time, since the ceiling is resolved once and cached
         // (`max_for`'s `OnceLock`). This is the only test touching Tcp.
         unsafe { std::env::set_var("NIRDOSHA_KERNEL_MAX_TCP", "2") };
-        assert!(acquire(Domain::Tcp));
-        assert!(acquire(Domain::Tcp));
-        let (_, _, denials_before, _) = stats(Domain::Tcp);
-        assert!(!acquire(Domain::Tcp), "third acquire must be denied at a ceiling of 2");
-        let (held, _, denials_after, _) = stats(Domain::Tcp);
+        assert!(acquire(domain::tcp()));
+        assert!(acquire(domain::tcp()));
+        let (_, _, denials_before, _) = stats(domain::tcp());
+        assert!(!acquire(domain::tcp()), "third acquire must be denied at a ceiling of 2");
+        let (held, _, denials_after, _) = stats(domain::tcp());
         assert_eq!(held, 2, "a denied acquire must not increment held");
         assert_eq!(denials_after, denials_before + 1);
-        release(Domain::Tcp);
-        release(Domain::Tcp);
+        release(domain::tcp());
+        release(domain::tcp());
     }
 
     #[test]
@@ -715,5 +870,80 @@ mod tests {
 
         let s = STALL.lock().unwrap();
         assert_eq!((s.live, s.blocked), (1, 0));
+    }
+
+    /// One combined test for the open domain registry, deliberately not
+    /// split into separate `#[test]`s: `cargo test`'s default
+    /// parallelism gives no ordering guarantee between two independent
+    /// tests even behind a shared lock (a lock only prevents them
+    /// *overlapping*, not which acquires it first) — and the last part
+    /// of this test deliberately exhausts the process-wide registry
+    /// (see its own comment below), which would make a *separately*
+    /// scheduled idempotence check that happens to run afterward fail
+    /// for an unrelated reason. Keeping idempotence → round-trip →
+    /// exhaustion as ordered steps inside one function body is what
+    /// actually guarantees that order.
+    ///
+    /// Covers: registering the same name twice is idempotent (returns
+    /// the same [`DomainId`], doesn't mint a second one); the 7
+    /// built-ins keep their historical ids 0-6 through registration and
+    /// well past 300 additional registrations; a domain id past 255
+    /// still resolves to its real name (proving the recorder's widened
+    /// `u16` field doesn't truncate the way the old `u8` field would);
+    /// and registering brand-new names all the way to [`MAX_DOMAINS`]
+    /// is a loud panic, never silent truncation or wraparound.
+    ///
+    /// **Deliberately exhausts the process-wide domain registry** in its
+    /// last step. Every other test in this crate only ever resolves
+    /// already-registered names (the 7 built-ins via
+    /// `domain::tcp()`/`domain::db()`/etc., idempotent lookups, not new
+    /// registrations), so this doesn't break anything else in this test
+    /// binary today. A future phase adding a same-process (not a
+    /// spawned compiled-binary child process, which gets a fresh
+    /// registry automatically) unit test that registers new domain
+    /// names in *this* crate's test binary will need to account for
+    /// that — flagged here rather than left as a silent trap.
+    #[test]
+    fn open_registry_idempotence_255_plus_domains_and_max_domains_overflow() {
+        let a = register_domain("registry_idempotence_test_domain", "NIRDOSHA_KERNEL_MAX_REGISTRY_IDEMPOTENCE_TEST", 1);
+        let b = register_domain("registry_idempotence_test_domain", "NIRDOSHA_KERNEL_MAX_REGISTRY_IDEMPOTENCE_TEST", 1);
+        assert_eq!(a, b, "registering the same domain name twice must return the same DomainId, not mint a second one");
+
+        domain::register_builtin_domains();
+        let builtins: [(DomainId, &str); 7] =
+            [(0, "tcp"), (1, "file"), (2, "thread"), (3, "db"), (4, "mq"), (5, "http"), (6, "serve_http")];
+        for (id, name) in builtins {
+            assert_eq!(registered_domain_name(id), Some(name), "built-in domain ids must be stable at 0-6");
+        }
+
+        let mut synthetic_ids = Vec::new();
+        for i in 0..300 {
+            let name: &'static str = Box::leak(format!("registry_round_trip_synthetic_domain_{i}").into_boxed_str());
+            let env_var: &'static str = Box::leak(format!("NIRDOSHA_KERNEL_MAX_SYNTH_{i}").into_boxed_str());
+            synthetic_ids.push(register_domain(name, env_var, 1));
+        }
+        let high_id = *synthetic_ids.last().unwrap();
+        assert!(high_id > 255, "must have registered at least one domain with an id past the old u8 ceiling, got {high_id}");
+        assert_eq!(
+            registered_domain_name(high_id),
+            Some("registry_round_trip_synthetic_domain_299"),
+            "a domain id past 255 must still resolve to its real name, not silently truncate the way a u8 field would"
+        );
+
+        // The built-ins' ids must still read back correctly after 300
+        // more domains registered after them -- registration is
+        // append-only, so ids already minted never move.
+        for (id, name) in builtins {
+            assert_eq!(registered_domain_name(id), Some(name), "built-in domain ids must stay stable even after later registrations");
+        }
+
+        let overflowed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            for i in 0..(MAX_DOMAINS + 16) {
+                let name: &'static str = Box::leak(format!("registry_overflow_synthetic_domain_{i}").into_boxed_str());
+                let env_var: &'static str = Box::leak(format!("NIRDOSHA_KERNEL_MAX_OVERFLOW_{i}").into_boxed_str());
+                register_domain(name, env_var, 1);
+            }
+        }));
+        assert!(overflowed.is_err(), "registering far more than MAX_DOMAINS distinct new domains must panic, not silently succeed or wrap around");
     }
 }

--- a/crates/runtime-kernels/src/kernel/plugin_provider.rs
+++ b/crates/runtime-kernels/src/kernel/plugin_provider.rs
@@ -1,0 +1,487 @@
+//! RFC 0011 §2/§4's runtime provider table and kernel-owned
+//! `HandleTable<PluginConn>` — the actual "look up a normalized scheme
+//! at runtime, dispatch through *that handle's own recorded* function
+//! pointers" mechanism `db.rs`'s `connect`/`nir_db_query`/`nir_db_stop`
+//! fall through to when a URL's scheme doesn't match a built-in one.
+//!
+//! **Scope note, disclosed rather than left implicit**: this phase
+//! wires exactly two consumers — `db_connect`'s `conn`-shape fallback
+//! and the new `call_via` builtin's `call`-shape fallback.
+//! `mq_connect_via`'s own fallback is explicitly deferred (RFC 0011's
+//! own Context section, `crates/compiler/src/codegen.rs`'s `MQ_BUILTINS`
+//! doc comment) — a follow-up that copies this module's `conn`-shape
+//! path as its template, not a gap in this module's own design.
+//!
+//! **`_op`'s signature, pinned here since the RFC's own text never
+//! fully nails it down**: a single `str` in, `str` out
+//! (`extern "C" fn(i64, NirStr) -> NirStr`) — the same minimal-ABI
+//! posture every other plugin function already has (RFC 0011 §2: "the
+//! plugin's four functions never see a kernel id... never a
+//! `handle(Kind)`"). This deliberately does **not** extend `db_query`/
+//! `db_execute`'s full bind-value array (`NirBindValue`) across the
+//! plugin boundary — that's a real, disclosed narrower cut, not
+//! something the RFC's own text promises: a plugin-routed `db_query`/
+//! `db_execute` call with any bind values supplied is a clean, named
+//! error (below), not a silent drop of the bind values or an attempt to
+//! marshal an aggregate across an ABI that's supposed to stay
+//! scalar/`str`/handle-only. `db_execute`'s "affected row count" is
+//! represented as `_op`'s returned string parsed as a decimal `i64` —
+//! reusing the one `_op` signature for both `db_query`/`db_execute`
+//! rather than inventing a second op-shaped function, at the cost of
+//! that one parse-convention document requirement on plugin authors.
+
+use super::pool::{self, Checkout, NirStr, PluginManagedConnection, PoolConfig, PoolRegistry};
+use super::{DomainId, HandleTable};
+use std::collections::HashMap;
+use std::sync::{Mutex, Once, OnceLock};
+
+/// One provider's shape-appropriate second function — `_op` for
+/// `conn`/`stream`-shape (`db_provider_.../mq_provider_...`), `_request`
+/// for `call`-shape (`<name>_provider_..._request`, RFC 0011 §2's
+/// corrected `call` contract). Which variant a provider gets is decided
+/// once, at registration time, by which sibling function
+/// `NativePluginBuiltin::validate`/`validate_plugin_roster` found next
+/// to `_connect` (`compiler/src/plugin.rs`) — never re-inferred here.
+#[derive(Clone, Copy)]
+pub enum ProviderOp {
+    ConnStream { op_fn: extern "C" fn(i64, NirStr) -> NirStr },
+    Call { request_fn: extern "C" fn(i64, NirStr, NirStr) -> NirStr },
+}
+
+/// Everything the kernel needs to dispatch through one registered
+/// plugin provider — populated once, at startup, by
+/// [`register`] (`codegen.rs` emits one `nir_kernel_register_plugin_
+/// provider` call per distinct validated provider, right after that
+/// same provider's `nir_kernel_register_domain` call, RFC 0011 §4).
+/// `Copy` so a `PluginConn` (below) can carry its own snapshot of the
+/// exact `ProviderFns` it was connected through, per RFC §2's
+/// structural-safety argument: "no code path calls a provider's `_op`
+/// based on anything but what that specific handle was given at
+/// `_connect` time."
+#[derive(Clone, Copy)]
+pub struct ProviderFns {
+    pub connect_fn: extern "C" fn(NirStr) -> i64,
+    pub is_valid_fn: extern "C" fn(i64) -> i64,
+    pub close_fn: extern "C" fn(i64) -> i64,
+    pub op: ProviderOp,
+    pub domain: DomainId,
+}
+
+static PLUGIN_PROVIDERS: OnceLock<Mutex<HashMap<String, ProviderFns>>> = OnceLock::new();
+
+/// Registered once per distinct provider, at process startup, before
+/// any user code runs (RFC 0011 §4 — the identical eager-registration
+/// posture Phase 4 already established for domains, extended here to
+/// also index dispatch function pointers). Keyed by **normalized
+/// scheme alone**, not `(shape, scheme)`: `compiler/src/plugin.rs`'s
+/// own `validate_plugin_roster` collision check already treats the
+/// normalized-scheme namespace as global across every shape (a `conn`-
+/// shape provider and a `call`-shape provider can't register the same
+/// scheme identifier at all), so one flat map is the RFC-consistent
+/// representation, not a simplification that loses information.
+pub fn register(scheme: String, fns: ProviderFns) {
+    let map = PLUGIN_PROVIDERS.get_or_init(|| Mutex::new(HashMap::new()));
+    map.lock().unwrap_or_else(|e| e.into_inner()).insert(scheme, fns);
+}
+
+fn lookup(normalized_scheme: &str) -> Option<ProviderFns> {
+    let map = PLUGIN_PROVIDERS.get_or_init(|| Mutex::new(HashMap::new()));
+    map.lock().unwrap_or_else(|e| e.into_inner()).get(normalized_scheme).copied()
+}
+
+/// rfcs/0011-uniform-service-provider-model.md §2: "take the substring
+/// before `://`, lowercase it, map `+`/`.`/`-` to `_`." **Duplicated
+/// verbatim from `compiler/src/plugin.rs::normalize_scheme`** — the
+/// RFC's own "one function, not two independent implementations that
+/// could drift" instruction, kept in sync by hand since there is no
+/// shared crate between `compiler` and `runtime-kernels` to put a
+/// single copy in (this crate's own module doc: "can't depend on the
+/// compiler crate at all"). Any change here needs the identical change
+/// there, and vice versa — both copies carry this same test vector set.
+pub fn normalize_scheme(scheme: &str) -> String {
+    let bare = scheme.split("://").next().unwrap_or(scheme);
+    bare.to_ascii_lowercase().chars().map(|c| if c == '+' || c == '.' || c == '-' { '_' } else { c }).collect()
+}
+
+/// RFC 0011 §2's credential-stripped `(provider, identity)` pool-key
+/// rule: `scheme://user@host:port/path`, password and query string
+/// both removed, username kept (a different user is a different
+/// privilege scope). Best-effort against a malformed URL — a schemeless
+/// or otherwise odd string just gets used mostly as-is rather than
+/// erroring, since even a degenerate case still partitions distinct
+/// URLs into distinct keys correctly, which is this function's only
+/// real correctness obligation (it's a pool/cache key, not a validator).
+pub fn pool_key_identity(normalized_scheme: &str, url: &str) -> String {
+    let after_scheme = url.split("://").nth(1).unwrap_or(url);
+    let before_query = after_scheme.split('?').next().unwrap_or(after_scheme);
+    let identity = match before_query.find('@') {
+        Some(at) => {
+            let (userinfo, host_and_path) = before_query.split_at(at);
+            let host_and_path = &host_and_path[1..]; // skip '@'
+            let user = userinfo.split(':').next().unwrap_or(userinfo);
+            format!("{user}@{host_and_path}")
+        }
+        None => before_query.to_string(),
+    };
+    format!("{normalized_scheme}://{identity}")
+}
+
+/// One process-wide `PoolRegistry<PluginManagedConnection>`, shared by
+/// every registered provider regardless of shape — RFC 0011 §5: "every
+/// plugin provider of a given shape reuses this same adapter type, so
+/// `PoolRegistry<PluginManagedConnection>` is the one pool type covering
+/// all of them." Providers don't collide within it because
+/// [`pool_key_identity`]'s key is already `(normalized_scheme,
+/// credential-stripped identity)`-shaped — two different providers can
+/// never produce the same key, since normalized schemes are globally
+/// unique per [`register`]'s own doc comment.
+fn plugin_pool() -> &'static PoolRegistry<PluginManagedConnection> {
+    static POOL: OnceLock<PoolRegistry<PluginManagedConnection>> = OnceLock::new();
+    static REGISTERED: Once = Once::new();
+    let pool_registry = POOL.get_or_init(PoolRegistry::new);
+    // RFC 0011 §5: registers once with the reaper, lazily. Unlike
+    // `db.rs`/`http.rs`'s per-backend registries (each pinned to one
+    // domain), this single registry spans every registered provider's
+    // own domain at once -- `PluginManagedConnection::domain` (set per
+    // instance at `connect_conn_shape`/`call_via`'s construction time
+    // below) is what lets `record_stale_rehydrated` still land against
+    // the *right* domain per connection, not this registry as a whole.
+    REGISTERED.call_once(|| pool::register_for_reaping(pool_registry));
+    pool_registry
+}
+
+/// One kernel-owned `HandleTable<PluginConn>`, playing the identical
+/// role `lib.rs`'s `db_table()` plays for core `db` — RFC 0011 §2:
+/// "the kernel keeps one `HandleTable<PluginConn>` per shape." A single
+/// shared table (not one per shape) is enough here for the same reason
+/// [`plugin_pool`] is single and shared: a `PluginConn`'s own recorded
+/// `ProviderFns` (not which table it lives in) is what makes dispatch
+/// structurally safe, per §2's own argument.
+pub fn plugin_conn_table() -> &'static HandleTable<PluginConn> {
+    static TABLE: OnceLock<HandleTable<PluginConn>> = OnceLock::new();
+    // A disjoint id range from `lib.rs`'s core `db_table()` (which
+    // starts at 1) -- see `HandleTable::new_starting_at`'s own doc
+    // comment for why this must never overlap.
+    TABLE.get_or_init(|| HandleTable::new_starting_at(1i64 << 62))
+}
+
+/// Which of the two checkout shapes (RFC 0011 §5's key-cap fallback,
+/// [`Checkout`]) this `PluginConn` was actually given. `Pooled` needs an
+/// explicit `kernel::release` on close (mirroring exactly how
+/// `lib.rs`'s `nir_db_stop` already releases `domain::db()` for core
+/// connections); `Unpooled`'s own [`super::pool::UnpooledConnection`]
+/// releases automatically on `Drop` (Phase 5), so nothing extra is
+/// needed for that variant here.
+pub enum PluginConnHold {
+    Pooled(r2d2::PooledConnection<PluginManagedConnection>),
+    Unpooled(super::pool::UnpooledConnection<PluginManagedConnection>),
+}
+
+/// The kernel-owned entry `HandleTable<PluginConn>` stores — RFC 0011
+/// §2: "`PluginConn` pairing the plugin's raw `i64` with the
+/// `ProviderFns` it was connected through." `.nir` code only ever holds
+/// this table's own id; a plugin's four functions only ever receive the
+/// raw `i64` unwrapped from here, on every call, not just `_connect`'s
+/// return.
+pub struct PluginConn {
+    hold: PluginConnHold,
+    pub provider: ProviderFns,
+}
+
+impl PluginConn {
+    pub fn raw(&self) -> i64 {
+        match &self.hold {
+            PluginConnHold::Pooled(c) => c.raw,
+            PluginConnHold::Unpooled(g) => g.get().raw,
+        }
+    }
+}
+
+impl Drop for PluginConn {
+    fn drop(&mut self) {
+        // `Unpooled`'s own guard releases its admission automatically
+        // when `self.hold` itself drops, right after this fn returns —
+        // nothing to do for that variant here. `Pooled` has no such
+        // automatic release built in (a `PooledConnection`'s own Drop
+        // only returns the checkout to the pool for reuse), so this is
+        // the one place that release call has to live, symmetric with
+        // the explicit `kernel::acquire` `connect_conn_shape`/
+        // `connect_call_shape` (below) make for exactly this variant.
+        if let PluginConnHold::Pooled(_) = &self.hold {
+            super::release(self.provider.domain);
+        }
+    }
+}
+
+/// A plugin provider's `_connect`/`_is_valid` call returned a failure
+/// sentinel, or the plugin ABI's own scalar `str` result (`_op`/
+/// `_request`) needs to be reported as a `.nir`-visible `Err` — RFC 0011
+/// §2's "0/1/negative sentinels every other kernel boundary already
+/// uses" convention. `Display`/`Error`, matching every other
+/// `ManageConnection::Error` in this crate.
+pub fn no_provider_registered_error(normalized_scheme: &str) -> String {
+    // RFC 0011 §2: "the error echoes only the normalized scheme... so
+    // it can never leak a credential even though it does echo
+    // tenant-controlled input" — never interpolate the raw url here.
+    format!("no provider registered for scheme {normalized_scheme:?}")
+}
+
+/// `PoolConfig::from_env`'s own default `max_size` (10, `pool.rs`'s own
+/// doc comment) has no idea what a given provider's admission ceiling
+/// actually is — for a provider whose `default_max`/env-var ceiling is
+/// below 10 (this module's own test coverage exercises exactly this: a
+/// `default_max: Some(1)` provider), an un-clamped config would fail
+/// `get_or_create_within_ceiling`'s own check on every single checkout,
+/// making a legitimately low-ceiling provider unusable rather than
+/// merely rate-limited. Clamping here — once, in the one place both
+/// `connect_conn_shape` and `call_via` build a `PoolConfig` — keeps
+/// `pool.rs`'s ceiling check doing its real job (catching a genuinely
+/// oversized `max_size`) instead of also having to absorb "a provider's
+/// ceiling happens to be smaller than the generic pool default."
+fn plugin_pool_config(normalized_scheme: &str, domain: DomainId) -> PoolConfig {
+    let mut cfg = PoolConfig::from_env(&format!("PLUGIN_{}", normalized_scheme.to_ascii_uppercase()));
+    let ceiling = super::ceiling_for(domain);
+    if ceiling > 0 && i64::from(cfg.max_size) > ceiling {
+        cfg.max_size = ceiling as u32;
+    }
+    cfg
+}
+
+/// `db_connect`'s (and, once wired, `mq_connect_via`'s) fallback: a URL
+/// whose scheme matched no built-in. Returns a real, disclosed error —
+/// never a panic — for every failure mode: unregistered scheme, a
+/// `call`-shape provider found where a `conn`/`stream`-shape one was
+/// expected, admission denial, or the plugin's own connect failure.
+pub fn connect_conn_shape(url: &str) -> Result<PluginConn, String> {
+    let scheme = url.split("://").next().unwrap_or(url);
+    let normalized = normalize_scheme(scheme);
+    let Some(fns) = lookup(&normalized) else {
+        return Err(no_provider_registered_error(&normalized));
+    };
+    let ProviderOp::ConnStream { .. } = fns.op else {
+        return Err(format!(
+            "provider registered for scheme {normalized:?} is call-shape (registered for call_via), not usable from db_connect/mq_connect_via"
+        ));
+    };
+    let key = pool_key_identity(&normalized, url);
+    let connect_fn = fns.connect_fn;
+    let is_valid_fn = fns.is_valid_fn;
+    let close_fn = fns.close_fn;
+    let host = url.to_string();
+    let domain = fns.domain;
+    let make_manager = move || Ok(PluginManagedConnection { connect_fn, is_valid_fn, close_fn, host, domain });
+
+    match plugin_pool().checkout_with_key_cap(&key, plugin_pool_config(&normalized, fns.domain), fns.domain, make_manager) {
+        Ok(Checkout::Pooled(pool)) => {
+            if !super::acquire(fns.domain) {
+                return Err("too many concurrently held connections for this provider".to_string());
+            }
+            match pool.get() {
+                Ok(pooled) => Ok(PluginConn { hold: PluginConnHold::Pooled(pooled), provider: fns }),
+                Err(e) => {
+                    super::release(fns.domain);
+                    Err(e.to_string())
+                }
+            }
+        }
+        // The key-cap fallback's own `acquire` already ran, inside
+        // `checkout_with_key_cap` itself (Phase 5) — this branch must
+        // NOT acquire again, or every fallback connection would consume
+        // two admission slots for one real connection.
+        Ok(Checkout::Unpooled(guard)) => Ok(PluginConn { hold: PluginConnHold::Unpooled(guard), provider: fns }),
+        Err(e) => Err(e),
+    }
+}
+
+/// `db_query`/`db_execute`'s plugin-routed op dispatch — called only
+/// after a `HandleTable<PluginConn>` lookup already found `conn`
+/// (never resolved any other way, per §2's structural-safety
+/// argument). `binds_present` is a clean, named error rather than a
+/// silent drop — see this module's own doc comment for why bind values
+/// don't cross the plugin `_op` boundary in this phase.
+pub fn op(conn: &PluginConn, arg: &str, binds_present: bool) -> Result<String, String> {
+    if binds_present {
+        return Err("bind parameters are not yet supported for plugin-routed db_query/db_execute calls -- inline values into the query string instead".to_string());
+    }
+    let ProviderOp::ConnStream { op_fn } = conn.provider.op else {
+        return Err("internal error: a call-shape provider's PluginConn reached conn-shape op dispatch".to_string());
+    };
+    let raw = conn.raw();
+    let arg = NirStr { ptr: arg.as_ptr(), len: arg.len() as i64 };
+    let result = op_fn(raw, arg);
+    // SAFETY: the plugin's own `_op` contract (RFC 0011 §2, `plugin.rs`'s
+    // doc comment) is the same `(ptr, len)`-by-value convention every
+    // other `str`-returning plugin function already uses -- the plugin
+    // allocates its own buffer (typically `Box::leak`) and this is
+    // never freed, the same permanent-leak posture `sha256_hex`/every
+    // other `str`-returning native builtin already has.
+    let bytes = if result.len == 0 { &[][..] } else { unsafe { std::slice::from_raw_parts(result.ptr, result.len as usize) } };
+    String::from_utf8(bytes.to_vec()).map_err(|_| "plugin _op returned a value that is not valid UTF-8".to_string())
+}
+
+/// `call_via`'s fallback: a URL whose scheme isn't plain `http`/
+/// `https`. Mirrors [`connect_conn_shape`] structurally (same admission
+/// bracketing, same pool-key rule) but dispatches through `_request`
+/// instead of `_op`, and — per RFC 0011 §2's corrected `call` contract
+/// — brackets admission **per request**, not per session: `kernel::
+/// acquire(domain)` around each checkout, `release` immediately after
+/// this one call returns, rather than held across multiple calls the
+/// way `conn`/`stream`'s handle-table session lifecycle is.
+pub fn call_via(url: &str, path: &str, body: &str) -> Result<String, String> {
+    let scheme = url.split("://").next().unwrap_or(url);
+    let normalized = normalize_scheme(scheme);
+    let Some(fns) = lookup(&normalized) else {
+        return Err(no_provider_registered_error(&normalized));
+    };
+    let ProviderOp::Call { request_fn } = fns.op else {
+        return Err(format!("provider registered for scheme {normalized:?} is conn/stream-shape (registered for db_connect/mq_connect_via), not usable from call_via"));
+    };
+    let key = pool_key_identity(&normalized, url);
+    let connect_fn = fns.connect_fn;
+    let is_valid_fn = fns.is_valid_fn;
+    let close_fn = fns.close_fn;
+    let host = url.to_string();
+    let domain = fns.domain;
+    let make_manager = move || Ok(PluginManagedConnection { connect_fn, is_valid_fn, close_fn, host, domain });
+
+    let checkout = plugin_pool().checkout_with_key_cap(&key, plugin_pool_config(&normalized, fns.domain), fns.domain, make_manager)?;
+    let raw = match &checkout {
+        Checkout::Pooled(pool) => {
+            if !super::acquire(fns.domain) {
+                return Err("too many concurrently held connections for this provider".to_string());
+            }
+            match pool.get() {
+                Ok(pooled) => pooled.raw,
+                Err(e) => {
+                    super::release(fns.domain);
+                    return Err(e.to_string());
+                }
+            }
+        }
+        // Same as `connect_conn_shape`: the fallback's own `acquire`
+        // already ran inside `checkout_with_key_cap`.
+        Checkout::Unpooled(guard) => guard.get().raw,
+    };
+
+    let path_arg = NirStr { ptr: path.as_ptr(), len: path.len() as i64 };
+    let body_arg = NirStr { ptr: body.as_ptr(), len: body.len() as i64 };
+    let result = request_fn(raw, path_arg, body_arg);
+
+    // Per-request release: this checkout was only ever meant to live for
+    // the duration of this one call (RFC 0011 §2's corrected `call`
+    // admission scope) — for the `Pooled` branch, release right here,
+    // now that `_request` has returned, rather than holding it across
+    // calls the way `conn`/`stream`'s session-scoped `PluginConn` does.
+    // The `Unpooled` branch's guard (`checkout`, still in scope) releases
+    // automatically when it drops at the end of this function.
+    if let Checkout::Pooled(_) = &checkout {
+        super::release(fns.domain);
+    }
+
+    let bytes = if result.len == 0 { &[][..] } else { unsafe { std::slice::from_raw_parts(result.ptr, result.len as usize) } };
+    String::from_utf8(bytes.to_vec()).map_err(|_| "plugin _request returned a value that is not valid UTF-8".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Same test vectors as `compiler/src/plugin.rs`'s
+    /// `normalize_scheme_matches_the_rfc_examples` — this module's own
+    /// doc comment on `normalize_scheme` names that file as the sibling
+    /// copy that must stay in sync; this test is what actually checks
+    /// that claim rather than just asserting it in prose.
+    #[test]
+    fn normalize_scheme_matches_the_rfc_examples() {
+        assert_eq!(normalize_scheme("mysql+tls://host"), "mysql_tls");
+        assert_eq!(normalize_scheme("POSTGRESQL://host"), "postgresql");
+        assert_eq!(normalize_scheme("s3.compat-v2://host"), "s3_compat_v2");
+    }
+
+    /// RFC 0011 §2's credential-stripped identity rule: password
+    /// removed, username kept, query string removed.
+    #[test]
+    fn pool_key_identity_strips_password_and_query_but_keeps_username_and_path() {
+        let key = pool_key_identity("s3", "s3://readonly:secret-pw@bucket.example.com:9000/my/path?token=abc123");
+        assert_eq!(key, "s3://readonly@bucket.example.com:9000/my/path");
+        assert!(!key.contains("secret-pw"), "password must never appear in a pool key");
+        assert!(!key.contains("token=abc123"), "query string (a common credential carrier) must never appear in a pool key");
+    }
+
+    /// No userinfo at all -- a bare `host[:port][/path]` after the
+    /// scheme, the common case for a provider whose credential lives
+    /// entirely in the path or is implicit (e.g. IAM-role-based auth).
+    #[test]
+    fn pool_key_identity_with_no_userinfo_is_used_as_is() {
+        let key = pool_key_identity("authedhttp", "authedhttp://api.example.com/v1/endpoint");
+        assert_eq!(key, "authedhttp://api.example.com/v1/endpoint");
+    }
+
+    /// Rotating a password behind the same user/host/path must NOT
+    /// change the identity -- RFC 0011 §2's own disclosed operational
+    /// trap ("a real operational trap this identity rule creates"):
+    /// same pool, same physical connections, until the pool evicts the
+    /// stale-credentialed ones.
+    #[test]
+    fn pool_key_identity_is_unchanged_by_a_password_rotation() {
+        let before = pool_key_identity("postgres_like", "custom://admin:pw1@h/db");
+        let after = pool_key_identity("postgres_like", "custom://admin:pw2@h/db");
+        assert_eq!(before, after, "rotating only the password must not change the pool key");
+    }
+
+    /// A different username IS a different privilege scope, and must
+    /// key a different pool -- the other half of the same RFC rule.
+    #[test]
+    fn pool_key_identity_differs_for_different_usernames() {
+        let admin = pool_key_identity("custom", "custom://admin:pw@h/db");
+        let readonly = pool_key_identity("custom", "custom://readonly:pw@h/db");
+        assert_ne!(admin, readonly, "a different user is a different privilege scope and must key a different pool");
+    }
+
+    /// Two URLs differing only in query parameters share a pool -- the
+    /// RFC's own disclosed cost of excluding the query string entirely,
+    /// stated as an explicit, checked property rather than an assumed
+    /// one.
+    #[test]
+    fn pool_key_identity_ignores_all_query_parameters_including_connection_affecting_ones() {
+        let a = pool_key_identity("custom", "custom://user@h/db?sslmode=require");
+        let b = pool_key_identity("custom", "custom://user@h/db?sslmode=disable");
+        assert_eq!(a, b, "query strings are excluded from identity entirely, including connection-affecting ones (RFC's own disclosed cost)");
+    }
+
+    /// Different normalized schemes must never collide on identity,
+    /// even against an otherwise-identical rest-of-url -- the pool key
+    /// is `(provider, identity)`, not identity alone.
+    #[test]
+    fn pool_key_identity_is_scoped_by_scheme() {
+        let a = pool_key_identity("schemea", "schemea://user@h/db");
+        let b = pool_key_identity("schemeb", "schemeb://user@h/db");
+        assert_ne!(a, b);
+    }
+
+    /// Caught by `call_via_brackets_admission_per_request_not_per_session`
+    /// (`native_plugin_codegen.rs`) failing before this existed:
+    /// `PoolConfig::from_env`'s own default `max_size` (10) is bigger
+    /// than a low-ceiling provider's own admission ceiling, so an
+    /// un-clamped config would fail `get_or_create_within_ceiling`'s
+    /// check on *every* checkout for such a provider -- making a
+    /// legitimately low-ceiling provider unusable, not merely rate-
+    /// limited. This is the regression test for that fix, isolated from
+    /// the full compiled-binary test that originally caught it.
+    #[test]
+    fn plugin_pool_config_clamps_max_size_down_to_a_low_domain_ceiling() {
+        let domain = super::super::register_domain("plugin_pool_config_clamp_test_domain", "NIRDOSHA_KERNEL_MAX_PLUGIN_POOL_CONFIG_CLAMP_TEST", 1);
+        let cfg = plugin_pool_config("clamp_test_scheme", domain);
+        assert_eq!(cfg.max_size, 1, "max_size must be clamped down to the domain's own ceiling, not left at PoolConfig::default's 10");
+    }
+
+    /// The other direction: a generous ceiling must not be clamped
+    /// *up* -- `PoolConfig::default`'s own `max_size` (10) stays
+    /// whatever it resolved to.
+    #[test]
+    fn plugin_pool_config_leaves_max_size_alone_when_already_under_a_generous_ceiling() {
+        let domain = super::super::register_domain("plugin_pool_config_no_clamp_test_domain", "NIRDOSHA_KERNEL_MAX_PLUGIN_POOL_CONFIG_NO_CLAMP_TEST", 10_000);
+        let cfg = plugin_pool_config("no_clamp_test_scheme", domain);
+        assert_eq!(cfg.max_size, PoolConfig::default().max_size, "a ceiling far above the default max_size must not change it");
+    }
+}

--- a/crates/runtime-kernels/src/kernel/pool.rs
+++ b/crates/runtime-kernels/src/kernel/pool.rs
@@ -35,8 +35,9 @@
 //! `r2d2_postgres`) — neither added as a dependency yet, since nothing
 //! calls this module yet either.
 
+use super::DomainId;
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
 pub use r2d2::{ManageConnection, Pool};
@@ -142,6 +143,63 @@ impl<M: ManageConnection> Default for PoolRegistry<M> {
     }
 }
 
+/// [`PoolRegistry::checkout_with_key_cap`]'s result: the common case is
+/// a normal pooled checkout, indistinguishable from what
+/// [`PoolRegistry::get_or_create`] always returned; past the per-
+/// provider key cap, a *new* key gets one direct, unpooled connection
+/// instead (RFC 0011 §5).
+pub enum Checkout<M: ManageConnection> {
+    /// A normal pooled checkout — caller calls `.get()` on this exactly
+    /// as it always has.
+    Pooled(Pool<M>),
+    /// The key cap was hit for a brand-new key: no `HashMap` entry, no
+    /// pool, no reaper coverage — one unpooled connection, already
+    /// `kernel::acquire`-admitted. Drop this guard (or call
+    /// [`UnpooledConnection::into_inner`] and drop what it returns) to
+    /// release the admission it holds.
+    Unpooled(UnpooledConnection<M>),
+}
+
+/// An unpooled, `kernel::acquire`/`release`-bracketed connection —
+/// [`PoolRegistry::checkout_with_key_cap`]'s fallback-path result.
+/// `release(domain)` runs exactly once, in [`Drop`], so the caller
+/// cannot forget it (RFC 0011 §5's own explicit warning: a skipped
+/// `acquire`/`release` on this path would turn the key cap into an
+/// admission-ceiling bypass, not just a memory-growth guard).
+pub struct UnpooledConnection<M: ManageConnection> {
+    conn: Option<M::Connection>,
+    domain: DomainId,
+}
+
+impl<M: ManageConnection> UnpooledConnection<M> {
+    pub fn get(&self) -> &M::Connection {
+        self.conn.as_ref().expect("conn is only ever None after into_inner/drop, which consume this value")
+    }
+
+    pub fn get_mut(&mut self) -> &mut M::Connection {
+        self.conn.as_mut().expect("conn is only ever None after drop")
+    }
+
+    // No `into_inner`, deliberately: a caller that needs to hold the
+    // raw connection past this guard's own scope (e.g. `conn`/`stream`-
+    // shape's session-scoped connect-to-stop lifecycle, stashed in a
+    // handle table) needs its own explicit acquire/release story at
+    // that point, which is Phase 6's job to design once real FFI
+    // dispatch exists — extracting the connection here while silently
+    // detaching it from this guard's automatic release would be exactly
+    // the "forget to release" hazard this guard exists to prevent.
+
+    pub fn domain(&self) -> DomainId {
+        self.domain
+    }
+}
+
+impl<M: ManageConnection> Drop for UnpooledConnection<M> {
+    fn drop(&mut self) {
+        super::release(self.domain);
+    }
+}
+
 impl<M: ManageConnection> PoolRegistry<M> {
     pub fn new() -> Self {
         PoolRegistry { pools: Mutex::new(HashMap::new()) }
@@ -172,11 +230,126 @@ impl<M: ManageConnection> PoolRegistry<M> {
         Ok(pool)
     }
 
-    /// Number of distinct keys with a live pool — test/diagnostic
-    /// visibility into the registry, not used on any hot path.
-    #[cfg(test)]
+    /// Number of distinct keys with a live pool. Used both as
+    /// test/diagnostic visibility into the registry and, non-test, by
+    /// [`PoolRegistry::checkout_with_key_cap`] to decide whether a new
+    /// key is still under `NIRDOSHA_KERNEL_POOL_MAX_KEYS` — registration-
+    /// frequency (once per distinct key), never a hot-path read.
     pub fn pool_count(&self) -> usize {
         self.pools.lock().unwrap().len()
+    }
+
+    /// [`PoolRegistry::get_or_create`], plus RFC 0011 §5's "what the
+    /// ceiling actually bounds" rule: refuses to build a pool whose
+    /// `config.max_size` would let r2d2 grow physical connections past
+    /// `domain`'s own admission ceiling — a startup-time error (named,
+    /// actionable), not a ceiling that silently goes decorative the
+    /// moment a provider's pool is allowed to outgrow it. Every plugin
+    /// provider pool (§4's single eager registration point, which knows
+    /// both numbers for a given provider at once) must go through this,
+    /// never bare `get_or_create`, once wired in Phase 6.
+    pub fn get_or_create_within_ceiling(
+        &self,
+        key: &str,
+        config: PoolConfig,
+        domain: DomainId,
+        make_manager: impl FnOnce() -> Result<M, String>,
+    ) -> Result<Pool<M>, String> {
+        let ceiling = super::ceiling_for(domain);
+        if i64::from(config.max_size) > ceiling {
+            return Err(format!(
+                "pool config max_size ({}) for key {key:?} exceeds its domain's admission ceiling ({ceiling}) -- \
+                 a ceiling nothing consults isn't a ceiling (rfcs/0011 §5); lower PoolConfig::max_size or raise the \
+                 domain's ceiling env var/default_max instead",
+                config.max_size
+            ));
+        }
+        self.get_or_create(key, config, make_manager)
+    }
+
+    /// `NIRDOSHA_KERNEL_POOL_MAX_KEYS` (RFC 0011 §5, name pinned exactly
+    /// in the RFC): the number of distinct pool keys one provider may
+    /// hold before a *new* key falls back to unpooled dialing instead of
+    /// growing this registry's `HashMap` without bound. Same
+    /// malformed-value-degrades-to-default posture every other env-var
+    /// convention in this file already uses, default 256 (the same
+    /// "generous, not tuned" posture as `MAX_DOMAINS`).
+    fn max_pool_keys() -> usize {
+        std::env::var("NIRDOSHA_KERNEL_POOL_MAX_KEYS").ok().and_then(|s| s.parse::<usize>().ok()).filter(|&n| n > 0).unwrap_or(256)
+    }
+
+    /// The RFC 0011 §5 key-cap + fallback rule, made real: a *new* pool
+    /// key past `NIRDOSHA_KERNEL_POOL_MAX_KEYS` distinct keys for this
+    /// provider doesn't grow the registry's `HashMap` at all — it falls
+    /// back to one direct, unpooled dial instead, still
+    /// `kernel::acquire`/`release`-bracketed exactly as if it were a
+    /// normal pooled checkout (the RFC's own explicit warning: skipping
+    /// `acquire` here would turn the key cap into an admission-ceiling
+    /// *bypass*, not just a memory-growth guard). `release` happens
+    /// automatically when the returned [`Checkout::Unpooled`] guard
+    /// drops — the caller cannot forget it the way a bare
+    /// acquire-then-remember-to-release pair could be gotten wrong.
+    /// An already-existing key never falls back, regardless of current
+    /// key count (this is a cap on *new* keys, not a demotion of
+    /// existing pools once the registry happens to be at/over the
+    /// threshold).
+    pub fn checkout_with_key_cap(
+        &self,
+        key: &str,
+        config: PoolConfig,
+        domain: DomainId,
+        make_manager: impl FnOnce() -> Result<M, String>,
+    ) -> Result<Checkout<M>, String> {
+        let already_has_key = self.pools.lock().unwrap().contains_key(key);
+        if already_has_key || self.pool_count() < Self::max_pool_keys() {
+            return self.get_or_create_within_ceiling(key, config, domain, make_manager).map(Checkout::Pooled);
+        }
+        if !super::acquire(domain) {
+            return Err(format!("too many concurrently held connections for this domain (unpooled fallback dial for key {key:?})"));
+        }
+        let manager = match make_manager() {
+            Ok(m) => m,
+            Err(e) => {
+                super::release(domain);
+                return Err(e);
+            }
+        };
+        match manager.connect() {
+            Ok(conn) => Ok(Checkout::Unpooled(UnpooledConnection { conn: Some(conn), domain })),
+            Err(e) => {
+                super::release(domain);
+                Err(e.to_string())
+            }
+        }
+    }
+
+    /// RFC 0011 §5's reaper primitive: one opportunistic
+    /// `pool.try_get()` per pool key currently registered, dropped
+    /// immediately. `try_get` never blocks and never opens a new
+    /// connection on an empty pool (confirmed against this repo's
+    /// pinned `r2d2 0.8.10`: `try_get_inner` only pops from the already-
+    /// idle list, `Err`ing immediately on empty rather than calling
+    /// `add_connection`) — the RFC's own "non-blocking checkout, not a
+    /// connection factory either" property. `test_on_check_out`
+    /// (`true` by default, never overridden by `PoolConfig::apply`)
+    /// makes r2d2 itself call `M::is_valid` on the popped connection
+    /// before handing it back — a stale connection fails there, r2d2
+    /// transparently drops and replaces it, and the manager's own
+    /// `is_valid` impl (`SqliteManager`/`PostgresManager`/`HttpManager`/
+    /// `PluginManagedConnection`, each in this crate) is what actually
+    /// calls `record_stale_rehydrated` on that path — this method
+    /// doesn't need to know a key's domain to make that counter move,
+    /// it just needs to trigger the checkout. Dropping the returned
+    /// `PooledConnection` immediately returns it to the pool (or, if
+    /// r2d2 evicted it as unrecoverable, simply lets it go).
+    fn sweep_one_round(&self) {
+        let keys: Vec<String> = { self.pools.lock().unwrap().keys().cloned().collect() };
+        for key in keys {
+            let pool = { self.pools.lock().unwrap().get(&key).cloned() };
+            if let Some(pool) = pool {
+                drop(pool.try_get());
+            }
+        }
     }
 
     /// Whether `key` specifically has a live pool right now — unlike
@@ -189,6 +362,181 @@ impl<M: ManageConnection> PoolRegistry<M> {
     #[cfg(test)]
     pub fn contains_key(&self, key: &str) -> bool {
         self.pools.lock().unwrap().contains_key(key)
+    }
+}
+
+/// A `str` value crossing the plugin ABI boundary by value — RFC 0011
+/// §2's `<shape>_provider_<scheme>_connect(host: str) -> i64` and
+/// `plugin.rs`'s own `NativePluginBuiltin` doc comment both describe
+/// this exact two-word `(ptr, len)` `#[repr(C)]` convention (matching
+/// `runtime-kernels/src/lib.rs`'s own established pattern for `str`
+/// crossing an `extern "C"` boundary by value, e.g. its `Dec128Bits`-
+/// shaped precedent). `ptr` is **not** NUL-terminated; `len` is
+/// load-bearing.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NirStr {
+    pub ptr: *const u8,
+    pub len: i64,
+}
+
+/// The `r2d2::ManageConnection` adapter RFC 0011 §5 describes: "the
+/// kernel supplies one generic adapter... that implements
+/// `ManageConnection` once by calling through whichever function
+/// pointers were resolved for a given provider at registration time."
+/// One `PluginManagedConnection` instance is the `M` for exactly one
+/// provider's `PoolRegistry<PluginManagedConnection>`, fixed to one
+/// `host` (the pool key) — `connect_fn` runs only when
+/// `PoolRegistry::get_or_create[_within_ceiling]` actually grows that
+/// pool, never called directly by anything else (§2 step 1).
+pub struct PluginManagedConnection {
+    pub connect_fn: extern "C" fn(NirStr) -> i64,
+    pub is_valid_fn: extern "C" fn(i64) -> i64,
+    pub close_fn: extern "C" fn(i64) -> i64,
+    pub host: String,
+    /// The provider's own registered domain (`plugin_provider::
+    /// ProviderFns::domain`) — needed only so `is_valid` below can call
+    /// `record_stale_rehydrated`, the identical thing `SqliteManager`/
+    /// `PostgresManager`/`HttpManager`'s own `is_valid` impls already do
+    /// on their `Err` path (`db.rs`/`http.rs`). Phase 5's original cut
+    /// of this struct omitted it (nothing needed it yet); Phase 7's
+    /// reaper is what makes proactive rehydration real for plugin
+    /// connections too, and the RFC's own §5 text says the reaper
+    /// "calls `is_valid_fn` through it exactly the way `db.rs`'s
+    /// `SqliteManager::is_valid` calls into `rusqlite` today" — that
+    /// parity was incomplete without this field.
+    pub domain: DomainId,
+}
+
+/// One live plugin connection — the kernel's own wrapper around the
+/// plugin's raw `i64`, never handed back to `.nir` code directly (§2:
+/// "the unwrap direction... `.nir` code holds the kernel id"). Carries
+/// its own `close_fn` (fixed at connect time, from the same provider
+/// that minted `raw`) so [`Drop`] can call it — r2d2's
+/// `ManageConnection` trait has no closing callback of its own; §2's
+/// own text is explicit that `close_fn` "only ever runs where r2d2
+/// already runs it": `has_broken`-triggered eviction, r2d2's own idle/
+/// lifetime reaping, or the reaper's sweep (Phase 7) — all of which
+/// just drop the `Connection` value, so `close_fn` belongs in `Drop`,
+/// not in any explicit "stop" call.
+pub struct PluginPoolConn {
+    pub raw: i64,
+    close_fn: extern "C" fn(i64) -> i64,
+}
+
+impl Drop for PluginPoolConn {
+    fn drop(&mut self) {
+        (self.close_fn)(self.raw);
+    }
+}
+
+impl std::fmt::Debug for PluginPoolConn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PluginPoolConn").field("raw", &self.raw).finish()
+    }
+}
+
+/// A plugin provider's `_connect`/`_is_valid` call returned a failure
+/// sentinel — §2's "0/1/negative sentinels every other kernel boundary
+/// already uses" convention, stringified the same way every other
+/// `ManageConnection::Error` in this crate already is
+/// (`CountingError` below, `db.rs`'s own manager errors).
+#[derive(Debug)]
+pub struct PluginConnError(pub String);
+
+impl std::fmt::Display for PluginConnError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for PluginConnError {}
+
+impl ManageConnection for PluginManagedConnection {
+    type Connection = PluginPoolConn;
+    type Error = PluginConnError;
+
+    fn connect(&self) -> Result<Self::Connection, Self::Error> {
+        let host = NirStr { ptr: self.host.as_ptr(), len: self.host.len() as i64 };
+        let raw = (self.connect_fn)(host);
+        if raw < 0 {
+            return Err(PluginConnError(format!(
+                "native plugin provider connect failed for host {:?} (returned {raw}, rfcs/0011 §2's negative-sentinel convention)",
+                self.host
+            )));
+        }
+        Ok(PluginPoolConn { raw, close_fn: self.close_fn })
+    }
+
+    fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
+        if (self.is_valid_fn)(conn.raw) != 0 {
+            Ok(())
+        } else {
+            super::record_stale_rehydrated(self.domain);
+            Err(PluginConnError(format!("native plugin provider is_valid returned false for connection {}", conn.raw)))
+        }
+    }
+
+    /// Always `false` — RFC 0011 §5's deliberate simplification, safe
+    /// specifically because `PoolConfig::apply` never overrides r2d2's
+    /// own `test_on_check_out` default (`true`, confirmed above), so
+    /// `is_valid` still runs on every checkout regardless of this
+    /// always-`false` shortcut; a genuinely broken connection is caught
+    /// there (or by the reaper's next sweep, Phase 7), not here.
+    fn has_broken(&self, _conn: &mut Self::Connection) -> bool {
+        false
+    }
+}
+
+/// One `PoolRegistry<M>`, type-erased so [`kernel::reaper`]
+/// (`crates/runtime-kernels/src/kernel/reaper.rs`) can hold a single
+/// process-wide list spanning every concrete `M` (`SqliteManager`,
+/// `PostgresManager`, `HttpManager`, `HttpsManager`,
+/// `PluginManagedConnection` — five distinct types, one trait). Every
+/// `PoolRegistry<M>` implements this the same way: forward to its own
+/// [`PoolRegistry::sweep_one_round`].
+pub trait Sweepable: Send + Sync {
+    fn sweep_one_round(&self);
+}
+
+impl<M: ManageConnection> Sweepable for PoolRegistry<M> {
+    fn sweep_one_round(&self) {
+        PoolRegistry::sweep_one_round(self)
+    }
+}
+
+static REAPER_TARGETS: OnceLock<Mutex<Vec<&'static dyn Sweepable>>> = OnceLock::new();
+
+/// Registers one process-wide `&'static PoolRegistry<M>` (any `M`) with
+/// the reaper — RFC 0011 §5: "every registered domain that's pool-backed
+/// also registers a `PoolRegistry<M>`." Idempotent by reference identity
+/// is not enforced here (the same `&'static` target pushed twice would
+/// just get swept twice per wake, harmlessly, since `sweep_one_round`
+/// itself is idempotent-safe) — every call site in this crate calls this
+/// at most once per registry anyway (`Once`-guarded at each call site),
+/// so double-registration is a call-site bug this doesn't need to guard
+/// against defensively.
+pub fn register_for_reaping(target: &'static dyn Sweepable) {
+    REAPER_TARGETS.get_or_init(|| Mutex::new(Vec::new())).lock().unwrap().push(target);
+}
+
+/// [`kernel::reaper`]'s one sweep primitive: one opportunistic
+/// `try_get`+drop per pool key, across every registered
+/// [`PoolRegistry`], in registration order rotated by `offset`
+/// (RFC 0011 §5's fairness note — whichever pool registered last isn't
+/// swept last on *every* cycle). The lock guarding
+/// [`REAPER_TARGETS`] is held only long enough to clone the list of
+/// `&'static` references (cheap — a reference is `Copy`), never across
+/// an actual sweep, so a sweep taking a while (a slow `is_valid`) never
+/// blocks a concurrent `register_for_reaping` call.
+pub fn sweep_all_registered(offset: usize) {
+    let targets: Vec<&'static dyn Sweepable> = REAPER_TARGETS.get_or_init(|| Mutex::new(Vec::new())).lock().unwrap().clone();
+    if targets.is_empty() {
+        return;
+    }
+    let n = targets.len();
+    for i in 0..n {
+        targets[(offset + i) % n].sweep_one_round();
     }
 }
 
@@ -317,5 +665,103 @@ mod tests {
             std::env::remove_var("NIRDOSHA_TESTPFX_POOL_MAX_SIZE");
             std::env::remove_var("NIRDOSHA_TESTPFX_POOL_IDLE_TIMEOUT_SECS");
         }
+    }
+
+    /// RFC 0011 §5's "what the ceiling actually bounds" rule: a
+    /// provider's `PoolConfig::max_size` must be ≤ its domain's own
+    /// admission ceiling, checked at registration time (here,
+    /// `get_or_create_within_ceiling`'s call), not left to r2d2 to grow
+    /// past silently.
+    #[test]
+    fn get_or_create_within_ceiling_refuses_a_max_size_past_the_domain_ceiling() {
+        let domain = super::super::register_domain("phase5_ceiling_test_domain", "NIRDOSHA_KERNEL_MAX_PHASE5_CEILING_TEST", 5);
+        let registry: PoolRegistry<CountingManager> = PoolRegistry::new();
+
+        let too_big = PoolConfig { max_size: 6, ..PoolConfig::default() };
+        let result = registry.get_or_create_within_ceiling("over", too_big, domain, || Ok(manager()));
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => panic!("max_size (6) exceeding the domain ceiling (5) must be refused, not silently allowed"),
+        };
+        assert!(err.contains("ceiling") && err.contains('6') && err.contains('5'), "expected a named, actionable ceiling error, got: {err}");
+        assert!(!registry.contains_key("over"), "a refused registration must not leave a pool behind");
+
+        let ok = PoolConfig { max_size: 5, ..PoolConfig::default() };
+        registry.get_or_create_within_ceiling("within", ok, domain, || Ok(manager())).expect("max_size equal to the ceiling must be allowed");
+        assert!(registry.contains_key("within"));
+    }
+
+    /// RFC 0011 §5's key-cap + fallback rule, the "dangerous direction to
+    /// get wrong" case named explicitly in the RFC: once
+    /// `NIRDOSHA_KERNEL_POOL_MAX_KEYS` distinct keys exist, a *new* key
+    /// must not grow the registry's `HashMap` — and the resulting
+    /// unpooled fallback dial must still move `kernel::acquire`'s
+    /// grant/denial counters exactly as if it were a normal checkout,
+    /// not silently bypass admission because it isn't a "real" checkout.
+    #[test]
+    fn checkout_with_key_cap_falls_back_to_unpooled_dialing_past_the_cap_and_still_brackets_acquire() {
+        // A small, low domain ceiling (2) so this test can also drive
+        // the *fallback path's own* acquire calls to a real denial,
+        // without needing thousands of iterations.
+        let domain = super::super::register_domain("phase5_key_cap_test_domain", "NIRDOSHA_KERNEL_MAX_PHASE5_KEY_CAP_TEST", 2);
+        // SAFETY (test-only): this env var is process-wide, but no other
+        // test in this crate reads NIRDOSHA_KERNEL_POOL_MAX_KEYS, and
+        // this test doesn't run concurrently with itself.
+        unsafe { std::env::set_var("NIRDOSHA_KERNEL_POOL_MAX_KEYS", "1") };
+
+        let registry: PoolRegistry<CountingManager> = PoolRegistry::new();
+        // max_size must fit the domain's own ceiling (2) too, since the
+        // pooled path goes through `get_or_create_within_ceiling`.
+        let cfg = PoolConfig { max_size: 2, ..PoolConfig::default() };
+
+        // First key: under the cap (0 existing keys < 1) -> pooled.
+        let first = registry.checkout_with_key_cap("k0", cfg, domain, || Ok(manager())).expect("the first key must be pooled");
+        assert!(matches!(first, Checkout::Pooled(_)), "the first key, under the cap, must be a normal pooled checkout");
+        assert_eq!(registry.pool_count(), 1);
+
+        let (held0, grants0, denials0, _) = super::super::stats(domain);
+        assert_eq!((held0, grants0, denials0), (0, 0, 0), "a pooled checkout must not itself move kernel::acquire's counters (unchanged from Phase 2b's convention: the caller brackets pooled checkouts, not pool.rs)");
+
+        // Second key: at the cap (1 existing key, not < 1) -> unpooled
+        // fallback. Must NOT grow the registry, and must go through
+        // kernel::acquire (grants: 0 -> 1, held: 0 -> 1).
+        let second = registry.checkout_with_key_cap("k1", cfg, domain, || Ok(manager())).expect("fallback dial must succeed while under the domain ceiling");
+        let guard1 = match second {
+            Checkout::Unpooled(g) => g,
+            Checkout::Pooled(_) => panic!("a key past the cap must fall back to unpooled, not silently pool anyway"),
+        };
+        assert_eq!(registry.pool_count(), 1, "an unpooled fallback must not add a HashMap entry");
+        let (held1, grants1, denials1, _) = super::super::stats(domain);
+        assert_eq!((held1, grants1, denials1), (1, 1, 0), "the fallback dial must be acquire-bracketed exactly like a real checkout");
+
+        // Third key: also past the cap -> another unpooled fallback,
+        // still within the domain ceiling of 2 (held 1 -> 2).
+        let third = registry.checkout_with_key_cap("k2", cfg, domain, || Ok(manager())).expect("second fallback dial must still succeed, at the ceiling");
+        let guard2 = match third {
+            Checkout::Unpooled(g) => g,
+            Checkout::Pooled(_) => panic!("must still fall back past the cap"),
+        };
+        assert_eq!(registry.pool_count(), 1, "still no HashMap growth from fallback keys");
+        let (held2, grants2, denials2, _) = super::super::stats(domain);
+        assert_eq!((held2, grants2, denials2), (2, 2, 0), "second fallback dial: held/grants both advance, at the domain ceiling now");
+
+        // Fourth key: past both the key cap AND the domain's own
+        // ceiling (already at 2/2 held) -> the fallback's own acquire
+        // must be denied, not silently let a third connection through.
+        let fourth = registry.checkout_with_key_cap("k3", cfg, domain, || Ok(manager()));
+        assert!(fourth.is_err(), "a fallback dial past the domain's own ceiling must be denied, not silently admitted");
+        assert_eq!(registry.pool_count(), 1, "a denied fallback must not add a HashMap entry either");
+        let (held3, grants3, denials3, _) = super::super::stats(domain);
+        assert_eq!((held3, grants3, denials3), (2, 2, 1), "the denied fallback must move the denials counter, not the held/grants ones");
+
+        // Dropping the fallback guards releases their admission --
+        // proving `release` isn't skipped just because the caller never
+        // explicitly called it.
+        drop(guard1);
+        drop(guard2);
+        let (held_after, _, _, _) = super::super::stats(domain);
+        assert_eq!(held_after, 0, "dropping every UnpooledConnection guard must release its admission back to zero");
+
+        unsafe { std::env::remove_var("NIRDOSHA_KERNEL_POOL_MAX_KEYS") };
     }
 }

--- a/crates/runtime-kernels/src/kernel/reaper.rs
+++ b/crates/runtime-kernels/src/kernel/reaper.rs
@@ -1,0 +1,315 @@
+//! RFC 0011 §5's reaper — proactive rehydration realized as one job,
+//! submitted once, whose body is its own infinite loop:
+//! `loop { sweep_all_pools(); thread::sleep(interval) }`, not a second
+//! threading primitive alongside [`super::thread_pool::ThreadPool`].
+//! Reactive rehydration (`ManageConnection::is_valid` on checkout,
+//! already real for every registered pool — `db.rs`/`http.rs`/
+//! `pool.rs`'s own `PluginManagedConnection`) already guarantees no
+//! caller ever sees a stale connection; this module exists only to
+//! shrink the *window* a stale idle connection sits unnoticed, per
+//! [[nirdosha_pool_rehydration_requirement]] — never something this
+//! RFC's own correctness claim depends on.
+//!
+//! Runs on its own dedicated [`super::thread_pool::ThreadPool`]
+//! singleton (not the one `lib.rs`'s `global_thread_pool` uses for
+//! user `spawn`/`join`) — RFC §5 only asks for "using
+//! `kernel::thread_pool::ThreadPool` as it actually exists," not that
+//! it share the same instance as user-code threads; keeping it
+//! dedicated avoids any lifecycle coupling with user thread-count
+//! accounting (`domain::thread()`'s own ceiling) for a job that isn't a
+//! user resource at all. From `ThreadPool`'s own perspective this
+//! permanently occupies one worker for the life of the process — a
+//! disclosed, deliberate cost of exactly one OS thread, not a new
+//! capability requirement on `thread_pool.rs` itself (that module's own
+//! doc comment already states it has none).
+
+use super::pool;
+use super::thread_pool::ThreadPool;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Once, OnceLock};
+use std::time::Duration;
+
+static REAPER_PANICS: AtomicU64 = AtomicU64::new(0);
+
+/// RFC §5: "a broken reaper is a visible number going up, not a silent
+/// absence" — surfaced through [`super::dump_report`].
+pub fn reaper_panics() -> u64 {
+    REAPER_PANICS.load(Ordering::Relaxed)
+}
+
+/// Checked once per wake, never joined against today — `ThreadPool` (as
+/// read, this module's own doc comment) has no shutdown/join API, so a
+/// real compiled Nirdosha binary already has no graceful-shutdown story
+/// that would need to signal this; this is forward-compatible plumbing
+/// for a future RFC 0006 structured-concurrency shutdown mechanism, not
+/// something exercised by any shutdown path today. A bare
+/// `thread::sleep(interval)` is uninterruptible for the whole interval,
+/// so even a signaled shutdown could take up to `interval` to actually
+/// notice — accepted for now, stated rather than hidden (RFC §5's own
+/// text).
+static SHUTDOWN: AtomicBool = AtomicBool::new(false);
+
+/// Signals the reaper loop to exit at its next wake (see [`SHUTDOWN`]'s
+/// own doc comment for what this does and does not guarantee today).
+pub fn request_shutdown() {
+    SHUTDOWN.store(true, Ordering::Relaxed);
+}
+
+/// RFC §5's fairness note: "starting each wake's sweep at a rotating
+/// offset into the pool list... fixes [uneven coverage] for free."
+static SWEEP_OFFSET: AtomicUsize = AtomicUsize::new(0);
+
+fn reaper_pool() -> &'static Arc<ThreadPool> {
+    static POOL: OnceLock<Arc<ThreadPool>> = OnceLock::new();
+    POOL.get_or_init(ThreadPool::new)
+}
+
+/// `NIRDOSHA_KERNEL_REAPER_INTERVAL_SECS` — parsed exactly the way
+/// [`super::pool::PoolConfig::from_env`] already resolves its own env
+/// vars (a malformed value degrades to the default field-by-field,
+/// never fails the whole program), extended with RFC §5's own floor/
+/// ceiling: parse failure or unset → default (30s, silently, same
+/// convention as `PoolConfig::from_env`); `0` or negative → the RFC's
+/// own explicit "never accepted silently" case, clamped up to the 1s
+/// floor with a warning (an accepted-but-unclamped `0` would be
+/// `sleep(Duration::ZERO)`, a busy loop pinning one core at 100%
+/// forever); above the 3600s (1h) soft ceiling → accepted as configured
+/// but warned, since an operator setting an enormous interval is far
+/// more likely to have made a typo than to have intended to disable
+/// proactive sweeping (reactive, checkout-time rehydration still covers
+/// correctness either way, per this module's own doc comment — so this
+/// is a warn, not a clamp).
+///
+/// Pure function of the raw env var string (or its absence), not of
+/// `std::env` directly, so unit tests can exercise every branch without
+/// racing real env-var mutation across parallel `cargo test` threads.
+fn resolve_interval_secs(raw: Option<&str>) -> u64 {
+    const DEFAULT_SECS: i64 = 30;
+    const FLOOR_SECS: i64 = 1;
+    const SOFT_CEILING_SECS: i64 = 3600;
+
+    let parsed = raw.and_then(|v| v.parse::<i64>().ok());
+    match parsed {
+        None => DEFAULT_SECS as u64,
+        Some(n) if n < FLOOR_SECS => {
+            eprintln!(
+                "nirdosha kernel: NIRDOSHA_KERNEL_REAPER_INTERVAL_SECS={n} is below the {FLOOR_SECS}-second floor -- \
+                 using {FLOOR_SECS}s instead (0 or a negative interval would busy-loop the reaper thread)"
+            );
+            FLOOR_SECS as u64
+        }
+        Some(n) if n > SOFT_CEILING_SECS => {
+            eprintln!(
+                "nirdosha kernel: NIRDOSHA_KERNEL_REAPER_INTERVAL_SECS={n} is above the {SOFT_CEILING_SECS}s (1h) soft ceiling -- \
+                 accepted as configured, but this likely disables proactive rehydration rather than being an intentional choice \
+                 (reactive, checkout-time rehydration still covers correctness either way)"
+            );
+            n as u64
+        }
+        Some(n) => n as u64,
+    }
+}
+
+fn interval() -> Duration {
+    Duration::from_secs(resolve_interval_secs(std::env::var("NIRDOSHA_KERNEL_REAPER_INTERVAL_SECS").ok().as_deref()))
+}
+
+/// One sweep round: [`super::pool::sweep_all_registered`], wrapped in
+/// its own `catch_unwind` — **inside** the reaper's loop body, not
+/// relying on [`super::thread_pool::ThreadPool`]'s own `worker_loop`
+/// outer `catch_unwind`. RFC §5's own review-caught failure mode: the
+/// reaper's job body is `loop { sweep_all_pools(); sleep(...) }`, a
+/// panic inside one `sweep_all_pools()` call would otherwise be caught
+/// at the *outermost* `catch_unwind`, ending the whole loop — the job
+/// "completes" from `ThreadPool`'s perspective, no crash, nothing
+/// visibly wrong, and rehydration silently stops forever while every
+/// other health signal stays green. This is the fix: catch each sweep
+/// individually, increment [`REAPER_PANICS`] on catch, and keep going
+/// to the next `sleep`/wake regardless.
+///
+/// This is a kernel-side-bug containment mechanism (a poisoned lock
+/// `.unwrap()`, an indexing error) — **not** a plugin-panic mechanism.
+/// A panic crossing a plugin's plain `extern "C"` boundary
+/// (`is_valid_fn`, called transitively through
+/// `PluginManagedConnection::is_valid` during a sweep) is a *defined
+/// abort at that boundary* (`thread_pool.rs`'s own "Panic containment"
+/// doc comment), not something any Rust-side `catch_unwind` can
+/// intercept — the panic never returns to this frame at all. This
+/// `catch_unwind` only ever catches a panic that happens to originate
+/// in this crate's own Rust code during a sweep.
+fn sweep_once() {
+    let offset = SWEEP_OFFSET.fetch_add(1, Ordering::Relaxed);
+    if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| pool::sweep_all_registered(offset))).is_err() {
+        REAPER_PANICS.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Starts the reaper, idempotently — safe to call more than once (later
+/// calls are no-ops), the same `Once`-guarded self-start posture
+/// `domain::register_builtin_domains` already established (Phase 2a).
+/// `lib.rs`'s `nir_kernel_start_reaper` FFI wrapper is what `codegen.rs`
+/// actually calls, once, in every compiled program's `main` preamble
+/// (immediately after the domain/plugin-provider registration calls) —
+/// this function itself has no dependency on that wiring and is
+/// directly callable (and tested) from plain Rust too.
+pub fn start() {
+    static STARTED: Once = Once::new();
+    STARTED.call_once(|| {
+        let interval = interval();
+        // `submit`'s `Job` (`thread_pool.rs`) is private to that module
+        // -- callers never name it, they just pass a closure that
+        // structurally matches it, the same pattern every other
+        // `ThreadPool::submit` call site in this crate already uses
+        // (`lib.rs`, `nfr.rs`, `recorder.rs`).
+        let _ = reaper_pool().submit(Box::new(move || {
+            loop {
+                if SHUTDOWN.load(Ordering::Relaxed) {
+                    return;
+                }
+                sweep_once();
+                std::thread::sleep(interval);
+            }
+        }));
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::pool::{ManageConnection, PoolConfig, PoolRegistry};
+
+    #[test]
+    fn resolve_interval_secs_defaults_on_unset_or_unparseable() {
+        assert_eq!(resolve_interval_secs(None), 30);
+        assert_eq!(resolve_interval_secs(Some("not a number")), 30);
+        assert_eq!(resolve_interval_secs(Some("")), 30);
+    }
+
+    #[test]
+    fn resolve_interval_secs_floors_zero_and_negative_to_one() {
+        assert_eq!(resolve_interval_secs(Some("0")), 1);
+        assert_eq!(resolve_interval_secs(Some("-5")), 1);
+    }
+
+    #[test]
+    fn resolve_interval_secs_accepts_a_value_above_the_soft_ceiling_unclamped() {
+        // Accepted as configured (just warned), not clamped down -- the
+        // RFC's own "warn, not clamp" rule for the ceiling, unlike the
+        // floor which does clamp.
+        assert_eq!(resolve_interval_secs(Some("99999999")), 99999999);
+    }
+
+    #[test]
+    fn resolve_interval_secs_passes_through_an_ordinary_value_unchanged() {
+        assert_eq!(resolve_interval_secs(Some("45")), 45);
+        assert_eq!(resolve_interval_secs(Some("3600")), 3600, "exactly the ceiling must not warn or clamp");
+        assert_eq!(resolve_interval_secs(Some("1")), 1, "exactly the floor must not warn or clamp");
+    }
+
+    /// A synthetic Rust-side `ManageConnection` whose `is_valid` panics
+    /// only while explicitly "armed" (an external `Arc<AtomicBool>` the
+    /// test flips, disarming itself on the way out) — deliberately
+    /// **not** "panics on its Nth call," because r2d2's own
+    /// `try_get_inner` (confirmed by reading `r2d2 0.8.10`'s source
+    /// directly, not assumed) calls `is_valid` on a connection it just
+    /// created just as readily as on one popped from the idle list —
+    /// `get_timeout`'s retry loop calls `add_connection` on an empty
+    /// pool, then loops back into `try_get_inner`, which pops that
+    /// freshly-added connection and validates it like any other. A
+    /// call-count-based "first call panics" design panics during this
+    /// test's own setup checkout, before `sweep_once` ever runs — caught
+    /// by nothing, since setup code isn't wrapped in `catch_unwind` —
+    /// which is exactly the failure this arm/disarm design avoids by
+    /// construction rather than by getting r2d2's internal call count
+    /// right.
+    ///
+    /// **Why this is the only correct shape for this test, stated
+    /// explicitly per RFC §5's own warning**: a panic inside a plugin's
+    /// `extern "C"` function is a defined *abort* at that FFI boundary
+    /// (`thread_pool.rs`'s own doc comment) -- no Rust-side
+    /// `catch_unwind` can intercept it, and attempting to exercise that
+    /// path here would abort the whole `cargo test` process instead of
+    /// producing a test failure. This test panics inside a plain Rust
+    /// `ManageConnection::is_valid` impl instead, deliberately, which is
+    /// exactly the class of bug (a kernel-side bug, not a plugin one)
+    /// `sweep_once`'s `catch_unwind` actually exists to contain.
+    struct PanicsWhileArmed {
+        armed: Arc<AtomicBool>,
+    }
+
+    struct DummyConn;
+
+    impl ManageConnection for PanicsWhileArmed {
+        type Connection = DummyConn;
+        type Error = std::io::Error;
+
+        fn connect(&self) -> Result<Self::Connection, Self::Error> {
+            Ok(DummyConn)
+        }
+
+        fn is_valid(&self, _conn: &mut Self::Connection) -> Result<(), Self::Error> {
+            if self.armed.swap(false, Ordering::SeqCst) {
+                panic!("PanicsWhileArmed: deliberate armed-call panic, kernel-side-bug simulation for sweep_once's catch_unwind test");
+            }
+            Ok(())
+        }
+
+        fn has_broken(&self, _conn: &mut Self::Connection) -> bool {
+            false
+        }
+    }
+
+    #[test]
+    fn sweep_once_contains_a_panic_inside_one_pools_is_valid_and_keeps_sweeping() {
+        let registry: PoolRegistry<PanicsWhileArmed> = PoolRegistry::new();
+        let armed = Arc::new(AtomicBool::new(false));
+        let mgr = PanicsWhileArmed { armed: Arc::clone(&armed) };
+        let cfg = PoolConfig::default();
+        let pool = registry.get_or_create("panic_test_key", cfg, || Ok(mgr)).expect("build a one-key pool");
+        // Setup checkout, unarmed: whether or not r2d2 happens to call
+        // `is_valid` on this freshly-created connection is irrelevant
+        // now -- it can only ever return `Ok`. Returning it (`drop`)
+        // makes it idle, available for `sweep_once`'s own `try_get`.
+        drop(pool.get().expect("setup checkout, unarmed, must always succeed"));
+
+        // Leaked deliberately -- `register_for_reaping` needs `&'static`,
+        // and this test-only registry only ever needs to outlive this
+        // one test process, the same permanent-leak posture other
+        // process-wide `'static` kernel state in this crate already has.
+        let leaked: &'static PoolRegistry<PanicsWhileArmed> = Box::leak(Box::new(registry));
+        pool::register_for_reaping(leaked);
+
+        let panics_before = reaper_panics();
+        armed.store(true, Ordering::SeqCst);
+        // `try_get` pops the one idle connection; `test_on_check_out`
+        // (on by default) calls `is_valid`, now armed -- `sweep_once`
+        // must contain the resulting panic.
+        sweep_once();
+        assert_eq!(reaper_panics(), panics_before + 1, "a panic inside one pool's is_valid during a sweep must increment reaper_panics");
+        assert!(!armed.load(Ordering::SeqCst), "is_valid must actually have run (and disarmed itself) during the sweep, not been skipped");
+
+        // r2d2 drops a connection whose `is_valid` panicked out from
+        // under `catch_unwind` (the checkout never completed), so the
+        // pool is now empty -- check one back in (unarmed, so this must
+        // succeed) so the second sweep below has something to find.
+        drop(pool.get().expect("checkout after the panic must still succeed, unarmed"));
+
+        // Second sweep: must run at all (the loop wasn't ended by the
+        // first sweep's panic) and must not double-count as a panic
+        // (still unarmed).
+        sweep_once();
+        assert_eq!(reaper_panics(), panics_before + 1, "a second, unarmed sweep must not increment reaper_panics again");
+    }
+
+    #[test]
+    fn start_is_idempotent_and_does_not_panic_when_called_more_than_once() {
+        // Real assertion here is narrow and deliberate: `start` must not
+        // panic or block, called twice, from a plain unit test -- it
+        // doesn't assert anything about sweep timing, since this
+        // process-wide reaper is shared with every other test in this
+        // binary and a real interval-based assertion would be flaky by
+        // construction.
+        start();
+        start();
+    }
+}

--- a/crates/runtime-kernels/src/kernel/recorder.rs
+++ b/crates/runtime-kernels/src/kernel/recorder.rs
@@ -21,15 +21,18 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
 /// One admission-relevant thing that happened. Deliberately tiny and
-/// allocation-free (10 bytes) — an event is recorded once per
-/// `acquire`/`release` call (boundary-only, never on the `send`/`recv`
-/// hot path, same scoping [`super::acquire`] itself uses), so the
-/// volume is inherently low, but the representation stays cheap anyway
-/// rather than assuming that.
+/// allocation-free — an event is recorded once per `acquire`/`release`
+/// call (boundary-only, never on the `send`/`recv` hot path, same
+/// scoping [`super::acquire`] itself uses), so the volume is inherently
+/// low, but the representation stays cheap anyway rather than assuming
+/// that. `domain` is `u16`, not `u8` — RFC 0011's open domain registry
+/// (`super::DomainId`) can exceed 255 once a single plugin provider
+/// registers, let alone several; `u16` (65536) stays comfortably above
+/// `super::MAX_DOMAINS` (4096) with room to spare.
 #[derive(Clone, Copy)]
 struct Event {
     seq: u64,
-    domain: u8,
+    domain: u16,
     kind: u8,
 }
 
@@ -73,9 +76,9 @@ static RECORDER: Recorder =
 /// queued for background flushing — this function itself never touches
 /// disk and never waits on anything but the page's own short-lived
 /// lock.
-pub fn record(domain: super::Domain, kind: EventKind) {
+pub fn record(domain: super::DomainId, kind: EventKind) {
     let seq = RECORDER.seq.fetch_add(1, Ordering::Relaxed);
-    let event = Event { seq, domain: domain as u8, kind: kind as u8 };
+    let event = Event { seq, domain: domain as u16, kind: kind as u8 };
     let active = RECORDER.active.load(Ordering::Acquire);
     let full = {
         let mut page = RECORDER.pages[active].lock().unwrap();
@@ -131,17 +134,8 @@ fn flush_async(page: Vec<Event>) {
     }
 }
 
-fn domain_name(d: u8) -> &'static str {
-    match d {
-        0 => "tcp",
-        1 => "file",
-        2 => "thread",
-        3 => "db",
-        4 => "mq",
-        5 => "http",
-        6 => "serve_http",
-        _ => "unknown",
-    }
+fn domain_name(d: u16) -> &'static str {
+    super::registered_domain_name(d as super::DomainId).unwrap_or("unknown")
 }
 
 fn kind_name(k: u8) -> &'static str {
@@ -259,7 +253,7 @@ mod tests {
         // hook calls, and it's the only thing that should produce a
         // file here.
         for _ in 0..5 {
-            record(super::super::Domain::File, EventKind::Grant);
+            record(super::super::domain::file(), EventKind::Grant);
         }
         assert!(!std::path::Path::new(PATH).exists(), "a page nowhere near full must not have flushed anything yet");
         flush_remaining();
@@ -270,7 +264,7 @@ mod tests {
         // itself automatically, with no further `flush_remaining()`
         // call -- appended as a second gzip member after part 1's.
         for _ in 0..CAP {
-            record(super::super::Domain::Tcp, EventKind::Release);
+            record(super::super::domain::tcp(), EventKind::Release);
         }
         // The flush runs on a background worker -- give it a real
         // moment to land before checking.

--- a/crates/runtime-kernels/src/lib.rs
+++ b/crates/runtime-kernels/src/lib.rs
@@ -1718,6 +1718,109 @@ pub unsafe extern "C" fn nir_oidc_validate_token(
     }
 }
 
+/// `mock_issue_token`'s real implementation — the inverse of
+/// `oidc_validate_token` above: signs a token instead of verifying one.
+/// `mock_` is load-bearing, not decorative (the builtin's own typeck doc
+/// comment) — this issues a token from key material the caller supplies
+/// directly, standing in for a real IdP's own signing endpoint, never a
+/// substitute for one.
+///
+/// **HS256 (symmetric) only, deliberately.** `jwks_json` is the exact
+/// same shape `oidc_validate_token`/`decoding_key_for` already parse
+/// (`RawJwks`/`RawJwk` above); this looks up the first `kty: "oct"` entry
+/// and signs with it. RSA/EC issuance would need real private-key
+/// material (a JWK's `d` parameter and friends) this first pass doesn't
+/// handle — a real, disclosed follow-up, not attempted here. Verifying
+/// the token this produces against the *same* `jwks_json` already works
+/// today, unchanged, via `oidc_validate_token`'s own existing `"oct"` arm.
+fn issue_mock_token_inner(
+    subject: &str,
+    issuer: &str,
+    audience: &str,
+    issued_at: i64,
+    ttl_secs: i64,
+    claims_json: &str,
+    jwks_json: &str,
+) -> Result<String, String> {
+    use base64::Engine as _;
+
+    let jwks: RawJwks = serde_json::from_str(jwks_json).map_err(|e| format!("malformed JWKS: {e}"))?;
+    let jwk = jwks
+        .keys
+        .iter()
+        .find(|k| k.kty == "oct")
+        .ok_or_else(|| "no `oct` (HMAC) signing key found in jwks_json -- mock_issue_token only supports HS256".to_string())?;
+    let k = jwk.k.as_deref().ok_or("JWK is missing required field `k`")?;
+    let raw_secret = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(k)
+        .map_err(|_| "JWK field `k` is not valid base64url".to_string())?;
+    let encoding_key = jsonwebtoken::EncodingKey::from_secret(&raw_secret);
+
+    // `claims_json`'s own fields (e.g. a `"roles"` array `check_role`
+    // reads back out later) are preserved -- only the six standard claims
+    // this builtin itself owns are overwritten, same "caller-supplied
+    // extras survive" convention `oidc_validate_token`'s own `claims_json`
+    // output already has.
+    let mut claims: serde_json::Value = serde_json::from_str(claims_json).unwrap_or_default();
+    if !claims.is_object() {
+        claims = serde_json::Value::Object(serde_json::Map::new());
+    }
+    let obj = claims.as_object_mut().expect("just ensured this is an object");
+    obj.insert("sub".to_string(), serde_json::Value::String(subject.to_string()));
+    obj.insert("iss".to_string(), serde_json::Value::String(issuer.to_string()));
+    obj.insert("aud".to_string(), serde_json::Value::String(audience.to_string()));
+    obj.insert("iat".to_string(), serde_json::Value::from(issued_at));
+    obj.insert("exp".to_string(), serde_json::Value::from(issued_at.saturating_add(ttl_secs)));
+
+    let mut header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::HS256);
+    header.kid = Some(jwk.kid.clone());
+
+    jsonwebtoken::encode(&header, &claims, &encoding_key).map_err(|e| format!("failed to sign token: {e}"))
+}
+
+/// `1` (with `out_token` populated) on success, `0` (with `out_err`
+/// populated) otherwise — a malformed JWKS or a JWKS with no usable
+/// signing key is a real `Err`, never a trap, same as every other
+/// identity check in this codebase.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_mock_issue_token(
+    subject_ptr: *const u8,
+    subject_len: i64,
+    issuer_ptr: *const u8,
+    issuer_len: i64,
+    audience_ptr: *const u8,
+    audience_len: i64,
+    issued_at: i64,
+    ttl_secs: i64,
+    claims_json_ptr: *const u8,
+    claims_json_len: i64,
+    jwks_ptr: *const u8,
+    jwks_len: i64,
+    out_token: *mut NirStrOut,
+    out_err: *mut NirStrOut,
+) -> i32 {
+    let (Some(subject), Some(issuer), Some(audience), Some(claims_json), Some(jwks_json)) = (
+        unsafe { str_from_raw(subject_ptr, subject_len) },
+        unsafe { str_from_raw(issuer_ptr, issuer_len) },
+        unsafe { str_from_raw(audience_ptr, audience_len) },
+        unsafe { str_from_raw(claims_json_ptr, claims_json_len) },
+        unsafe { str_from_raw(jwks_ptr, jwks_len) },
+    ) else {
+        unsafe { write_str_out(out_err, "subject/issuer/audience/claims_json/jwks is not valid UTF-8".to_string()) };
+        return 0;
+    };
+    match issue_mock_token_inner(subject, issuer, audience, issued_at, ttl_secs, claims_json, jwks_json) {
+        Ok(token) => unsafe {
+            write_str_out(out_token, token);
+            1
+        },
+        Err(msg) => unsafe {
+            write_str_out(out_err, msg);
+            0
+        },
+    }
+}
+
 /// `1` if `role` (as UTF-8 bytes) is present in `claims`'s roles, `0`
 /// otherwise — including if either buffer isn't valid UTF-8, the same
 /// "fail closed on malformed input" posture every other identity check

--- a/crates/runtime-kernels/src/lib.rs
+++ b/crates/runtime-kernels/src/lib.rs
@@ -45,7 +45,7 @@
 // embedding path every compiled `.nir` binary uses. Every compiled
 // `.nir` binary still only ever calls the `#[no_mangle] extern "C"`
 // `nir_*` functions below (unaffected by this); `compiled-serve` is a
-// second, additive consumer needing real Rust-level access (`Domain`,
+// second, additive consumer needing real Rust-level access (`domain`,
 // `acquire`/`release`, `dump_report`) for things a `.nir` program has
 // no reason to ever touch directly, matching this module's own "no
 // query interface for `.nir` code" doc comment.
@@ -90,6 +90,120 @@ pub extern "C" fn nir_kernel_self_test_panic_containment() -> i32 {
         Ok(()) => 1,
         Err(_) => 0,
     }
+}
+
+/// The open domain registry's one bootstrap point — `codegen.rs`
+/// (`emit_c_main`) emits exactly one call to this, at the very top of
+/// every compiled program's `main`, strictly before any user code
+/// (`nir_main`) or any other kernel-preamble setup runs. This is what
+/// gives the 7 built-in domains their historical, stable ids 0-6 in a
+/// compiled binary: nothing else has had a chance to register a domain
+/// first. `kernel::domain::register_builtin_domains` is itself
+/// idempotent (`Once`-guarded) and every domain accessor
+/// (`kernel::domain::db()`, etc.) also self-registers on first use, so
+/// this call is a deliberate, redundant belt-and-suspenders bootstrap,
+/// not the only path that can make registration happen — see that
+/// function's own doc comment.
+#[unsafe(no_mangle)]
+pub extern "C" fn nir_kernel_register_builtin_domains() {
+    kernel::domain::register_builtin_domains();
+}
+
+/// RFC 0011 §4's per-provider registration point — `codegen.rs` emits
+/// one call to this per distinct validated plugin provider in
+/// `build_with_native_plugins`'s list, in the order given, immediately
+/// after the single `nir_kernel_register_builtin_domains()` bootstrap
+/// call above, still inside `main`'s preamble before any user code
+/// runs. `name`/`env_var` arrive as `(ptr, len)` pairs pointing at
+/// LLVM string-constant globals `codegen.rs` emits alongside this
+/// call — those globals live for the whole process (they're `.rodata`,
+/// never freed), so leaking a heap copy here to satisfy
+/// `register_domain`'s `&'static str` requirement is the correct
+/// permanent-leak posture (same one `NativePluginBuiltin`'s own str
+/// return-value convention already documents), not a real leak in any
+/// sense that matters for a process that's about to eagerly register
+/// every provider it will ever have, once, at startup.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_kernel_register_domain(
+    name_ptr: *const u8,
+    name_len: i64,
+    env_var_ptr: *const u8,
+    env_var_len: i64,
+    default_max: i64,
+) {
+    let name = unsafe { str_from_raw(name_ptr, name_len) }.expect("codegen only ever emits valid UTF-8 domain-name globals");
+    let env_var = unsafe { str_from_raw(env_var_ptr, env_var_len) }.expect("codegen only ever emits valid UTF-8 env-var-name globals");
+    let name: &'static str = Box::leak(name.to_string().into_boxed_str());
+    let env_var: &'static str = Box::leak(env_var.to_string().into_boxed_str());
+    kernel::register_domain(name, env_var, default_max);
+}
+
+/// RFC 0011 §2/§4's dispatch-table registration — `codegen.rs` emits
+/// one call to this immediately after this same provider's
+/// `nir_kernel_register_domain` call above (same preamble loop
+/// iteration), so `domain_name`/`domain_name_len` name an
+/// already-registered domain here: `kernel::domain_id_for_name` is a
+/// plain lookup, not a second registration path. `scheme` is the
+/// compiler's own already-normalized scheme identifier
+/// (`plugin::normalize_scheme`'s output) — this call does not
+/// re-normalize it.
+///
+/// The four function-pointer parameters are opaque addresses
+/// (`*const ()`, matching LLVM's untyped `ptr` at this boundary) rather
+/// than their real `extern "C" fn` types, because `_op`'s and
+/// `_request`'s real signatures differ in arity (one `str` arg vs two) —
+/// `is_call_shape` says which one `op_or_request_fn` actually is, so
+/// this function can transmute it back to the correct type on this side
+/// rather than `codegen.rs` needing two mutually-exclusive parameters,
+/// one always unused. Sound because a function pointer and a data
+/// pointer share the same representation on every platform this
+/// backend targets (the identical assumption every other `ptr`-typed
+/// `declare` in `codegen.rs` already makes for its own extern calls),
+/// and because `codegen.rs` only ever passes the address of a real,
+/// `declare`d symbol with the shape this call expects — never a value
+/// `.nir` code could influence.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_kernel_register_plugin_provider(
+    domain_name_ptr: *const u8,
+    domain_name_len: i64,
+    scheme_ptr: *const u8,
+    scheme_len: i64,
+    connect_fn: *const (),
+    op_or_request_fn: *const (),
+    is_valid_fn: *const (),
+    close_fn: *const (),
+    is_call_shape: i32,
+) {
+    let domain_name = unsafe { str_from_raw(domain_name_ptr, domain_name_len) }.expect("codegen only ever emits valid UTF-8 domain-name globals");
+    let scheme = unsafe { str_from_raw(scheme_ptr, scheme_len) }.expect("codegen only ever emits valid UTF-8 scheme globals");
+    let domain = kernel::domain_id_for_name(domain_name)
+        .expect("codegen emits nir_kernel_register_domain for this exact provider immediately before this call, in the same preamble loop iteration");
+    let connect_fn: extern "C" fn(kernel::pool::NirStr) -> i64 = unsafe { std::mem::transmute(connect_fn) };
+    let is_valid_fn: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(is_valid_fn) };
+    let close_fn: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(close_fn) };
+    let op = if is_call_shape != 0 {
+        let request_fn: extern "C" fn(i64, kernel::pool::NirStr, kernel::pool::NirStr) -> kernel::pool::NirStr = unsafe { std::mem::transmute(op_or_request_fn) };
+        kernel::plugin_provider::ProviderOp::Call { request_fn }
+    } else {
+        let op_fn: extern "C" fn(i64, kernel::pool::NirStr) -> kernel::pool::NirStr = unsafe { std::mem::transmute(op_or_request_fn) };
+        kernel::plugin_provider::ProviderOp::ConnStream { op_fn }
+    };
+    kernel::plugin_provider::register(scheme.to_string(), kernel::plugin_provider::ProviderFns { connect_fn, is_valid_fn, close_fn, op, domain });
+}
+
+/// RFC 0011 §5's reaper startup point — `codegen.rs` emits exactly one
+/// call to this, in every compiled program's `main` preamble,
+/// immediately after the domain/plugin-provider registration calls
+/// above. `kernel::reaper::start` is itself `Once`-guarded and directly
+/// callable (and tested) from plain Rust with no dependency on this FFI
+/// wrapper existing at all — this function exists only so a compiled
+/// `.nir` binary actually starts the reaper thread once, the same
+/// "codegen carries zero knowledge of the mechanism, just calls the one
+/// bootstrap entrypoint" shape `nir_kernel_register_builtin_domains`
+/// already established.
+#[unsafe(no_mangle)]
+pub extern "C" fn nir_kernel_start_reaper() {
+    kernel::reaper::start();
 }
 
 /// The flight recorder's one exit point — `codegen.rs`'s generated
@@ -782,13 +896,13 @@ pub unsafe extern "C" fn nir_tcp_connect(host_ptr: *const u8, host_len: i64, por
     // the same `-1` every other connect failure already returns; a
     // distinct error code is real future work, not a gap to route
     // around here.
-    if !kernel::acquire(kernel::Domain::Tcp) {
+    if !kernel::acquire(kernel::domain::tcp()) {
         return -1;
     }
     match TcpStream::connect((host, port)) {
         Ok(stream) => handle_of_stream(stream),
         Err(_) => {
-            kernel::release(kernel::Domain::Tcp);
+            kernel::release(kernel::domain::tcp());
             -1
         }
     }
@@ -800,13 +914,13 @@ pub unsafe extern "C" fn nir_tcp_connect(host_ptr: *const u8, host_len: i64, por
 #[unsafe(no_mangle)]
 pub extern "C" fn nir_tcp_listen(port: i64) -> i64 {
     let Ok(port) = u16::try_from(port) else { return -1 };
-    if !kernel::acquire(kernel::Domain::Tcp) {
+    if !kernel::acquire(kernel::domain::tcp()) {
         return -1;
     }
     match TcpListener::bind(("0.0.0.0", port)) {
         Ok(listener) => handle_of_listener(listener),
         Err(_) => {
-            kernel::release(kernel::Domain::Tcp);
+            kernel::release(kernel::domain::tcp());
             -1
         }
     }
@@ -821,13 +935,13 @@ pub extern "C" fn nir_tcp_listen(port: i64) -> i64 {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn nir_tcp_accept(listener_handle: i64) -> i64 {
     let listener = ManuallyDrop::new(unsafe { listener_from_handle(listener_handle) });
-    if !kernel::acquire(kernel::Domain::Tcp) {
+    if !kernel::acquire(kernel::domain::tcp()) {
         return -1;
     }
     match listener.accept() {
         Ok((stream, _addr)) => handle_of_stream(stream),
         Err(_) => {
-            kernel::release(kernel::Domain::Tcp);
+            kernel::release(kernel::domain::tcp());
             -1
         }
     }
@@ -881,7 +995,7 @@ pub unsafe extern "C" fn nir_tcp_stop(handle: i64) -> i32 {
     // accept originally admitted it -- all three fold into this one
     // close path (this fn's own doc comment), so the acquire:release
     // ratio stays 1:1 either way.
-    kernel::release(kernel::Domain::Tcp);
+    kernel::release(kernel::domain::tcp());
     0
 }
 
@@ -941,7 +1055,7 @@ pub unsafe extern "C" fn nir_file_open(path_ptr: *const u8, path_len: i64, mode_
     let Ok(path) = std::str::from_utf8(path) else { return -1 };
     let mode = unsafe { std::slice::from_raw_parts(mode_ptr, mode_len as usize) };
     let Ok(mode) = std::str::from_utf8(mode) else { return -1 };
-    if !kernel::acquire(kernel::Domain::File) {
+    if !kernel::acquire(kernel::domain::file()) {
         return -1;
     }
     let opened = match mode {
@@ -949,14 +1063,14 @@ pub unsafe extern "C" fn nir_file_open(path_ptr: *const u8, path_len: i64, mode_
         "w" => std::fs::File::create(path),
         "a" => std::fs::OpenOptions::new().append(true).create(true).open(path),
         _ => {
-            kernel::release(kernel::Domain::File);
+            kernel::release(kernel::domain::file());
             return -1;
         }
     };
     match opened {
         Ok(file) => handle_of_file(file),
         Err(_) => {
-            kernel::release(kernel::Domain::File);
+            kernel::release(kernel::domain::file());
             -1
         }
     }
@@ -1002,7 +1116,7 @@ pub unsafe extern "C" fn nir_file_stop(handle: i64) -> i32 {
         use std::os::windows::io::{FromRawHandle, OwnedHandle, RawHandle};
         drop(unsafe { OwnedHandle::from_raw_handle(handle as RawHandle) });
     }
-    kernel::release(kernel::Domain::File);
+    kernel::release(kernel::domain::file());
     0
 }
 
@@ -1367,7 +1481,7 @@ pub extern "C" fn nir_thread_spawn(trampoline: extern "C" fn(*mut u8, *mut i64),
     // concurrently-outstanding `thread` handle held between `spawn` and
     // its matching `join`, the same ceiling `nir_tcp_connect`/
     // `nir_file_open` already enforce for their own domains.
-    if !kernel::acquire(kernel::Domain::Thread) {
+    if !kernel::acquire(kernel::domain::thread()) {
         unsafe {
             if !ctx.is_null() {
                 nir_free(ctx);
@@ -1423,7 +1537,7 @@ pub extern "C" fn nir_thread_spawn(trampoline: extern "C" fn(*mut u8, *mut i64),
         // inserted into `thread_table`, so `nir_thread_join` will never
         // run for it either).
         kernel::concurrency_thread_finished();
-        kernel::release(kernel::Domain::Thread);
+        kernel::release(kernel::domain::thread());
         unsafe {
             drop(Box::from_raw(result_ptr));
             if !ctx.is_null() {
@@ -1475,7 +1589,7 @@ pub extern "C" fn nir_thread_join(handle: i64) -> i64 {
     // that closes it — the same acquire-at-creation/release-at-close
     // pairing `nir_tcp_stop`/`nir_file_stop` already use for their own
     // domains.
-    kernel::release(kernel::Domain::Thread);
+    kernel::release(kernel::domain::thread());
     result
 }
 
@@ -2061,7 +2175,24 @@ pub unsafe extern "C" fn nir_db_connect(path_ptr: *const u8, path_len: i64, out_
         unsafe { write_str_out(out_err, "connection string is not valid UTF-8".to_string()) };
         return 0;
     };
-    if !kernel::acquire(kernel::Domain::Db) {
+    // RFC 0011 §2 step 1: which domain to `kernel::acquire` depends on
+    // whether `path`'s scheme is built-in -- decided *before* acquiring
+    // anything, so a plugin-routed connect never consumes the built-in
+    // `db` domain's ceiling (and vice versa).
+    if !kernel::db::is_builtin_scheme(path) {
+        return match kernel::plugin_provider::connect_conn_shape(path) {
+            Ok(conn) => {
+                let id = kernel::plugin_provider::plugin_conn_table().insert(conn);
+                unsafe { *out_handle = id };
+                1
+            }
+            Err(e) => {
+                unsafe { write_str_out(out_err, e) };
+                0
+            }
+        };
+    }
+    if !kernel::acquire(kernel::domain::db()) {
         unsafe { write_str_out(out_err, "too many open db connections".to_string()) };
         return 0;
     }
@@ -2072,7 +2203,7 @@ pub unsafe extern "C" fn nir_db_connect(path_ptr: *const u8, path_len: i64, out_
             1
         }
         Err(e) => {
-            kernel::release(kernel::Domain::Db);
+            kernel::release(kernel::domain::db());
             unsafe { write_str_out(out_err, e) };
             0
         }
@@ -2086,8 +2217,15 @@ pub unsafe extern "C" fn nir_db_connect(path_ptr: *const u8, path_len: i64, out_
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn nir_db_stop(handle: i64) -> i32 {
     if db_table().remove(handle).is_some() {
-        kernel::release(kernel::Domain::Db);
+        kernel::release(kernel::domain::db());
+        return 0;
     }
+    // RFC 0011 §2 step 2: core `db_table()` first, then `HandleTable<
+    // PluginConn>` on a miss -- `PluginConn`'s own `Drop` releases its
+    // provider's domain (the `Pooled` variant explicitly, the
+    // `Unpooled` variant via its own guard), so nothing else is needed
+    // here beyond removing it from the table and letting it drop.
+    kernel::plugin_provider::plugin_conn_table().remove(handle);
     0
 }
 
@@ -2128,10 +2266,35 @@ pub unsafe extern "C" fn nir_db_execute(
             unsafe { write_str_out(out_err, e) };
             0
         }
-        None => {
-            unsafe { write_str_out(out_err, "db handle is not open".to_string()) };
-            0
-        }
+        // RFC 0011 §2 step 2: a miss in `db_table()` falls through to
+        // `HandleTable<PluginConn>` before giving up -- "a miss in
+        // *both* is the same invalid-handle error every kernel boundary
+        // already returns," not a new error kind.
+        None => match kernel::plugin_provider::plugin_conn_table().with(handle, |conn| kernel::plugin_provider::op(conn, sql, binds_len > 0)) {
+            Some(Ok(affected_str)) => match affected_str.trim().parse::<i64>() {
+                Ok(n) => {
+                    unsafe { *out_affected = n };
+                    1
+                }
+                Err(_) => {
+                    unsafe {
+                        write_str_out(
+                            out_err,
+                            format!("plugin _op returned {affected_str:?} for db_execute, which is not a decimal affected-row count"),
+                        )
+                    };
+                    0
+                }
+            },
+            Some(Err(e)) => {
+                unsafe { write_str_out(out_err, e) };
+                0
+            }
+            None => {
+                unsafe { write_str_out(out_err, "db handle is not open".to_string()) };
+                0
+            }
+        },
     }
 }
 
@@ -2191,10 +2354,25 @@ pub unsafe extern "C" fn nir_db_query(
             unsafe { write_str_out(out_err, e) };
             0
         }
-        None => {
-            unsafe { write_str_out(out_err, "db handle is not open".to_string()) };
-            0
-        }
+        // RFC 0011 §2 step 2: same fallback priority as `nir_db_execute`
+        // above -- `_op`'s returned string is passed straight through as
+        // the JSON payload (this module's own doc comment: `Ty::Json` is
+        // already represented as raw text, so a plugin author's `_op`
+        // simply has to return well-formed JSON text by convention).
+        None => match kernel::plugin_provider::plugin_conn_table().with(handle, |conn| kernel::plugin_provider::op(conn, sql, binds_len > 0)) {
+            Some(Ok(json)) => {
+                unsafe { write_str_out(out_json, json) };
+                1
+            }
+            Some(Err(e)) => {
+                unsafe { write_str_out(out_err, e) };
+                0
+            }
+            None => {
+                unsafe { write_str_out(out_err, "db handle is not open".to_string()) };
+                0
+            }
+        },
     }
 }
 
@@ -2261,6 +2439,35 @@ mod db_kernel_tests {
             assert_eq!(updated, 1);
 
             assert_eq!(nir_db_stop(conn), 0);
+        }
+    }
+
+    /// Proves the `db` domain's admission ceiling is real, not
+    /// decorative — `nir_db_connect`/`nir_db_stop` already bracket every
+    /// connect-to-stop session with `kernel::acquire`/`release`
+    /// (confirmed pre-existing, not new to this phase; `kernel::db::connect`
+    /// itself never calls `acquire`, see that function's own doc comment).
+    /// `#[ignore]`d for the same reason `db.rs`'s own
+    /// `postgres_checkout_rehydrates_a_connection_killed_out_from_under_the_pool`
+    /// is: `NIRDOSHA_KERNEL_MAX_DB`'s ceiling is resolved once and cached
+    /// process-wide (`kernel::mod.rs`'s `max_for`), so lowering it here
+    /// would corrupt every other concurrently-running test in this binary
+    /// that also opens a `db` connection — safe only run alone
+    /// (`cargo test -- --ignored connect_past_the_db_ceiling...`).
+    #[test]
+    #[ignore]
+    fn connect_past_the_db_ceiling_is_denied_fast_not_blocked() {
+        unsafe { std::env::set_var("NIRDOSHA_KERNEL_MAX_DB", "2") };
+        unsafe {
+            let a = connect(":memory:").expect("first connect under the ceiling must succeed");
+            let b = connect(":memory:").expect("second connect under the ceiling must succeed");
+            let denied = connect(":memory:");
+            assert!(denied.is_err(), "third connect past a ceiling of 2 must be denied, not blocked");
+            assert_eq!(denied.unwrap_err(), "too many open db connections");
+            nir_db_stop(a);
+            nir_db_stop(b);
+            let c = connect(":memory:").expect("connect after release must succeed again");
+            nir_db_stop(c);
         }
     }
 
@@ -2488,6 +2695,29 @@ pub unsafe extern "C" fn nir_json_get_str(doc_ptr: *const u8, doc_len: i64, key_
         }
         None => {
             unsafe { write_str_out(out_err, format!("key `{key}` not found, or not a string")) };
+            0
+        }
+    }
+}
+
+/// `env(name) -> Result(str, str)` (RFC 0011 §1) — `Ok(value)` when the
+/// process environment variable is set, `Err(_)` when unset or not valid
+/// Unicode. Not resource-gated: no `kernel::acquire`/`Domain` involved,
+/// unlike `nir_db_connect` above — reading process environment state
+/// isn't a pooled/ceiling-bound resource.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_env_get(name_ptr: *const u8, name_len: i64, out_value: *mut NirStrOut, out_err: *mut NirStrOut) -> i32 {
+    let Some(name) = (unsafe { str_from_raw(name_ptr, name_len) }) else {
+        unsafe { write_str_out(out_err, "variable name is not valid UTF-8".to_string()) };
+        return 0;
+    };
+    match std::env::var(name) {
+        Ok(value) => {
+            unsafe { write_str_out(out_value, value) };
+            1
+        }
+        Err(e) => {
+            unsafe { write_str_out(out_err, format!("{name}: {e}")) };
             0
         }
     }
@@ -2825,7 +3055,7 @@ pub unsafe extern "C" fn nir_mq_connect(host_ptr: *const u8, host_len: i64, port
         unsafe { write_str_out(out_err, "host is not valid UTF-8".to_string()) };
         return 0;
     };
-    if !kernel::acquire(kernel::Domain::Mq) {
+    if !kernel::acquire(kernel::domain::mq()) {
         unsafe { write_str_out(out_err, "too many open mq connections".to_string()) };
         return 0;
     }
@@ -2838,7 +3068,7 @@ pub unsafe extern "C" fn nir_mq_connect(host_ptr: *const u8, host_len: i64, port
             1
         }
         Err(e) => {
-            kernel::release(kernel::Domain::Mq);
+            kernel::release(kernel::domain::mq());
             unsafe { write_str_out(out_err, e.to_string()) };
             0
         }
@@ -2850,7 +3080,7 @@ pub unsafe extern "C" fn nir_mq_connect(host_ptr: *const u8, host_len: i64, port
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn nir_mq_stop(handle: i64) -> i32 {
     if mq_table().remove(handle).is_some() {
-        kernel::release(kernel::Domain::Mq);
+        kernel::release(kernel::domain::mq());
     }
     0
 }
@@ -2973,7 +3203,7 @@ mod mq_kernel_tests {
 // ---- http/https kernels (`http_get`/`http_post`/`https_get`/`https_post`) --
 //
 // Real, pooled HTTP/1.1 keep-alive connections plus real admission
-// control (`Domain::Http`) — `kernel::http` has the full design and the
+// control (`domain::http()`) — `kernel::http` has the full design and the
 // protocol rewrite this required (real `Content-Length`/chunked framing,
 // replacing the original connection-per-call `Connection: close` +
 // read-to-EOF cut, which was correct for its own scope but structurally
@@ -3099,6 +3329,81 @@ pub unsafe extern "C" fn nir_https_post(
     };
     let result = do_https(host, port, path, "POST", Some(body));
     unsafe { write_http_result(result, out_status, out_body, out_err) }
+}
+
+/// `rest` is everything after `scheme://` -- `host` or `host:port`,
+/// optionally followed by a path/query this function ignores (`call_via`
+/// takes `path` as its own separate argument, matching `http_get`/
+/// `http_post`'s existing `(host, port, path)` split rather than a
+/// single combined URL).
+fn split_host_port(rest: &str, default_port: i64) -> (&str, i64) {
+    let host_part = rest.split(['/', '?']).next().unwrap_or(rest);
+    match host_part.rsplit_once(':') {
+        Some((host, port_str)) => match port_str.parse::<i64>() {
+            Ok(port) => (host, port),
+            Err(_) => (host_part, default_port),
+        },
+        None => (host_part, default_port),
+    }
+}
+
+/// `call_via(url, path, body) -> Result(HttpResponse, str)` —
+/// rfcs/0011-uniform-service-provider-model.md §1/§2's `call`-shape
+/// dispatch entrypoint. `url`'s scheme decides everything: `http://`/
+/// `https://` are served by the exact same pooled, admission-controlled
+/// core path `http_post`/`https_post` already use (this function is a
+/// thin scheme-sniff in front of `do_http`/`do_https`, not a second
+/// implementation of either); anything else falls through to
+/// `kernel::plugin_provider::call_via`.
+///
+/// **Plugin-routed status code, disclosed rather than left implicit**:
+/// RFC 0011 §2 pins `_request`'s ABI as a single `str` return with no
+/// separate status code — a plugin has no way to hand back a numeric
+/// status at all. A successful plugin-routed call therefore always
+/// reports `status: 200`; a plugin wanting to signal a non-2xx-shaped
+/// outcome has to encode that in its own returned body text (or fail
+/// the call outright, which surfaces as `Err`, not a status code).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nir_call_via(
+    url_ptr: *const u8,
+    url_len: i64,
+    path_ptr: *const u8,
+    path_len: i64,
+    body_ptr: *const u8,
+    body_len: i64,
+    out_status: *mut i64,
+    out_body: *mut NirStrOut,
+    out_err: *mut NirStrOut,
+) -> i32 {
+    let (Some(url), Some(path), Some(body)) =
+        (unsafe { str_from_raw(url_ptr, url_len) }, unsafe { str_from_raw(path_ptr, path_len) }, unsafe { str_from_raw(body_ptr, body_len) })
+    else {
+        unsafe { write_str_out(out_err, "url/path/body is not valid UTF-8".to_string()) };
+        return 0;
+    };
+    if let Some(rest) = url.strip_prefix("http://") {
+        let (host, port) = split_host_port(rest, 80);
+        let result = do_http(host, port, path, "POST", Some(body));
+        return unsafe { write_http_result(result, out_status, out_body, out_err) };
+    }
+    if let Some(rest) = url.strip_prefix("https://") {
+        let (host, port) = split_host_port(rest, 443);
+        let result = do_https(host, port, path, "POST", Some(body));
+        return unsafe { write_http_result(result, out_status, out_body, out_err) };
+    }
+    match kernel::plugin_provider::call_via(url, path, body) {
+        Ok(response_body) => {
+            unsafe {
+                *out_status = 200;
+                write_str_out(out_body, response_body);
+            }
+            1
+        }
+        Err(e) => {
+            unsafe { write_str_out(out_err, e) };
+            0
+        }
+    }
 }
 
 #[cfg(test)]

--- a/examples/features/57_nirdosha_ops_console_server_v2.nir
+++ b/examples/features/57_nirdosha_ops_console_server_v2.nir
@@ -1,0 +1,954 @@
+// Feature: strengthens the browser-clickable Nirdosha Ops Console
+// (`56_nirdosha_ops_console_server.nir`) along four real axes:
+//
+//   1. **Real signed authentication.** `POST /api/login` returns a real
+//      HMAC-SHA256 JWT (`mock_issue_token`, finished alongside this file
+//      -- it was already fully declared in the grammar/typeck/ownership
+//      layers as leftover scaffolding from the deleted interpreter, with
+//      zero codegen until now), verified server-side on every gated
+//      route via the already-real `oidc_validate_token`. The forgeable
+//      `X-Demo-Role` header is gone -- every admin action here is
+//      guarded by a real signature check against a real (if hardcoded,
+//      demo-only) JWKS.
+//   2. **The `Disbursement` workflow wired to a real browser button.**
+//      `55_nirdosha_ops_console.nir`'s workflow-gated, `transact`-backed
+//      disbursement (RBAC + a real webhook call + a real durable
+//      Postgres write) was previously only ever exercised by a test
+//      harness. `POST /api/purchase_orders/approve` really starts and
+//      advances a real workflow instance from the browser.
+//   3. **Broader CRUD.** Real `UPDATE`/`DELETE` via `db_execute` -- both
+//      already exercised elsewhere in this compiler's own test suite;
+//      neither route needed anything new from the compiler.
+//   4. **Search + real pagination, without a string-to-int parser.** No
+//      `str_to_i64`/`parse_i64` builtin exists in this language today,
+//      so `POST /api/purchase_orders/list` (additive alongside the
+//      plain `GET` one) takes an optional `{q, offset, limit}` JSON
+//      body instead of query-string parameters -- every integer here
+//      always arrives as a real JSON number, the same convention
+//      `POST /api/create` already established in `56_...`.
+//
+// **Deliberately not attempted here, disclosed rather than silently
+// deferred**: `crates/compiled-serve` (ROADMAP B8's real Rust HTTP
+// engine) is still not wired into `codegen.rs` -- this file stays on
+// the same primitives-based `tcp_listener`/`accept` style
+// `51_compiled_serve.nir`/`56_...` already use. Wiring `compiled-serve`
+// in for real needs, at minimum: a `#[repr(C)]` route table (its `Route`
+// struct isn't one today), a generic arbitrary-`Ty`-to-JSON result
+// encoder codegen doesn't have (the one existing precedent,
+// `emit_transact_replay_trampoline`, only ever decodes JSON *into* typed
+// args, never encodes a return value back out), and a brand-new compiled
+// entrypoint `compiled-serve` could call into. That's real, separate,
+// dedicated follow-up work -- not something to bolt on opportunistically
+// next to this file.
+//
+// Run it:
+//   nirdosha build examples/features/57_nirdosha_ops_console_server_v2.nir -o /tmp/ops_console_v2
+//   /tmp/ops_console_v2 &
+//   open http://127.0.0.1:8091/
+//
+// **Demo-only shortcut, disclosed, not hidden**: `mock_issue_token`
+// signs against a single hardcoded HMAC secret this file's own
+// `demo_jwks()` literally contains (`kid: "demo-key"`) -- a real
+// deployment's signing key never lives in the binary's own source this
+// way. `issued_at` is a fixed constant, not a real wall-clock read (no
+// `now()` builtin exists in this language), so every issued token
+// carries the same `iat` -- fine for a demo, not for production.
+
+struct Text {
+    value: str,
+}
+
+struct ErrMsg {
+    value: str,
+}
+
+// ---- demo identity provider (real HS256 signing + verification,
+// against one shared hardcoded key) ---------------------------------------
+
+fn demo_jwks() -> Text {
+    return Text("{\"keys\":[{\"kid\":\"demo-key\",\"kty\":\"oct\",\"k\":\"bXktc2VjcmV0LWtleQ\"}]}")
+}
+
+fn demo_issuer() -> Text {
+    return Text("https://mock-idp.local")
+}
+
+fn demo_audience() -> Text {
+    return Text("ops-console")
+}
+
+fn role_subject(role: Text) -> Text {
+    if role.value == "admin" {
+        return Text("cfo-1")
+    }
+    return Text("clerk-1")
+}
+
+fn role_claims_json(role: Text) -> Text {
+    if role.value == "admin" {
+        return Text("{\"roles\":[\"admin\"]}")
+    }
+    return Text("{\"roles\":[\"finance\"]}")
+}
+
+// `admin_identity`'s real, compiled `VerifiedIdentity` -- used only to
+// drive the `acquire`d `Disbursement` workflow transition below (Layer
+// 1's own `advance_<workflow>` signature takes a `VerifiedIdentity`
+// directly, not a bearer token), never returned to a browser. The
+// browser's own admin authority comes from the real bearer-token check
+// in `authorized_identity` below.
+fn admin_identity() -> VerifiedIdentity {
+    return VerifiedIdentity("cfo-1", "https://mock-idp.local", "ops-console", 9999999999, 0, "{\"roles\":[\"admin\"]}")
+}
+
+// `codegen.rs::declare_named_type`'s own doc comment has the full story
+// (`wrap_ok_identity`'s doc comment just above cites it too) -- these two
+// route around the exact same bare-`Ok(...)`/`Err(...)`-as-match-arm-body
+// panic for `Result(Text, ErrMsg)`.
+fn wrap_ok_text(t: Text) -> Result(Text, ErrMsg) {
+    return Ok(t)
+}
+
+fn wrap_err_text(e: ErrMsg) -> Result(Text, ErrMsg) {
+    return Err(e)
+}
+
+// `issued_at`/`ttl_secs` are fixed constants -- see this file's own
+// header note on why (no `now()` builtin).
+fn issue_demo_token(role: Text) -> Result(Text, ErrMsg) {
+    let issuer: Text = demo_issuer()
+    let audience: Text = demo_audience()
+    let jwks: Text = demo_jwks()
+    let subject: Text = role_subject(role)
+    let claims: Text = role_claims_json(role)
+    return match mock_issue_token(subject.value, issuer.value, audience.value, 1700000000, 315360000, claims.value, jwks.value) {
+        Err(e) => wrap_err_text(ErrMsg(e)),
+        Ok(t) => wrap_ok_text(Text(t)),
+    }
+}
+
+// ---- bearer-token extraction (same `str_index_of`/`str_slice`/`len`
+// primitives `req_method`/`req_path`/`req_body` below already use) -------
+
+fn req_bearer_token(req: Text) -> Text {
+    let r: str = req.value
+    let marker: str = "Authorization: Bearer "
+    let start: i64 = str_index_of(r, marker)
+    if start < 0 {
+        return Text("")
+    }
+    let after_marker: str = str_slice(r, start + len(marker), len(r))
+    let line_end: i64 = str_index_of(after_marker, "\r\n")
+    if line_end < 0 {
+        return Text(after_marker)
+    }
+    return Text(str_slice(after_marker, 0, line_end))
+}
+
+// Real verification, not an echo: a missing/malformed/wrong-audience/
+// tampered bearer token is a real `Err`, and every gated route below
+// refuses to proceed past it.
+// `codegen.rs::declare_named_type`'s own doc comment (also cited in
+// `55_nirdosha_ops_console.nir`'s header) has the full story: `match ...
+// { Ok(x) => Ok(x), ... }` -- re-wrapping a `Result` via a bare
+// `Ok(...)`/`Err(...)` as a match arm's own tail expression -- hits a
+// real, pre-existing compiler panic. These two named helpers exist
+// specifically to route around it, same disclosed workaround `55_...`
+// already uses for `wrap_ok_json`/`wrap_err_json`.
+fn wrap_ok_identity(identity: VerifiedIdentity) -> Result(VerifiedIdentity, ErrMsg) {
+    return Ok(identity)
+}
+
+fn wrap_err_identity(e: ErrMsg) -> Result(VerifiedIdentity, ErrMsg) {
+    return Err(e)
+}
+
+fn authorized_identity(req: Text) -> Result(VerifiedIdentity, ErrMsg) {
+    let token: Text = req_bearer_token(req)
+    if len(token.value) == 0 {
+        return wrap_err_identity(ErrMsg("missing Authorization: Bearer token"))
+    }
+    let issuer: Text = demo_issuer()
+    let audience: Text = demo_audience()
+    let jwks: Text = demo_jwks()
+    return match oidc_validate_token(token.value, issuer.value, audience.value, jwks.value) {
+        Err(e) => wrap_err_identity(ErrMsg(e)),
+        Ok(identity) => wrap_ok_identity(identity),
+    }
+}
+
+// ---- Postgres-backed CRUD (same shape as `56_...`, extended with
+// UPDATE/DELETE/search+pagination) ----------------------------------------
+
+fn create_purchase_order(vendor: Text, amount_cents: i64) -> Text requires(role: "admin") {
+    return match db_connect("postgres://postgres@127.0.0.1:5432/postgres") {
+        Err(e) => Text(e),
+        Ok(conn) => run_create(conn, vendor, amount_cents),
+    }
+}
+
+fn run_create(conn: db, vendor: Text, amount_cents: i64) -> Text {
+    let schema_ok: i64 = match db_execute(conn, "CREATE TABLE IF NOT EXISTS purchase_orders (id SERIAL PRIMARY KEY, vendor TEXT NOT NULL, amount_cents BIGINT NOT NULL)") {
+        Ok(n) => n,
+        Err(e) => -1,
+    }
+    let inserted: i64 = match db_execute(conn, "INSERT INTO purchase_orders (vendor, amount_cents) VALUES (?, ?)", vendor.value, amount_cents) {
+        Ok(n) => n,
+        Err(e) => -1,
+    }
+    stop conn
+    return Text(vendor.value)
+}
+
+fn update_purchase_order(id: i64, vendor: Text, amount_cents: i64) -> Text requires(role: "admin") {
+    return match db_connect("postgres://postgres@127.0.0.1:5432/postgres") {
+        Err(e) => Text(e),
+        Ok(conn) => run_update(conn, id, vendor, amount_cents),
+    }
+}
+
+fn run_update(conn: db, id: i64, vendor: Text, amount_cents: i64) -> Text {
+    let updated: i64 = match db_execute(conn, "UPDATE purchase_orders SET vendor = ?, amount_cents = ? WHERE id = ?", vendor.value, amount_cents, id) {
+        Ok(n) => n,
+        Err(e) => -1,
+    }
+    stop conn
+    if updated <= 0 {
+        return Text("not found")
+    }
+    return Text(vendor.value)
+}
+
+fn delete_purchase_order(id: i64) -> bool requires(role: "admin") {
+    return match db_connect("postgres://postgres@127.0.0.1:5432/postgres") {
+        Err(e) => false,
+        Ok(conn) => run_delete(conn, id),
+    }
+}
+
+fn run_delete(conn: db, id: i64) -> bool {
+    let deleted: i64 = match db_execute(conn, "DELETE FROM purchase_orders WHERE id = ?", id) {
+        Ok(n) => n,
+        Err(e) => -1,
+    }
+    stop conn
+    return deleted > 0
+}
+
+fn wrap_ok_json(j: json) -> Result(json, ErrMsg) {
+    return Ok(j)
+}
+
+fn wrap_err_json(e: ErrMsg) -> Result(json, ErrMsg) {
+    return Err(e)
+}
+
+// Real `LIKE`-based search + real `LIMIT`/`OFFSET` pagination, all
+// server-side SQL -- `q`/`offset`/`limit` arrive as real JSON values
+// from the request body, never parsed out of a URL.
+fn search_purchase_orders(q: Text, offset: i64, limit: i64) -> Result(json, ErrMsg) {
+    return match db_connect("postgres://postgres@127.0.0.1:5432/postgres") {
+        Err(e) => wrap_err_json(ErrMsg(e)),
+        Ok(conn) => run_search(conn, q, offset, limit),
+    }
+}
+
+fn run_search(conn: db, q: Text, offset: i64, limit: i64) -> Result(json, ErrMsg) {
+    let schema_ok: i64 = match db_execute(conn, "CREATE TABLE IF NOT EXISTS purchase_orders (id SERIAL PRIMARY KEY, vendor TEXT NOT NULL, amount_cents BIGINT NOT NULL)") {
+        Ok(n) => n,
+        Err(e) => -1,
+    }
+    // This language has no string-concatenation builtin at all (this
+    // file's own header note on `56_...`'s `send(tcp, json)` extension
+    // already disclosed why) -- so the `%query%` pattern is built in SQL
+    // itself, via Postgres's own `||` concatenation, not in `.nir` code.
+    // An empty `q` naturally becomes `'%' || '' || '%'` = `%%`, which
+    // `LIKE` treats identically to a bare `%` (matches every row) -- no
+    // special-casing needed for the "no search" case either.
+    let result: Result(json, ErrMsg) = match db_query(conn, "SELECT id, vendor, amount_cents FROM purchase_orders WHERE vendor LIKE '%' || ? || '%' ORDER BY id DESC LIMIT ? OFFSET ?", q.value, limit, offset) {
+        Ok(rows) => wrap_ok_json(rows),
+        Err(e) => wrap_err_json(ErrMsg(e)),
+    }
+    stop conn
+    return result
+}
+
+fn list_purchase_order() -> Result(json, ErrMsg) {
+    return search_purchase_orders(Text(""), 0, 25)
+}
+
+fn stat_purchase_order_count() -> Result(json, ErrMsg) {
+    return match db_connect("postgres://postgres@127.0.0.1:5432/postgres") {
+        Err(e) => wrap_err_json(ErrMsg(e)),
+        Ok(conn) => run_count(conn),
+    }
+}
+
+fn run_count(conn: db) -> Result(json, ErrMsg) {
+    let schema_ok: i64 = match db_execute(conn, "CREATE TABLE IF NOT EXISTS purchase_orders (id SERIAL PRIMARY KEY, vendor TEXT NOT NULL, amount_cents BIGINT NOT NULL)") {
+        Ok(n) => n,
+        Err(e) => -1,
+    }
+    let result: Result(json, ErrMsg) = match db_query(conn, "SELECT COUNT(*) AS n FROM purchase_orders") {
+        Ok(rows) => match json_array_get(rows, 0) {
+            Ok(row) => wrap_ok_json(row),
+            Err(e) => wrap_err_json(ErrMsg(e)),
+        },
+        Err(e) => wrap_err_json(ErrMsg(e)),
+    }
+    stop conn
+    return result
+}
+
+// ---- workflow-gated, `transact`-backed disbursement (real `http_post`
+// to a local mock webhook + real durable Postgres write, copied from
+// `55_nirdosha_ops_console.nir` -- each numbered example file in this
+// catalog is self-contained, no cross-file `.nir` imports exist) --------
+
+fn notify_webhook(txn_id: str, amount_cents: i64) -> i64 {
+    return match http_post("127.0.0.1", 18101, "/webhook", "payment") {
+        Ok(resp) => resp.status,
+        Err(e) => -1,
+    }
+}
+
+fn check_response(status: i64) -> bool {
+    return status == 200
+}
+
+fn wrap_ok_i64(n: i64) -> Result(i64, ErrMsg) {
+    return Ok(n)
+}
+
+fn wrap_err_i64(e: ErrMsg) -> Result(i64, ErrMsg) {
+    return Err(e)
+}
+
+fn record_disbursement(txn_id: str, po_id: i64, amount_cents: i64) -> Result(i64, ErrMsg) {
+    return match db_connect("postgres://postgres@127.0.0.1:5432/postgres") {
+        Err(e) => wrap_err_i64(ErrMsg(e)),
+        Ok(conn) => run_record_disbursement(conn, txn_id, po_id, amount_cents),
+    }
+}
+
+fn run_record_disbursement(conn: db, txn_id: str, po_id: i64, amount_cents: i64) -> Result(i64, ErrMsg) {
+    let schema_ok: i64 = match db_execute(conn, "CREATE TABLE IF NOT EXISTS disbursements (txn_id TEXT PRIMARY KEY, po_id BIGINT NOT NULL, amount_cents BIGINT NOT NULL)") {
+        Ok(n) => n,
+        Err(e) => -1,
+    }
+    let result: Result(i64, ErrMsg) = match db_execute(conn, "INSERT INTO disbursements (txn_id, po_id, amount_cents) VALUES (?, ?, ?) ON CONFLICT (txn_id) DO NOTHING", txn_id, po_id, amount_cents) {
+        Ok(n) => wrap_ok_i64(n),
+        Err(e) => wrap_err_i64(ErrMsg(e)),
+    }
+    stop conn
+    return result
+}
+
+fn log_disbursement_failure(txn_id: str, po_id: i64) -> unit {
+    print("disbursement failed", txn_id, po_id)
+}
+
+// Layer 1's only implicit `on_entry` binding is `instance_id` (no
+// non-empty `data{}` block support), so -- same disclosed limitation
+// `55_...` already has -- the disbursed amount is fixed, not read back
+// from the purchase order that triggered it, and the workflow's own
+// `instance_id` doubles as the disbursement record's `po_id`, not the
+// browser's own purchase-order row id.
+fn disburse(instance_id: i64, amount_cents: i64) -> bool {
+    return transact {
+        network:    notify_webhook(txn_id, amount_cents)
+        verify:     check_response(network)
+        commit:     record_disbursement(txn_id, instance_id, amount_cents)
+        compensate: log_disbursement_failure(txn_id, instance_id)
+    }
+}
+
+fn disburse_on_approval(instance_id: i64) -> unit {
+    let ok: bool = disburse(instance_id, 250000)
+    print("disbursement", instance_id, ok)
+}
+
+workflow Disbursement {
+    state Draft {
+        on Approve -> Approved
+    }
+    state Approved terminal {
+        on_entry {
+            disburse_on_approval(instance_id)
+        }
+    }
+}
+
+fn advance_disbursement_now(identity: VerifiedIdentity, instance_id: i64, event: DisbursementEvent) -> Result(bool, WorkflowActionError) {
+    return match json_parse("{}") {
+        Ok(payload) => advance_disbursement(identity, instance_id, event, payload),
+        Err(e) => Err(NoSuchTransition()),
+    }
+}
+
+fn run_approval() -> Text {
+    let instance_id: i64 = match start_disbursement(None(), DisbursementData()) {
+        Ok(id) => id,
+        Err(e) => -1,
+    }
+    if instance_id < 0 {
+        return Text("failed to start disbursement workflow")
+    }
+    let approved: bool = match advance_disbursement_now(admin_identity(), instance_id, Approve()) {
+        Err(e) => false,
+        Ok(v) => v,
+    }
+    if approved {
+        return Text("approved")
+    }
+    return Text("approval failed")
+}
+
+fn approve_purchase_order() -> Text requires(role: "admin") {
+    return run_approval()
+}
+
+// ---- gated-route helpers: real bearer-token check, then real
+// `acquire`/`check_role`, exactly `56_...`'s own `create_as_admin`
+// pattern, one level deeper (auth, then role) -----------------------------
+
+fn create_as_admin(req: Text, vendor: Text, amount_cents: i64) -> Text {
+    return match authorized_identity(req) {
+        Err(e) => Text(e.value),
+        Ok(identity) => match check_role(identity, "admin") {
+            Err(e) => Text(e),
+            Ok(proof) => match acquire create_purchase_order(proof) {
+                Err(msg) => Text(msg),
+                Ok(f) => f(vendor, amount_cents),
+            },
+        },
+    }
+}
+
+fn update_as_admin(req: Text, id: i64, vendor: Text, amount_cents: i64) -> Text {
+    return match authorized_identity(req) {
+        Err(e) => Text(e.value),
+        Ok(identity) => match check_role(identity, "admin") {
+            Err(e) => Text(e),
+            Ok(proof) => match acquire update_purchase_order(proof) {
+                Err(msg) => Text(msg),
+                Ok(f) => f(id, vendor, amount_cents),
+            },
+        },
+    }
+}
+
+fn delete_as_admin(req: Text, id: i64) -> bool {
+    return match authorized_identity(req) {
+        Err(e) => false,
+        Ok(identity) => match check_role(identity, "admin") {
+            Err(e) => false,
+            Ok(proof) => match acquire delete_purchase_order(proof) {
+                Err(msg) => false,
+                Ok(f) => f(id),
+            },
+        },
+    }
+}
+
+fn approve_as_admin(req: Text) -> Text {
+    return match authorized_identity(req) {
+        Err(e) => Text(e.value),
+        Ok(identity) => match check_role(identity, "admin") {
+            Err(e) => Text(e),
+            Ok(proof) => match acquire approve_purchase_order(proof) {
+                Err(msg) => Text(msg),
+                Ok(f) => f(),
+            },
+        },
+    }
+}
+
+// ---- request parsing (same primitives `51_compiled_serve.nir` already
+// proves) ------------------------------------------------------------------
+
+fn req_method(req: Text) -> Text {
+    let r: str = req.value
+    let line_end: i64 = str_index_of(r, "\r\n")
+    let line: str = str_slice(r, 0, line_end)
+    let sp1: i64 = str_index_of(line, " ")
+    return Text(str_slice(line, 0, sp1))
+}
+
+fn req_path(req: Text) -> Text {
+    let r: str = req.value
+    let line_end: i64 = str_index_of(r, "\r\n")
+    let line: str = str_slice(r, 0, line_end)
+    let sp1: i64 = str_index_of(line, " ")
+    let after_method: str = str_slice(line, sp1 + 1, len(line))
+    let sp2: i64 = str_index_of(after_method, " ")
+    return Text(str_slice(after_method, 0, sp2))
+}
+
+fn req_body(req: Text) -> Text {
+    let r: str = req.value
+    let sep: i64 = str_index_of(r, "\r\n\r\n")
+    if sep < 0 {
+        return Text("")
+    }
+    return Text(str_slice(r, sep + 4, len(r)))
+}
+
+// ---- JSON body -> typed-argument helpers (all via already-proven
+// `json_parse`/`json_get_str`/`json_get_i64`) ------------------------------
+
+fn body_role(req: Text) -> Text {
+    let body: Text = req_body(req)
+    return match json_parse(body.value) {
+        Err(e) => Text("finance"),
+        Ok(doc) => match json_get_str(doc, "role") {
+            Err(e) => Text("finance"),
+            Ok(v) => Text(v),
+        },
+    }
+}
+
+fn body_id(req: Text) -> i64 {
+    let body: Text = req_body(req)
+    return match json_parse(body.value) {
+        Err(e) => -1,
+        Ok(doc) => match json_get_i64(doc, "id") {
+            Err(e) => -1,
+            Ok(v) => v,
+        },
+    }
+}
+
+fn body_vendor(req: Text) -> Text {
+    let body: Text = req_body(req)
+    return match json_parse(body.value) {
+        Err(e) => Text("unknown vendor"),
+        Ok(doc) => match json_get_str(doc, "vendor") {
+            Err(e) => Text("unknown vendor"),
+            Ok(v) => Text(v),
+        },
+    }
+}
+
+fn body_amount_cents(req: Text) -> i64 {
+    let body: Text = req_body(req)
+    return match json_parse(body.value) {
+        Err(e) => 0,
+        Ok(doc) => match json_get_i64(doc, "amount_cents") {
+            Err(e) => 0,
+            Ok(v) => v,
+        },
+    }
+}
+
+fn body_search_q(req: Text) -> Text {
+    let body: Text = req_body(req)
+    return match json_parse(body.value) {
+        Err(e) => Text(""),
+        Ok(doc) => match json_get_str(doc, "q") {
+            Err(e) => Text(""),
+            Ok(v) => Text(v),
+        },
+    }
+}
+
+fn body_offset(req: Text) -> i64 {
+    let body: Text = req_body(req)
+    return match json_parse(body.value) {
+        Err(e) => 0,
+        Ok(doc) => match json_get_i64(doc, "offset") {
+            Err(e) => 0,
+            Ok(v) => v,
+        },
+    }
+}
+
+fn body_limit(req: Text) -> i64 {
+    let body: Text = req_body(req)
+    return match json_parse(body.value) {
+        Err(e) => 25,
+        Ok(doc) => match json_get_i64(doc, "limit") {
+            Err(e) => 25,
+            Ok(v) => v,
+        },
+    }
+}
+
+// ---- response bodies (all real JSON, via already-proven `json_set_str`) -
+
+fn empty_json_array() -> json {
+    return match json_parse("[]") {
+        Err(e) => empty_json_object(),
+        Ok(j) => j,
+    }
+}
+
+fn empty_json_object() -> json {
+    return match json_parse("{}") {
+        Err(e) => empty_json_object(),
+        Ok(j) => j,
+    }
+}
+
+fn value_json(value: Text) -> json {
+    return match json_set_str(empty_json_object(), "value", value.value) {
+        Err(e) => empty_json_object(),
+        Ok(j) => j,
+    }
+}
+
+fn err_json(message: Text) -> json {
+    return match json_set_str(empty_json_object(), "err", message.value) {
+        Err(e) => empty_json_object(),
+        Ok(j) => j,
+    }
+}
+
+fn ok_flag_json(ok: bool) -> json {
+    if ok {
+        return value_json(Text("true"))
+    }
+    return err_json(Text("operation failed"))
+}
+
+fn login_response_body(req: Text) -> json {
+    return match issue_demo_token(body_role(req)) {
+        Err(e) => err_json(Text(e.value)),
+        Ok(token) => value_json(token),
+    }
+}
+
+fn list_response_body(req: Text) -> json {
+    return match search_purchase_orders(body_search_q(req), body_offset(req), body_limit(req)) {
+        Err(e) => empty_json_array(),
+        Ok(rows) => rows,
+    }
+}
+
+fn plain_list_response_body() -> json {
+    return match list_purchase_order() {
+        Err(e) => empty_json_array(),
+        Ok(rows) => rows,
+    }
+}
+
+fn count_response_body() -> json {
+    return match stat_purchase_order_count() {
+        Err(e) => empty_json_object(),
+        Ok(row) => row,
+    }
+}
+
+fn create_response_body(req: Text) -> json {
+    let created: Text = create_as_admin(req, body_vendor(req), body_amount_cents(req))
+    return value_json(created)
+}
+
+fn update_response_body(req: Text) -> json {
+    let updated: Text = update_as_admin(req, body_id(req), body_vendor(req), body_amount_cents(req))
+    return value_json(updated)
+}
+
+fn delete_response_body(req: Text) -> json {
+    return ok_flag_json(delete_as_admin(req, body_id(req)))
+}
+
+fn approve_response_body(req: Text) -> json {
+    let approved: Text = approve_as_admin(req)
+    return value_json(approved)
+}
+
+// ---- HTML/CSS/JS page, one real static response body --------------------
+// No `\"` inside -- every HTML attribute and every JS string below uses
+// single quotes on purpose (`56_...`'s own note on this language's
+// minimal string-literal escape set applies unchanged).
+
+fn index_html() -> Text {
+    return Text("<!doctype html>
+<html>
+<head>
+<meta charset='utf-8'>
+<title>Nirdosha Ops Console v2</title>
+<style>
+  body { font-family: -apple-system, sans-serif; margin: 2rem auto; max-width: 780px; background: #f4f5f7; color: #1a1a1a; }
+  h1 { font-size: 1.4rem; }
+  .card { background: white; border-radius: 10px; padding: 1.5rem; margin-bottom: 1rem; box-shadow: 0 1px 3px rgba(0,0,0,0.12); }
+  button { padding: 0.5rem 1rem; margin-right: 0.5rem; border-radius: 6px; border: none; cursor: pointer; font-size: 0.9rem; }
+  .role-admin { background: #2563eb; color: white; }
+  .role-finance { background: #16a34a; color: white; }
+  .role-signout { background: #e5e7eb; color: #111; }
+  .role-danger { background: #dc2626; color: white; }
+  .role-neutral { background: #eef2ff; color: #3730a3; }
+  table { width: 100%; border-collapse: collapse; margin-top: 0.75rem; }
+  td, th { padding: 0.5rem 0.3rem; border-bottom: 1px solid #eee; text-align: left; }
+  input { padding: 0.45rem; margin-right: 0.5rem; border: 1px solid #ccc; border-radius: 6px; }
+  .badge { display: inline-block; padding: 0.2rem 0.6rem; border-radius: 999px; font-size: 0.8rem; background: #eef2ff; color: #3730a3; }
+  #create-status, #search-status { color: #555; font-size: 0.9rem; }
+  #error-banner { display: none; background: #fef2f2; color: #991b1b; border: 1px solid #fecaca; border-radius: 8px; padding: 0.75rem 1rem; margin-bottom: 1rem; }
+  #loading { display: none; color: #555; font-size: 0.9rem; margin-top: 0.5rem; }
+  #empty-state { display: none; color: #777; padding: 1rem 0; }
+  .row-actions button { padding: 0.3rem 0.6rem; font-size: 0.8rem; }
+</style>
+</head>
+<body>
+<h1>Nirdosha Ops Console v2</h1>
+<p style='color:#555'>Real compiled Nirdosha binary. Real Postgres. Real signed JWTs. Real RBAC. Real workflow + webhook + durable disbursement -- no mock server behind this page.</p>
+
+<div id='error-banner'></div>
+
+<div class='card' id='login-card'>
+  <p>Sign in as:</p>
+  <button class='role-admin' id='admin-btn'>Admin (CFO)</button>
+  <button class='role-finance' id='finance-btn'>Finance Clerk</button>
+</div>
+
+<div class='card' id='app-card' style='display:none'>
+  <p>Signed in as <b id='who'></b> with a real signed JWT &mdash; a real <code>landing</code> rule (RFC 0010) would send this role to <span class='badge' id='landing-target'></span></p>
+  <button class='role-signout' id='signout-btn'>Sign out</button>
+</div>
+
+<div class='card' id='po-card' style='display:none'>
+  <h2>Purchase Orders</h2>
+  <div>
+    <input id='search-input' placeholder='Search vendor...'>
+    <button class='role-neutral' id='search-btn'>Search</button>
+    <button class='role-neutral' id='prev-btn'>&larr; Prev</button>
+    <button class='role-neutral' id='next-btn'>Next &rarr;</button>
+  </div>
+  <div id='loading'>Loading&hellip;</div>
+  <table>
+    <thead><tr><th>Vendor</th><th>Amount (cents)</th><th id='actions-head' style='display:none'>Actions</th></tr></thead>
+    <tbody id='po-body'></tbody>
+  </table>
+  <div id='empty-state'>No purchase orders match.</div>
+  <div id='create-panel' style='display:none; margin-top:1rem'>
+    <input id='vendor-input' placeholder='Vendor name'>
+    <input id='amount-input' placeholder='Amount cents' type='number'>
+    <button class='role-admin' id='create-btn'>Create Purchase Order</button>
+  </div>
+  <p id='create-status'></p>
+</div>
+
+<script>
+var LANDING = [
+  { role: 'admin', target: 'admin_home' },
+  { role: 'finance', target: 'finance_queue' },
+  { isDefault: true, target: 'home_screen' }
+];
+
+function landingTarget(role) {
+  for (var i = 0; i < LANDING.length; i++) {
+    if (LANDING[i].isDefault) return LANDING[i].target;
+    if (LANDING[i].role === role) return LANDING[i].target;
+  }
+  return 'home_screen';
+}
+
+var currentRole = null;
+var currentToken = null;
+var currentOffset = 0;
+var pageSize = 10;
+
+function showError(message) {
+  var banner = document.getElementById('error-banner');
+  banner.textContent = message;
+  banner.style.display = 'block';
+}
+
+function clearError() {
+  document.getElementById('error-banner').style.display = 'none';
+}
+
+function authHeaders(extra) {
+  var headers = extra || {};
+  if (currentToken) {
+    headers['Authorization'] = 'Bearer ' + currentToken;
+  }
+  return headers;
+}
+
+function signIn(role) {
+  clearError();
+  fetch('/api/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ role: role })
+  }).then(function (r) { return r.json(); }).then(function (res) {
+    if (res.err) {
+      showError('Sign-in failed: ' + res.err);
+      return;
+    }
+    currentRole = role;
+    currentToken = res.value;
+    currentOffset = 0;
+    document.getElementById('login-card').style.display = 'none';
+    document.getElementById('app-card').style.display = 'block';
+    document.getElementById('po-card').style.display = 'block';
+    document.getElementById('who').textContent = role;
+    document.getElementById('landing-target').textContent = landingTarget(role);
+    document.getElementById('create-panel').style.display = (role === 'admin') ? 'block' : 'none';
+    document.getElementById('actions-head').style.display = (role === 'admin') ? 'table-cell' : 'none';
+    document.getElementById('create-status').textContent = '';
+    loadPOs();
+  }).catch(function () { showError('Sign-in request failed.'); });
+}
+
+function signOut() {
+  currentRole = null;
+  currentToken = null;
+  document.getElementById('login-card').style.display = 'block';
+  document.getElementById('app-card').style.display = 'none';
+  document.getElementById('po-card').style.display = 'none';
+}
+
+function loadPOs() {
+  clearError();
+  document.getElementById('loading').style.display = 'block';
+  document.getElementById('empty-state').style.display = 'none';
+  var q = document.getElementById('search-input').value;
+  fetch('/api/purchase_orders/list', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ q: q, offset: currentOffset, limit: pageSize })
+  }).then(function (r) { return r.json(); }).then(function (rows) {
+    document.getElementById('loading').style.display = 'none';
+    var body = document.getElementById('po-body');
+    body.innerHTML = '';
+    if (!rows || rows.length === 0) {
+      document.getElementById('empty-state').style.display = 'block';
+      return;
+    }
+    for (var i = 0; i < rows.length; i++) {
+      var row = rows[i];
+      var tr = document.createElement('tr');
+      var td1 = document.createElement('td');
+      td1.textContent = row.vendor;
+      var td2 = document.createElement('td');
+      td2.textContent = row.amount_cents;
+      tr.appendChild(td1);
+      tr.appendChild(td2);
+      if (currentRole === 'admin') {
+        var tdActions = document.createElement('td');
+        tdActions.className = 'row-actions';
+        var approveBtn = document.createElement('button');
+        approveBtn.className = 'role-admin';
+        approveBtn.textContent = 'Approve';
+        approveBtn.addEventListener('click', function () { approvePO(); });
+        var deleteBtn = document.createElement('button');
+        deleteBtn.className = 'role-danger';
+        deleteBtn.textContent = 'Delete';
+        (function (id) {
+          deleteBtn.addEventListener('click', function () { deletePO(id); });
+        })(row.id);
+        tdActions.appendChild(approveBtn);
+        tdActions.appendChild(deleteBtn);
+        tr.appendChild(tdActions);
+      }
+      body.appendChild(tr);
+    }
+  }).catch(function () {
+    document.getElementById('loading').style.display = 'none';
+    showError('Failed to load purchase orders.');
+  });
+}
+
+function createPO() {
+  clearError();
+  var v = document.getElementById('vendor-input').value;
+  var a = parseInt(document.getElementById('amount-input').value, 10) || 0;
+  fetch('/api/create', {
+    method: 'POST',
+    headers: authHeaders({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ vendor: v, amount_cents: a })
+  }).then(function (r) { return r.json(); }).then(function (res) {
+    document.getElementById('create-status').textContent = res.err ? ('Error: ' + res.err) : ('Created: ' + res.value);
+    document.getElementById('vendor-input').value = '';
+    document.getElementById('amount-input').value = '';
+    loadPOs();
+  }).catch(function () { showError('Create request failed.'); });
+}
+
+function approvePO() {
+  clearError();
+  fetch('/api/purchase_orders/approve', {
+    method: 'POST',
+    headers: authHeaders({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({})
+  }).then(function (r) { return r.json(); }).then(function (res) {
+    if (res.err) { showError('Approve failed: ' + res.err); return; }
+    document.getElementById('create-status').textContent = 'Disbursement: ' + res.value;
+  }).catch(function () { showError('Approve request failed.'); });
+}
+
+function deletePO(id) {
+  clearError();
+  fetch('/api/purchase_orders/delete', {
+    method: 'POST',
+    headers: authHeaders({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ id: id })
+  }).then(function (r) { return r.json(); }).then(function (res) {
+    if (res.err) { showError('Delete failed: ' + res.err); return; }
+    loadPOs();
+  }).catch(function () { showError('Delete request failed.'); });
+}
+
+document.getElementById('admin-btn').addEventListener('click', function () { signIn('admin'); });
+document.getElementById('finance-btn').addEventListener('click', function () { signIn('finance'); });
+document.getElementById('signout-btn').addEventListener('click', signOut);
+document.getElementById('create-btn').addEventListener('click', createPO);
+document.getElementById('search-btn').addEventListener('click', function () { currentOffset = 0; loadPOs(); });
+document.getElementById('prev-btn').addEventListener('click', function () { currentOffset = Math.max(0, currentOffset - pageSize); loadPOs(); });
+document.getElementById('next-btn').addEventListener('click', function () { currentOffset = currentOffset + pageSize; loadPOs(); });
+</script>
+</body>
+</html>
+")
+}
+
+// ---- accept loop -----------------------------------------------------
+
+fn main() {
+    let l: tcp_listener = listen(8091)
+    print("Nirdosha Ops Console v2 server listening on http://127.0.0.1:8091/")
+    while true {
+        let conn: tcp = accept(l)
+        let req: Text = Text(recv(conn))
+        let method_text: Text = req_method(req)
+        let method: str = method_text.value
+        let path_text: Text = req_path(req)
+        let path: str = path_text.value
+
+        if method == "GET" && path == "/" {
+            let page: Text = index_html()
+            send(conn, "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nConnection: close\r\n\r\n")
+            send(conn, page.value)
+        } else if method == "GET" && path == "/api/list" {
+            send(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\nConnection: close\r\n\r\n")
+            send(conn, plain_list_response_body())
+        } else if method == "POST" && path == "/api/purchase_orders/list" {
+            send(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n")
+            send(conn, list_response_body(req))
+        } else if method == "GET" && path == "/api/count" {
+            send(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\nConnection: close\r\n\r\n")
+            send(conn, count_response_body())
+        } else if method == "POST" && path == "/api/login" {
+            send(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n")
+            send(conn, login_response_body(req))
+        } else if method == "POST" && path == "/api/create" {
+            send(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n")
+            send(conn, create_response_body(req))
+        } else if method == "POST" && path == "/api/purchase_orders/update" {
+            send(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n")
+            send(conn, update_response_body(req))
+        } else if method == "POST" && path == "/api/purchase_orders/delete" {
+            send(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n")
+            send(conn, delete_response_body(req))
+        } else if method == "POST" && path == "/api/purchase_orders/approve" {
+            send(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n")
+            send(conn, approve_response_body(req))
+        } else {
+            send(conn, "HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n")
+        }
+        stop conn
+    }
+}

--- a/examples/features/57_nirdosha_ops_console_server_v2.nir
+++ b/examples/features/57_nirdosha_ops_console_server_v2.nir
@@ -1,5 +1,5 @@
 // Feature: strengthens the browser-clickable Nirdosha Ops Console
-// (`56_nirdosha_ops_console_server.nir`) along four real axes:
+// (`56_nirdosha_ops_console_server.nir`) along seven real axes:
 //
 //   1. **Real signed authentication.** `POST /api/login` returns a real
 //      HMAC-SHA256 JWT (`mock_issue_token`, finished alongside this file
@@ -10,12 +10,15 @@
 //      `X-Demo-Role` header is gone -- every admin action here is
 //      guarded by a real signature check against a real (if hardcoded,
 //      demo-only) JWKS.
-//   2. **The `Disbursement` workflow wired to a real browser button.**
-//      `55_nirdosha_ops_console.nir`'s workflow-gated, `transact`-backed
-//      disbursement (RBAC + a real webhook call + a real durable
-//      Postgres write) was previously only ever exercised by a test
-//      harness. `POST /api/purchase_orders/approve` really starts and
-//      advances a real workflow instance from the browser.
+//   2. **The `Disbursement` workflow wired to real browser buttons,
+//      with a real second branch.** `55_nirdosha_ops_console.nir`'s
+//      workflow-gated, `transact`-backed disbursement (RBAC + a real
+//      webhook call + a real durable Postgres write) was previously
+//      only ever exercised by a test harness, and only ever had one
+//      real transition to prove the mechanism. `Draft` here has two --
+//      `POST /api/purchase_orders/approve`/`.../reject` really start
+//      and advance a real workflow instance from the browser, down
+//      either real branch.
 //   3. **Broader CRUD.** Real `UPDATE`/`DELETE` via `db_execute` -- both
 //      already exercised elsewhere in this compiler's own test suite;
 //      neither route needed anything new from the compiler.
@@ -29,8 +32,8 @@
 //   5. **Real `nfr(...)` SLOs on every real route** (`LANGUAGE.md` §6f,
 //      first used in `50_field_masking_and_check_role.nir`) -- a
 //      latency ceiling everywhere, plus either `error_rate_max` (on the
-//      two functions that genuinely return `Result(...)`: token
-//      issuance/verification) or `concurrency_max` (on the `Text`/`bool`-
+//      functions that genuinely return `Result(...)`: token issuance/
+//      verification) or `concurrency_max` (on the `Text`/`bool`-
 //      returning CRUD and approval routes, where there's no tagged
 //      success/error a `Result` return would give the APM kernel to
 //      inspect). Zero code at any call site; a crossed threshold fires
@@ -38,6 +41,27 @@
 //      configured. Each threshold's own comment explains why its value
 //      differs from its neighbors -- these aren't the same number
 //      copy-pasted five times.
+//   6. **Real SLA/overdue detection** (`state { sla_seconds: N }`, first
+//      used in `54_compiled_workflow_escalation.nir`) on `Draft` -- a
+//      real, production-shaped 3-day SLA, plus `GET /api/disbursements/
+//      overdue` exposing the compiler-synthesized
+//      `list_disbursement_overdue()` to the browser for real, not just
+//      to a test harness's own polling loop.
+//   7. **Real dual control on large purchase orders.** A PO at or above
+//      `escalation_threshold_cents()` ($100,000) refuses a plain
+//      `admin` token and only accepts a real `finance_director`-proven
+//      identity -- `route_approval` `acquire`s a structurally different
+//      `requires`-gated function depending on the PO's *real* amount
+//      (looked up fresh from Postgres, never trusted from the request),
+//      the same real RBAC mechanism every other gated route here already
+//      uses, just choosing between two different callables instead of
+//      one. **What this does NOT change, disclosed plainly**: the actual
+//      disbursement `disburse_on_approval` records is still the same
+//      fixed $2,500 both `55_...` and this file's own axis 2 already
+//      disclose (Layer 1's `on_entry` has no way to carry the PO's real
+//      amount through) -- escalating *who* may approve a large PO is
+//      real; making the disbursed amount itself scale with it is the
+//      same already-disclosed gap, not newly hidden here.
 //
 // **Deliberately not attempted here, disclosed rather than silently
 // deferred**: `crates/compiled-serve` (ROADMAP B8's real Rust HTTP
@@ -93,12 +117,18 @@ fn role_subject(role: Text) -> Text {
     if role.value == "admin" {
         return Text("cfo-1")
     }
+    if role.value == "finance_director" {
+        return Text("finance-director-1")
+    }
     return Text("clerk-1")
 }
 
 fn role_claims_json(role: Text) -> Text {
     if role.value == "admin" {
         return Text("{\"roles\":[\"admin\"]}")
+    }
+    if role.value == "finance_director" {
+        return Text("{\"roles\":[\"finance_director\"]}")
     }
     return Text("{\"roles\":[\"finance\"]}")
 }
@@ -279,6 +309,37 @@ fn run_delete(conn: db, id: i64) -> bool {
     return deleted > 0
 }
 
+// The real dollar figure `route_approval` below decides escalation on
+// -- a fresh read from Postgres for the specific PO the browser named,
+// never trusted from the request body itself.
+fn lookup_amount_cents(id: i64) -> i64 {
+    return match db_connect("postgres://postgres@127.0.0.1:5432/postgres") {
+        Err(e) => -1,
+        Ok(conn) => run_lookup_amount_cents(conn, id),
+    }
+}
+
+fn run_lookup_amount_cents(conn: db, id: i64) -> i64 {
+    let result: i64 = match db_query(conn, "SELECT amount_cents FROM purchase_orders WHERE id = ?", id) {
+        Ok(rows) => match json_array_get(rows, 0) {
+            Ok(row) => match json_get_i64(row, "amount_cents") {
+                Ok(n) => n,
+                Err(e) => -1,
+            },
+            Err(e) => -1,
+        },
+        Err(e) => -1,
+    }
+    stop conn
+    return result
+}
+
+// $100,000 -- an ordinary enterprise-shaped dual-control threshold, not
+// a number picked to make the demo work.
+fn escalation_threshold_cents() -> i64 {
+    return 10000000
+}
+
 fn wrap_ok_json(j: json) -> Result(json, ErrMsg) {
     return Ok(j)
 }
@@ -392,6 +453,10 @@ fn log_disbursement_failure(txn_id: str, po_id: i64) -> unit {
     print("disbursement failed", txn_id, po_id)
 }
 
+fn log_disbursement_rejected(instance_id: i64) -> unit {
+    print("disbursement", instance_id, "rejected")
+}
+
 // Layer 1's only implicit `on_entry` binding is `instance_id` (no
 // non-empty `data{}` block support), so -- same disclosed limitation
 // `55_...` already has -- the disbursed amount is fixed, not read back
@@ -412,13 +477,28 @@ fn disburse_on_approval(instance_id: i64) -> unit {
     print("disbursement", instance_id, ok)
 }
 
+// `sla_seconds` (`LANGUAGE.md`/`docs/ROADMAP.md` A15, first used in
+// `54_compiled_workflow_escalation.nir`) plus a real second branch out
+// of `Draft` -- 55_...'s own workflow only ever had one real transition
+// to prove the mechanism; a real approval queue has two outcomes and a
+// real SLA on how long a request may sit unactioned. 3 days (259200s)
+// here is the real, production-shaped value (`54_...`'s own header
+// note on why ITS example uses 1s instead: fast/deterministic demo
+// timing -- not a value meant to be copied unchanged).
 workflow Disbursement {
     state Draft {
+        sla_seconds: 259200
         on Approve -> Approved
+        on Reject -> Rejected
     }
     state Approved terminal {
         on_entry {
             disburse_on_approval(instance_id)
+        }
+    }
+    state Rejected terminal {
+        on_entry {
+            log_disbursement_rejected(instance_id)
         }
     }
 }
@@ -448,17 +528,63 @@ fn run_approval() -> Text {
     return Text("approval failed")
 }
 
+fn run_rejection() -> Text {
+    let instance_id: i64 = match start_disbursement(None(), DisbursementData()) {
+        Ok(id) => id,
+        Err(e) => -1,
+    }
+    if instance_id < 0 {
+        return Text("failed to start disbursement workflow")
+    }
+    let rejected: bool = match advance_disbursement_now(admin_identity(), instance_id, Reject()) {
+        Err(e) => false,
+        Ok(v) => v,
+    }
+    if rejected {
+        return Text("rejected")
+    }
+    return Text("rejection failed")
+}
+
 // A real network hop (the webhook) plus a `transact`-backed durable
 // write sits behind this one -- a much higher latency ceiling than the
 // plain CRUD routes above, and a deliberately low `concurrency_max`:
 // this is the one route that moves real money, so capping how many
 // disbursements can be in flight at once is itself a real production
 // control, not just a performance knob.
-fn approve_purchase_order() -> Text
+//
+// **Dual control, a real production pattern, not a toy threshold**: a
+// purchase order at or above `escalation_threshold_cents()` needs a
+// `finance_director`-proven identity, not just `admin` --
+// `route_approval` below decides which of these two `requires`-gated
+// functions to `acquire` based on the *real* PO amount looked up from
+// Postgres (`lookup_amount_cents`), not a client-supplied one. **What
+// this threshold check does NOT change, disclosed plainly**: the
+// disbursement `disburse_on_approval` actually records is still the
+// same fixed $2,500 both `55_...` and this file's own header already
+// disclose (Layer 1's `on_entry` has no way to carry the PO's real
+// amount through) -- escalating *who* may approve a large PO is real;
+// making the disbursement itself scale with it is the same
+// already-disclosed gap, not newly hidden here.
+fn approve_purchase_order_standard() -> Text
     requires(role: "admin")
     nfr(latency_ms: 2000, concurrency_max: 10)
 {
     return run_approval()
+}
+
+fn approve_purchase_order_escalated() -> Text
+    requires(role: "finance_director")
+    nfr(latency_ms: 2000, concurrency_max: 5)
+{
+    return run_approval()
+}
+
+fn reject_purchase_order() -> Text
+    requires(role: "admin")
+    nfr(latency_ms: 300, concurrency_max: 50)
+{
+    return run_rejection()
 }
 
 // ---- gated-route helpers: real bearer-token check, then real
@@ -504,12 +630,46 @@ fn delete_as_admin(req: Text, id: i64) -> bool {
     }
 }
 
+// Real dual control: a real `acquire`d call to a *different*
+// `requires`-gated function depending on the PO's own real amount, not
+// a same-function `if` deciding after the fact -- the "gate" a
+// `finance_director`-only PO goes through is structurally a different
+// callable value than the `admin`-only one, exactly the same
+// distinction `check_role`/`acquire` already enforce between any other
+// two roles in this codebase.
+fn route_approval(identity: VerifiedIdentity, amount_cents: i64) -> Text {
+    if amount_cents >= escalation_threshold_cents() {
+        return match check_role(identity, "finance_director") {
+            Err(e) => Text("this purchase order requires finance_director approval"),
+            Ok(proof) => match acquire approve_purchase_order_escalated(proof) {
+                Err(msg) => Text(msg),
+                Ok(f) => f(),
+            },
+        }
+    }
+    return match check_role(identity, "admin") {
+        Err(e) => Text(e),
+        Ok(proof) => match acquire approve_purchase_order_standard(proof) {
+            Err(msg) => Text(msg),
+            Ok(f) => f(),
+        },
+    }
+}
+
 fn approve_as_admin(req: Text) -> Text {
+    let amount_cents: i64 = lookup_amount_cents(body_id(req))
+    return match authorized_identity(req) {
+        Err(e) => Text(e.value),
+        Ok(identity) => route_approval(identity, amount_cents),
+    }
+}
+
+fn reject_as_admin(req: Text) -> Text {
     return match authorized_identity(req) {
         Err(e) => Text(e.value),
         Ok(identity) => match check_role(identity, "admin") {
             Err(e) => Text(e),
-            Ok(proof) => match acquire approve_purchase_order(proof) {
+            Ok(proof) => match acquire reject_purchase_order(proof) {
                 Err(msg) => Text(msg),
                 Ok(f) => f(),
             },
@@ -711,6 +871,18 @@ fn approve_response_body(req: Text) -> json {
     return value_json(approved)
 }
 
+fn reject_response_body(req: Text) -> json {
+    let rejected: Text = reject_as_admin(req)
+    return value_json(rejected)
+}
+
+fn overdue_response_body() -> json {
+    return match list_disbursement_overdue() {
+        Err(e) => empty_json_array(),
+        Ok(j) => j,
+    }
+}
+
 // ---- HTML/CSS/JS page, one real static response body --------------------
 // No `\"` inside -- every HTML attribute and every JS string below uses
 // single quotes on purpose (`56_...`'s own note on this language's
@@ -753,10 +925,12 @@ fn index_html() -> Text {
   <p>Sign in as:</p>
   <button class='role-admin' id='admin-btn'>Admin (CFO)</button>
   <button class='role-finance' id='finance-btn'>Finance Clerk</button>
+  <button class='role-neutral' id='director-btn'>Finance Director</button>
 </div>
 
 <div class='card' id='app-card' style='display:none'>
   <p>Signed in as <b id='who'></b> with a real signed JWT &mdash; a real <code>landing</code> rule (RFC 0010) would send this role to <span class='badge' id='landing-target'></span></p>
+  <span class='badge' id='overdue-badge' style='background:#fef2f2;color:#991b1b'></span>
   <button class='role-signout' id='signout-btn'>Sign out</button>
 </div>
 
@@ -840,9 +1014,10 @@ function signIn(role) {
     document.getElementById('who').textContent = role;
     document.getElementById('landing-target').textContent = landingTarget(role);
     document.getElementById('create-panel').style.display = (role === 'admin') ? 'block' : 'none';
-    document.getElementById('actions-head').style.display = (role === 'admin') ? 'table-cell' : 'none';
+    document.getElementById('actions-head').style.display = (role === 'admin' || role === 'finance_director') ? 'table-cell' : 'none';
     document.getElementById('create-status').textContent = '';
     loadPOs();
+    loadOverdueCount();
   }).catch(function () { showError('Sign-in request failed.'); });
 }
 
@@ -880,20 +1055,25 @@ function loadPOs() {
       td2.textContent = row.amount_cents;
       tr.appendChild(td1);
       tr.appendChild(td2);
-      if (currentRole === 'admin') {
+      if (currentRole === 'admin' || currentRole === 'finance_director') {
         var tdActions = document.createElement('td');
         tdActions.className = 'row-actions';
         var approveBtn = document.createElement('button');
         approveBtn.className = 'role-admin';
-        approveBtn.textContent = 'Approve';
-        approveBtn.addEventListener('click', function () { approvePO(); });
+        approveBtn.textContent = row.amount_cents >= 10000000 ? 'Approve (needs director)' : 'Approve';
+        var rejectBtn = document.createElement('button');
+        rejectBtn.className = 'role-danger';
+        rejectBtn.textContent = 'Reject';
         var deleteBtn = document.createElement('button');
-        deleteBtn.className = 'role-danger';
+        deleteBtn.className = 'role-signout';
         deleteBtn.textContent = 'Delete';
         (function (id) {
+          approveBtn.addEventListener('click', function () { approvePO(id); });
+          rejectBtn.addEventListener('click', function () { rejectPO(id); });
           deleteBtn.addEventListener('click', function () { deletePO(id); });
         })(row.id);
         tdActions.appendChild(approveBtn);
+        tdActions.appendChild(rejectBtn);
         tdActions.appendChild(deleteBtn);
         tr.appendChild(tdActions);
       }
@@ -921,16 +1101,38 @@ function createPO() {
   }).catch(function () { showError('Create request failed.'); });
 }
 
-function approvePO() {
+function approvePO(id) {
   clearError();
   fetch('/api/purchase_orders/approve', {
     method: 'POST',
     headers: authHeaders({ 'Content-Type': 'application/json' }),
-    body: JSON.stringify({})
+    body: JSON.stringify({ id: id })
   }).then(function (r) { return r.json(); }).then(function (res) {
     if (res.err) { showError('Approve failed: ' + res.err); return; }
     document.getElementById('create-status').textContent = 'Disbursement: ' + res.value;
+    loadOverdueCount();
   }).catch(function () { showError('Approve request failed.'); });
+}
+
+function rejectPO(id) {
+  clearError();
+  fetch('/api/purchase_orders/reject', {
+    method: 'POST',
+    headers: authHeaders({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ id: id })
+  }).then(function (r) { return r.json(); }).then(function (res) {
+    if (res.err) { showError('Reject failed: ' + res.err); return; }
+    document.getElementById('create-status').textContent = 'Disbursement: ' + res.value;
+    loadOverdueCount();
+  }).catch(function () { showError('Reject request failed.'); });
+}
+
+function loadOverdueCount() {
+  fetch('/api/disbursements/overdue').then(function (r) { return r.json(); }).then(function (rows) {
+    var el = document.getElementById('overdue-badge');
+    var n = (rows && rows.length) || 0;
+    el.textContent = n > 0 ? (n + ' approval(s) overdue') : '';
+  }).catch(function () {});
 }
 
 function deletePO(id) {
@@ -947,6 +1149,7 @@ function deletePO(id) {
 
 document.getElementById('admin-btn').addEventListener('click', function () { signIn('admin'); });
 document.getElementById('finance-btn').addEventListener('click', function () { signIn('finance'); });
+document.getElementById('director-btn').addEventListener('click', function () { signIn('finance_director'); });
 document.getElementById('signout-btn').addEventListener('click', signOut);
 document.getElementById('create-btn').addEventListener('click', createPO);
 document.getElementById('search-btn').addEventListener('click', function () { currentOffset = 0; loadPOs(); });
@@ -999,6 +1202,12 @@ fn main() {
         } else if method == "POST" && path == "/api/purchase_orders/approve" {
             send(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n")
             send(conn, approve_response_body(req))
+        } else if method == "POST" && path == "/api/purchase_orders/reject" {
+            send(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n")
+            send(conn, reject_response_body(req))
+        } else if method == "GET" && path == "/api/disbursements/overdue" {
+            send(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\nConnection: close\r\n\r\n")
+            send(conn, overdue_response_body())
         } else {
             send(conn, "HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n")
         }

--- a/examples/features/57_nirdosha_ops_console_server_v2.nir
+++ b/examples/features/57_nirdosha_ops_console_server_v2.nir
@@ -26,6 +26,18 @@
 //      body instead of query-string parameters -- every integer here
 //      always arrives as a real JSON number, the same convention
 //      `POST /api/create` already established in `56_...`.
+//   5. **Real `nfr(...)` SLOs on every real route** (`LANGUAGE.md` §6f,
+//      first used in `50_field_masking_and_check_role.nir`) -- a
+//      latency ceiling everywhere, plus either `error_rate_max` (on the
+//      two functions that genuinely return `Result(...)`: token
+//      issuance/verification) or `concurrency_max` (on the `Text`/`bool`-
+//      returning CRUD and approval routes, where there's no tagged
+//      success/error a `Result` return would give the APM kernel to
+//      inspect). Zero code at any call site; a crossed threshold fires
+//      an async escalation POST to `NIRDOSHA_OBSERVABILITY_URL` if one's
+//      configured. Each threshold's own comment explains why its value
+//      differs from its neighbors -- these aren't the same number
+//      copy-pasted five times.
 //
 // **Deliberately not attempted here, disclosed rather than silently
 // deferred**: `crates/compiled-serve` (ROADMAP B8's real Rust HTTP
@@ -115,7 +127,17 @@ fn wrap_err_text(e: ErrMsg) -> Result(Text, ErrMsg) {
 
 // `issued_at`/`ttl_secs` are fixed constants -- see this file's own
 // header note on why (no `now()` builtin).
-fn issue_demo_token(role: Text) -> Result(Text, ErrMsg) {
+// `nfr(...)` (`LANGUAGE.md` §6f): real per-call latency/error-rate
+// tracking, zero code at any call site -- `error_rate_max` is legal here
+// specifically because this function returns a real `Result(...)`,
+// which is how `nir_nfr_call_end` tells a real error from a real
+// success. A crossed threshold fires an async escalation POST to
+// `NIRDOSHA_OBSERVABILITY_URL` if one is configured (unset means no
+// escalation ever happens, not an error) -- a genuine production
+// concern (auth latency/error-rate SLOs), not decoration.
+fn issue_demo_token(role: Text) -> Result(Text, ErrMsg)
+    nfr(latency_ms: 100, error_rate_max: 0.01)
+{
     let issuer: Text = demo_issuer()
     let audience: Text = demo_audience()
     let jwks: Text = demo_jwks()
@@ -163,7 +185,14 @@ fn wrap_err_identity(e: ErrMsg) -> Result(VerifiedIdentity, ErrMsg) {
     return Err(e)
 }
 
-fn authorized_identity(req: Text) -> Result(VerifiedIdentity, ErrMsg) {
+// Real token verification has no I/O (`oidc_validate_token`'s own doc
+// comment: a pure function of its inputs) -- a much tighter latency
+// ceiling than the Postgres-backed routes below, and a higher tolerated
+// error rate, since a missing/expired/malformed bearer token is an
+// expected, routine outcome here, not a system fault.
+fn authorized_identity(req: Text) -> Result(VerifiedIdentity, ErrMsg)
+    nfr(latency_ms: 20, error_rate_max: 0.2)
+{
     let token: Text = req_bearer_token(req)
     if len(token.value) == 0 {
         return wrap_err_identity(ErrMsg("missing Authorization: Bearer token"))
@@ -180,7 +209,16 @@ fn authorized_identity(req: Text) -> Result(VerifiedIdentity, ErrMsg) {
 // ---- Postgres-backed CRUD (same shape as `56_...`, extended with
 // UPDATE/DELETE/search+pagination) ----------------------------------------
 
-fn create_purchase_order(vendor: Text, amount_cents: i64) -> Text requires(role: "admin") {
+// `error_rate_max` isn't legal on this one -- it returns a bare `Text`,
+// not a `Result(...)`, so there's no tagged success/error the kernel
+// could inspect (`TypeErrorKind::NfrErrorRateNeedsResultReturn`).
+// `latency_ms`/`concurrency_max` alone still give a real production
+// SLO on the write path: a real Postgres round trip per call, capped
+// concurrency so a burst of creates can't starve the connection pool.
+fn create_purchase_order(vendor: Text, amount_cents: i64) -> Text
+    requires(role: "admin")
+    nfr(latency_ms: 300, concurrency_max: 50)
+{
     return match db_connect("postgres://postgres@127.0.0.1:5432/postgres") {
         Err(e) => Text(e),
         Ok(conn) => run_create(conn, vendor, amount_cents),
@@ -200,7 +238,10 @@ fn run_create(conn: db, vendor: Text, amount_cents: i64) -> Text {
     return Text(vendor.value)
 }
 
-fn update_purchase_order(id: i64, vendor: Text, amount_cents: i64) -> Text requires(role: "admin") {
+fn update_purchase_order(id: i64, vendor: Text, amount_cents: i64) -> Text
+    requires(role: "admin")
+    nfr(latency_ms: 300, concurrency_max: 50)
+{
     return match db_connect("postgres://postgres@127.0.0.1:5432/postgres") {
         Err(e) => Text(e),
         Ok(conn) => run_update(conn, id, vendor, amount_cents),
@@ -219,7 +260,10 @@ fn run_update(conn: db, id: i64, vendor: Text, amount_cents: i64) -> Text {
     return Text(vendor.value)
 }
 
-fn delete_purchase_order(id: i64) -> bool requires(role: "admin") {
+fn delete_purchase_order(id: i64) -> bool
+    requires(role: "admin")
+    nfr(latency_ms: 200, concurrency_max: 50)
+{
     return match db_connect("postgres://postgres@127.0.0.1:5432/postgres") {
         Err(e) => false,
         Ok(conn) => run_delete(conn, id),
@@ -404,7 +448,16 @@ fn run_approval() -> Text {
     return Text("approval failed")
 }
 
-fn approve_purchase_order() -> Text requires(role: "admin") {
+// A real network hop (the webhook) plus a `transact`-backed durable
+// write sits behind this one -- a much higher latency ceiling than the
+// plain CRUD routes above, and a deliberately low `concurrency_max`:
+// this is the one route that moves real money, so capping how many
+// disbursements can be in flight at once is itself a real production
+// control, not just a performance knob.
+fn approve_purchase_order() -> Text
+    requires(role: "admin")
+    nfr(latency_ms: 2000, concurrency_max: 10)
+{
     return run_approval()
 }
 

--- a/examples/features/57_nirdosha_ops_console_server_v2.nir
+++ b/examples/features/57_nirdosha_ops_console_server_v2.nir
@@ -62,6 +62,21 @@
 //      amount through) -- escalating *who* may approve a large PO is
 //      real; making the disbursed amount itself scale with it is the
 //      same already-disclosed gap, not newly hidden here.
+//   8. **A different real dashboard per role -- the landing page IS the
+//      per-role view.** Three genuinely different SQL aggregates, not
+//      one query re-labeled three times: admin sees spend-by-vendor
+//      (`SUM(amount_cents) GROUP BY vendor`), finance sees the most
+//      recent real disbursements, finance_director sees exactly the
+//      purchase orders `route_approval` would route to *them*
+//      specifically (`>= escalation_threshold_cents()`). Each renders
+//      as a real, hand-rolled inline-SVG horizontal bar chart -- the
+//      same no-external-library ethos the compiler's own static UI
+//      engine uses for its four built-in chart shapes, hand-written
+//      here since this file's compiled server predates
+//      `nirdosha emit-ui`'s chart renderer entirely (a separate, static
+//      code path this file never goes through). A `Dashboard`/
+//      `Purchase Orders` nav toggle lets a signed-in user move between
+//      their landing dashboard and the CRUD table freely.
 //
 // **Deliberately not attempted here, disclosed rather than silently
 // deferred**: `crates/compiled-serve` (ROADMAP B8's real Rust HTTP
@@ -399,6 +414,84 @@ fn run_count(conn: db) -> Result(json, ErrMsg) {
             Ok(row) => wrap_ok_json(row),
             Err(e) => wrap_err_json(ErrMsg(e)),
         },
+        Err(e) => wrap_err_json(ErrMsg(e)),
+    }
+    stop conn
+    return result
+}
+
+// ---- per-role dashboards -- a different real chart for a different
+// real job (`landing { role(...) -> Screen }`'s own per-role-page idea,
+// `55_...`'s minimal `dashboard { tile ... }` block, applied here to
+// this file's own hand-written server instead of the separate, static
+// `nirdosha emit-ui` path those blocks normally drive -- three
+// genuinely different SQL aggregates, one per role, not the same query
+// re-labeled three times. -----------------------------------------------
+
+// Admin cares about spend concentration: which vendors are taking the
+// most money, in aggregate, across every purchase order ever created.
+fn dashboard_admin_json() -> Result(json, ErrMsg) {
+    return match db_connect("postgres://postgres@127.0.0.1:5432/postgres") {
+        Err(e) => wrap_err_json(ErrMsg(e)),
+        Ok(conn) => run_dashboard_admin(conn),
+    }
+}
+
+// `::bigint`, not decoration: Postgres widens `SUM(BIGINT)` to `NUMERIC`
+// (overflow avoidance, standard SQL semantics), and this compiler's own
+// `pg_row_to_json` (`kernel/db.rs`) doesn't have a `NUMERIC` case yet --
+// it falls back to a `String` read, which fails silently against a
+// numeric wire value and comes back a real, disclosed `null`, found by
+// actually running this query against real Postgres, not assumed. Real
+// dashboards can't answer "which vendor got the most money" with a
+// SQL-standard aggregate query as-is today -- casting the sum back down
+// to a type the kernel already handles (safe here; a cents total is
+// nowhere near `i64::MAX`) is the honest fix at this layer, not a
+// compiler change this demo takes on.
+fn run_dashboard_admin(conn: db) -> Result(json, ErrMsg) {
+    let result: Result(json, ErrMsg) = match db_query(conn, "SELECT vendor, SUM(amount_cents)::bigint AS amount_cents FROM purchase_orders GROUP BY vendor ORDER BY amount_cents DESC LIMIT 10") {
+        Ok(rows) => wrap_ok_json(rows),
+        Err(e) => wrap_err_json(ErrMsg(e)),
+    }
+    stop conn
+    return result
+}
+
+// Finance clerks track what's actually gone out the door recently, not
+// what's still sitting in the purchase-order table.
+fn dashboard_finance_json() -> Result(json, ErrMsg) {
+    return match db_connect("postgres://postgres@127.0.0.1:5432/postgres") {
+        Err(e) => wrap_err_json(ErrMsg(e)),
+        Ok(conn) => run_dashboard_finance(conn),
+    }
+}
+
+fn run_dashboard_finance(conn: db) -> Result(json, ErrMsg) {
+    let schema_ok: i64 = match db_execute(conn, "CREATE TABLE IF NOT EXISTS disbursements (txn_id TEXT PRIMARY KEY, po_id BIGINT NOT NULL, amount_cents BIGINT NOT NULL)") {
+        Ok(n) => n,
+        Err(e) => -1,
+    }
+    let result: Result(json, ErrMsg) = match db_query(conn, "SELECT po_id, amount_cents FROM disbursements ORDER BY txn_id DESC LIMIT 10") {
+        Ok(rows) => wrap_ok_json(rows),
+        Err(e) => wrap_err_json(ErrMsg(e)),
+    }
+    stop conn
+    return result
+}
+
+// A finance director's own real oversight job: exactly the purchase
+// orders `route_approval` would route to *them* specifically --
+// `>= escalation_threshold_cents()` -- not every PO in the system.
+fn dashboard_director_json() -> Result(json, ErrMsg) {
+    return match db_connect("postgres://postgres@127.0.0.1:5432/postgres") {
+        Err(e) => wrap_err_json(ErrMsg(e)),
+        Ok(conn) => run_dashboard_director(conn),
+    }
+}
+
+fn run_dashboard_director(conn: db) -> Result(json, ErrMsg) {
+    let result: Result(json, ErrMsg) = match db_query(conn, "SELECT vendor, amount_cents FROM purchase_orders WHERE amount_cents >= ? ORDER BY amount_cents DESC LIMIT 10", escalation_threshold_cents()) {
+        Ok(rows) => wrap_ok_json(rows),
         Err(e) => wrap_err_json(ErrMsg(e)),
     }
     stop conn
@@ -883,6 +976,27 @@ fn overdue_response_body() -> json {
     }
 }
 
+fn dashboard_admin_response_body() -> json {
+    return match dashboard_admin_json() {
+        Err(e) => empty_json_array(),
+        Ok(rows) => rows,
+    }
+}
+
+fn dashboard_finance_response_body() -> json {
+    return match dashboard_finance_json() {
+        Err(e) => empty_json_array(),
+        Ok(rows) => rows,
+    }
+}
+
+fn dashboard_director_response_body() -> json {
+    return match dashboard_director_json() {
+        Err(e) => empty_json_array(),
+        Ok(rows) => rows,
+    }
+}
+
 // ---- HTML/CSS/JS page, one real static response body --------------------
 // No `\"` inside -- every HTML attribute and every JS string below uses
 // single quotes on purpose (`56_...`'s own note on this language's
@@ -913,6 +1027,10 @@ fn index_html() -> Text {
   #loading { display: none; color: #555; font-size: 0.9rem; margin-top: 0.5rem; }
   #empty-state { display: none; color: #777; padding: 1rem 0; }
   .row-actions button { padding: 0.3rem 0.6rem; font-size: 0.8rem; }
+  nav { margin: 0.75rem 0; }
+  nav button.active { outline: 2px solid #3730a3; }
+  .bar-label { font-size: 0.8rem; fill: #333; }
+  .bar-value { font-size: 0.75rem; fill: #555; }
 </style>
 </head>
 <body>
@@ -931,7 +1049,17 @@ fn index_html() -> Text {
 <div class='card' id='app-card' style='display:none'>
   <p>Signed in as <b id='who'></b> with a real signed JWT &mdash; a real <code>landing</code> rule (RFC 0010) would send this role to <span class='badge' id='landing-target'></span></p>
   <span class='badge' id='overdue-badge' style='background:#fef2f2;color:#991b1b'></span>
+  <nav>
+    <button class='role-neutral' id='nav-dashboard-btn'>Dashboard</button>
+    <button class='role-neutral' id='nav-po-btn'>Purchase Orders</button>
+  </nav>
   <button class='role-signout' id='signout-btn'>Sign out</button>
+</div>
+
+<div class='card' id='dashboard-card' style='display:none'>
+  <h2 id='dashboard-title'>Dashboard</h2>
+  <div id='dashboard-empty' style='display:none'>No data yet.</div>
+  <svg id='dashboard-chart' width='100%' height='260' style='overflow:visible'></svg>
 </div>
 
 <div class='card' id='po-card' style='display:none'>
@@ -1010,15 +1138,99 @@ function signIn(role) {
     currentOffset = 0;
     document.getElementById('login-card').style.display = 'none';
     document.getElementById('app-card').style.display = 'block';
-    document.getElementById('po-card').style.display = 'block';
     document.getElementById('who').textContent = role;
     document.getElementById('landing-target').textContent = landingTarget(role);
     document.getElementById('create-panel').style.display = (role === 'admin') ? 'block' : 'none';
     document.getElementById('actions-head').style.display = (role === 'admin' || role === 'finance_director') ? 'table-cell' : 'none';
     document.getElementById('create-status').textContent = '';
-    loadPOs();
+    // The dashboard *is* this role's landing page -- a different real
+    // chart depending on the job, shown first, not the same
+    // purchase-orders table everyone gets today.
+    showDashboard();
     loadOverdueCount();
   }).catch(function () { showError('Sign-in request failed.'); });
+}
+
+// A different real query per role (DASHBOARD_BY_ROLE), same closed
+// per-role mapping idea LANDING above already models -- not the same
+// endpoint re-labeled three times.
+var DASHBOARD_BY_ROLE = {
+  admin: { url: '/api/dashboard/admin', title: 'Spend by Vendor', labelKey: 'vendor' },
+  finance: { url: '/api/dashboard/finance', title: 'Recent Disbursements', labelKey: 'po_id' },
+  finance_director: { url: '/api/dashboard/finance_director', title: 'Large Purchase Orders (Your Approval Queue)', labelKey: 'vendor' }
+};
+
+function showDashboard() {
+  document.getElementById('nav-dashboard-btn').className = 'role-neutral active';
+  document.getElementById('nav-po-btn').className = 'role-neutral';
+  document.getElementById('dashboard-card').style.display = 'block';
+  document.getElementById('po-card').style.display = 'none';
+  loadDashboard();
+}
+
+function showPOs() {
+  document.getElementById('nav-dashboard-btn').className = 'role-neutral';
+  document.getElementById('nav-po-btn').className = 'role-neutral active';
+  document.getElementById('dashboard-card').style.display = 'none';
+  document.getElementById('po-card').style.display = 'block';
+  loadPOs();
+}
+
+function loadDashboard() {
+  var spec = DASHBOARD_BY_ROLE[currentRole] || DASHBOARD_BY_ROLE.finance;
+  document.getElementById('dashboard-title').textContent = spec.title;
+  fetch(spec.url).then(function (r) { return r.json(); }).then(function (rows) {
+    renderBarChart(rows || [], spec.labelKey, 'amount_cents');
+  }).catch(function () { showError('Failed to load dashboard.'); });
+}
+
+// A real, hand-rolled inline-SVG horizontal bar chart -- the same
+// no-external-chart-library ethos the compiler's own static UI engine
+// uses for its four built-in chart shapes (`The UI Engine` wiki page),
+// just hand-written here since this file's compiled server predates
+// `nirdosha emit-ui`'s chart renderer entirely (it's a separate, static
+// code path -- see this file's own header on why `compiled-serve`-style
+// wiring isn't attempted here either).
+function renderBarChart(rows, labelKey, valueKey) {
+  var svg = document.getElementById('dashboard-chart');
+  while (svg.firstChild) svg.removeChild(svg.firstChild);
+  document.getElementById('dashboard-empty').style.display = rows.length === 0 ? 'block' : 'none';
+  if (rows.length === 0) { svg.setAttribute('height', 0); return; }
+  var rowHeight = 32;
+  var height = rows.length * rowHeight + 10;
+  svg.setAttribute('height', height);
+  var maxValue = 0;
+  for (var i = 0; i < rows.length; i++) {
+    maxValue = Math.max(maxValue, rows[i][valueKey] || 0);
+  }
+  var chartWidth = 420;
+  var labelWidth = 140;
+  for (var i = 0; i < rows.length; i++) {
+    var y = i * rowHeight + 6;
+    var value = rows[i][valueKey] || 0;
+    var barWidth = maxValue > 0 ? (value / maxValue) * chartWidth : 0;
+    var label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+    label.setAttribute('x', labelWidth - 8);
+    label.setAttribute('y', y + 16);
+    label.setAttribute('text-anchor', 'end');
+    label.setAttribute('class', 'bar-label');
+    label.textContent = String(rows[i][labelKey]);
+    svg.appendChild(label);
+    var rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    rect.setAttribute('x', labelWidth);
+    rect.setAttribute('y', y);
+    rect.setAttribute('width', Math.max(barWidth, 2));
+    rect.setAttribute('height', rowHeight - 10);
+    rect.setAttribute('rx', 4);
+    rect.setAttribute('fill', '#2563eb');
+    svg.appendChild(rect);
+    var valueLabel = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+    valueLabel.setAttribute('x', labelWidth + barWidth + 8);
+    valueLabel.setAttribute('y', y + 16);
+    valueLabel.setAttribute('class', 'bar-value');
+    valueLabel.textContent = value;
+    svg.appendChild(valueLabel);
+  }
 }
 
 function signOut() {
@@ -1026,6 +1238,7 @@ function signOut() {
   currentToken = null;
   document.getElementById('login-card').style.display = 'block';
   document.getElementById('app-card').style.display = 'none';
+  document.getElementById('dashboard-card').style.display = 'none';
   document.getElementById('po-card').style.display = 'none';
 }
 
@@ -1151,6 +1364,8 @@ document.getElementById('admin-btn').addEventListener('click', function () { sig
 document.getElementById('finance-btn').addEventListener('click', function () { signIn('finance'); });
 document.getElementById('director-btn').addEventListener('click', function () { signIn('finance_director'); });
 document.getElementById('signout-btn').addEventListener('click', signOut);
+document.getElementById('nav-dashboard-btn').addEventListener('click', showDashboard);
+document.getElementById('nav-po-btn').addEventListener('click', showPOs);
 document.getElementById('create-btn').addEventListener('click', createPO);
 document.getElementById('search-btn').addEventListener('click', function () { currentOffset = 0; loadPOs(); });
 document.getElementById('prev-btn').addEventListener('click', function () { currentOffset = Math.max(0, currentOffset - pageSize); loadPOs(); });
@@ -1208,6 +1423,15 @@ fn main() {
         } else if method == "GET" && path == "/api/disbursements/overdue" {
             send(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\nConnection: close\r\n\r\n")
             send(conn, overdue_response_body())
+        } else if method == "GET" && path == "/api/dashboard/admin" {
+            send(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\nConnection: close\r\n\r\n")
+            send(conn, dashboard_admin_response_body())
+        } else if method == "GET" && path == "/api/dashboard/finance" {
+            send(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\nConnection: close\r\n\r\n")
+            send(conn, dashboard_finance_response_body())
+        } else if method == "GET" && path == "/api/dashboard/finance_director" {
+            send(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\nConnection: close\r\n\r\n")
+            send(conn, dashboard_director_response_body())
         } else {
             send(conn, "HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n")
         }

--- a/rfcs/0011-uniform-service-provider-model.md
+++ b/rfcs/0011-uniform-service-provider-model.md
@@ -1,0 +1,1442 @@
+# RFC 0011: A uniform service-provider model — open admission domains, revived plugin dispatch, and proactive rehydration for any future backend
+
+> **Status.** All 8 phases of the implementation checklist below have
+> landed and pass real, compiled-and-run tests — `env(...)`, the opened
+> `Domain` registry, eager startup registration, runtime scheme dispatch
+> for `db_connect`/the new `call_via` (`mq_connect_via`'s own fallback is
+> explicitly deferred, see that checklist item below, not silently
+> unfinished), `PoolRegistry<PluginManagedConnection>` with
+> credential-stripped keys and a per-provider pool-key cap, the reaper
+> (panic containment, shutdown flag, interval validation), `Effect::Env`,
+> the plugin ABI's panic/thread-safety contract, and — the closing item —
+> one real, shipped `call`-shape plugin
+> (`crates/plugin-example-native-authed-http`) built, linked, and run
+> end to end against a real local server. Five review passes hardened
+> the design before implementation began (correctness, then
+> adversarial/security, then performance); the implementation itself
+> was then verified phase by phase against real `cargo build`/
+> `cargo test` runs, not just review. **Everything this RFC's scope
+> actually covers is done; `mq_connect_via`'s fallback remains a named,
+> pointed-at follow-up, not a gap in what was promised.**
+>
+> Implementation checklist (all required before this RFC can be called
+> complete; not a mandated order):
+> - **Done (Phase 1).** `env(name) -> Result(str, str)` — the `ENV_BUILTINS` builtin, its
+>   `nir_env_get` extern, and `Effect::Env` added to `ast::Effect`'s
+>   closed set (§6, "Effect on the permission model").
+> - **Done (Phase 2a).** `Domain` opened to a runtime registry (`DOMAIN_SLOTS`, `NAME_INDEX`,
+>   `register_domain`) with `acquire`/`release` unchanged and lock-free
+>   (§3), plus the `kernel::recorder` discriminant-encoding update done
+>   in the same change, not deferred.
+> - **Done (Phase 4).** Eager, deterministic startup registration for the seven built-ins
+>   and every `build_with_native_plugins`-supplied provider (§4).
+> - **Done for `db_connect`/`call_via` (Phase 6); `mq_connect_via` explicitly
+>   deferred, not forgotten.** Runtime scheme dispatch inside `nir_db_connect`/
+>   the new `nir_call_via`, plus the plugin-provider table (`kernel::
+>   plugin_provider`), replacing any compile-time scheme match (§2).
+>   `nir_mq_connect_via`'s own fallback is deliberately out of scope for
+>   this pass — Context (above) already named it "not 'existing' the way
+>   §1 assumes" (no `nir_mq_connect_via` kernel fn exists at all yet,
+>   `mq_connect_via` is typechecked/ownership-checked but never reaches
+>   codegen). The follow-up that adds it should copy `kernel::
+>   plugin_provider::connect_conn_shape` (used by `nir_db_connect`) as
+>   its template verbatim — same `ProviderOp::ConnStream` variant, same
+>   `HandleTable<PluginConn>`, same acquire-on-`Pooled`/acquire-inside-
+>   `checkout_with_key_cap`-on-`Unpooled` split — rather than rederiving
+>   the dispatch shape from scratch.
+> - **Done (Phase 5).** `PoolRegistry<PluginManagedConnection>`, the credential-stripped
+>   `(provider, identity)` pool-key rule, the per-provider pool-key cap
+>   and its unpooled fallback (still `acquire`/`release`-bracketed), and
+>   `has_broken`'s always-`false` simplification (§5).
+> - **Done (Phase 7).** The reaper: a single self-looping `ThreadPool` job
+>   (`kernel::reaper`, its own dedicated `ThreadPool` singleton, not
+>   `lib.rs`'s user-`spawn` one), per-sweep panic containment (a
+>   `reaper_panics` counter surfaced through `dump_report`, not the outer
+>   `worker_loop` `catch_unwind` the RFC's own review pass flagged as
+>   silently ending the loop on one bad sweep), a shutdown flag (checked
+>   each wake, unused by anything today since `ThreadPool` still has no
+>   join API), `NIRDOSHA_KERNEL_REAPER_INTERVAL_SECS` floor/ceiling
+>   validation, and a rotating sweep offset. Every pool-backed registry
+>   this RFC touches (`db.rs`'s sqlite/postgres, `http.rs`'s http/https,
+>   `plugin_provider.rs`'s shared plugin registry) self-registers with it
+>   on first use via a new type-erased `pool::Sweepable` trait +
+>   `pool::register_for_reaping`/`sweep_all_registered` — a real
+>   extension beyond §5's own text, which described the mechanism but not
+>   how a `PoolRegistry<M>` actually reaches it; this closes that gap for
+>   every registry this RFC's own phases created or already had, not just
+>   the plugin one. One real gap fixed while wiring this: `pool.rs`'s
+>   `PluginManagedConnection::is_valid` never called
+>   `record_stale_rehydrated` (unlike `SqliteManager`/`PostgresManager`/
+>   `HttpManager`'s own `is_valid` impls) — it had no `domain` field to
+>   record against; Phase 7 adds one (§5's own text already assumed this
+>   parity existed).
+> - **Done (Phase 3).** The plugin ABI additions: `_is_valid`/`_close` on every shape
+>   (`call` included, via its kernel-internal `_connect`), the
+>   must-not-unwind and must-be-thread-safe contracts, and
+>   `NativePluginBuiltin::validate`'s four-functions-or-none build-time
+>   check (§2).
+> - **Done (Phase 8).** At least one real plugin built and run against this ABI end to
+>   end — RFC 0008 Phase 4's own still-open ask, which this RFC is — the
+>   same bar RFC 0008 Phase 1 itself shipped with
+>   `crates/plugin-example-native-shout`/`-native-kv`: a real,
+>   separately-compiled `call`-shape crate
+>   (`crates/plugin-example-native-authed-http`), linked into a real
+>   `nirdosha build` output, making a genuine `TcpStream`-backed HTTP/1.1
+>   request with an `Authorization: Bearer <token>` header sourced from
+>   the process environment at connect time — the concrete gap this
+>   RFC's own Motivation names (`http_get`/`http_post`/`call_via`'s two
+>   core-served schemes have no way to set a custom header from `.nir`).
+>   Proven by `crates/compiler/tests/native_plugin_examples.rs`'s
+>   `the_shipped_authed_http_plugin_compiles_and_makes_a_real_authenticated_request`
+>   (a real local `tiny_http` server on an ephemeral port observes the
+>   real header) and, once more, by hand: the same compiled binary run
+>   standalone against an independent local server process, watching the
+>   request land live.
+>
+> All 8 phases (env, the open domain registry, eager registration, the
+> plugin provider contract, `db_connect`/`call_via`'s runtime dispatch,
+> pooling, the reaper, and one real end-to-end plugin) have landed and
+> pass real, compiled-and-run tests
+> (`crates/compiler/tests/native_plugin_codegen.rs`,
+> `crates/compiler/tests/native_plugin_examples.rs`,
+> `crates/runtime-kernels/src/kernel/pool.rs`'s and `reaper.rs`'s own
+> test modules). `mq_connect_via`'s own runtime fallback is the one
+> item explicitly out of scope for this RFC's phases — see that
+> checklist item above for the template a follow-up should copy.
+
+## Motivation
+
+Every external service Nirdosha consumes today (`db`, `mq`, `http`/
+`https`, the identity builtins) got there the same expensive way: a
+hand-written `Ty`, a hand-written set of builtins in `ast::BUILTIN_NAMES`,
+a hand-written `typeck.rs` signature, a hand-written `codegen.rs` `emit_*`
++ `declare`, and a hand-written `runtime-kernels` implementation wired
+into a *closed* `Domain` enum (`kernel/mod.rs:141`, currently `Tcp`,
+`File`, `Thread`, `Db`, `Mq`, `Http`, `ServeHttp`). That's a real,
+deliberate design for the handful of backends that justify a compiler
+change — but it doesn't scale to "whatever Nirdosha may be asked to
+consume next" (object storage, a payment API, an external OIDC IdP,
+anything), and nothing today lets a new backend show up without
+touching the compiler.
+
+This isn't a green-field problem. Three prior efforts in this repo
+already converged on pieces of the answer, independently, and this RFC
+is the work of finishing and connecting them, not inventing a fourth
+mechanism:
+
+- **ADR 0004** built exactly the right dispatch shape — a `scheme://`
+  connection string routed to a plugin by naming convention
+  (`db_provider_mysql_connect`, `mq_provider_stomp_connect`) — proved
+  against real MySQL and ActiveMQ containers. It died the next day when
+  the tree-walking interpreter it depended on (`PluginFn`, `self.plugins`)
+  was deleted (`c82fa1f`). The ADR's own note says the shape is still
+  right, "whenever `db`/`mq` gain compiled-path codegen and a revived...
+  plugin mechanism." `db`/`mq`'s compiled-path codegen now exists
+  (`emit_db_connect`/`emit_mq_connect`, real `nir_db_*`/`nir_mq_*`
+  kernels). The revived plugin mechanism is what §2 below is.
+- **RFC 0008** built the compiled-path plugin ABI itself —
+  `crate::plugin::NativePluginBuiltin` — a third-party crate exports
+  plain `#[no_mangle] extern "C"` functions over scalars/`str`/
+  `handle(Kind)`, precompiled to a staticlib, and `codegen.rs`'s
+  existing `sigs`-driven call dispatch links and calls it with zero
+  special-casing. Its own status box names Phase 3 (Cargo-driven
+  auto-discovery) and Phase 4 (a real external-I/O plugin ported onto
+  this ABI) as open. This RFC is that Phase 4, with the admission/
+  rehydration requirements below folded in.
+- **RFC 0007** named, but never built, "the compiler-side manifest
+  pass... declared bounds feed the kernel's ceilings instead of the
+  current hardcoded default" (§10, row "Manifests"). It also already
+  built — and left explicitly unwired — the two generic primitives a
+  uniform model needs: `kernel::HandleTable<T>` and
+  `kernel::pool::PoolRegistry<M: r2d2::ManageConnection>`, both
+  documented as built "for the next resource domain... instead of
+  inventing its own table," and `kernel::thread_pool::ThreadPool`,
+  "the exact deadlock-avoidance design `rfcs/0006`'s spawn/join
+  concerns need."
+
+What's requested, restated precisely against that background:
+
+1. One uniform way to add a future service, not a bespoke compiler
+  change per vendor — matching JMS's "write once against the shape,
+  swap the vendor" model (a `.nir` program calls `db_connect`, never a
+  vendor-named function; the vendor lives only in the URL scheme).
+2. That uniform way must never add a blocking wait anywhere in the
+  admission path. [[nirdosha_admission_kernel_nonblocking]]:
+  `kernel::acquire` is fail-fast CAS, never blocks. This is a hard
+  invariant, not a starting point to negotiate from — see "Rejected
+  alternatives" for why the closest Java precedent (JCA's blocking
+  pool checkout) is explicitly not the model. **Scoped precisely,
+  since a later review pass rightly pushed on this**: the invariant is
+  about `kernel::acquire`'s own CAS decision, which this RFC keeps
+  instantaneous for every domain it adds. It does *not* — today,
+  already, in shipped `db.rs`/`http.rs` — extend to pool *checkout*:
+  `pool.get()` blocks up to `connect_timeout` (default 5s) waiting for
+  a free connection when a pool is exhausted, one layer below
+  `acquire`. That's real, and this RFC's plugin providers inherit it
+  unchanged rather than resolving the tension — see §5 for the fuller
+  discussion and "Open questions" for whether checkout should also
+  move to fail-fast.
+3. Config (URLs, credentials) must be sourceable from the process
+  environment, not hardcoded in `.nir` source — today neither exists;
+  every `db_connect`/JWT secret in `examples/features/
+  57_nirdosha_ops_console_server_v2.nir` is a literal.
+4. The kernel should have a live catalog of every service a program
+  depends on, and proactively keep pooled connections healthy — not
+  just discover staleness reactively, the first time a caller happens
+  to check one out. [[nirdosha_pool_rehydration_requirement]]'s
+  original ask (db/http rehydration) already shipped
+  (`kernel/db.rs`'s `SqliteManager`/`PostgresManager::is_valid`,
+  `kernel/http.rs`'s `HttpManager`/`HttpsManager::is_valid`, both
+  calling `record_stale_rehydrated`) — but strictly lazily, on
+  checkout. Nothing watches a pool while it's idle, and nothing knows
+  a provider exists before the first connect.
+
+## Threat model
+
+Added after a review pass pointed out that severity judgments about
+this design are meaningless without stating who the adversaries are —
+worth pinning down before the findings below, not after:
+
+- **A `NativePluginBuiltin` plugin is build-time trusted, not an
+  adversary.** It's native code, statically linked into the host binary
+  by whoever built it — it can already do anything the host process
+  can do, with or without this RFC. "Malicious plugin" isn't a useful
+  threat to design against here; **buggy plugin** and **compromised
+  build pipeline** are the real, in-scope concerns (a panic, a resource
+  leak, a slow `is_valid` — not a plugin deliberately attacking its own
+  host).
+- **The `.nir` program is the real tenant adversary.** It may be
+  third-party code running against operator-linked plugins and
+  operator-set env vars — a multi-tenant `serve` deployment is the
+  concrete case this matters for. Most of the findings below are
+  **tenant → operator** attacks: a `.nir` program doing something
+  within its type-checked rights that costs the operator more than
+  intended (holding resources, reaching a provider it shouldn't,
+  exhausting a shared pool).
+- **The external endpoint** (a DB server, an S3 bucket, an IdP) may be
+  hostile or compromised — already true today for `db`/`http`, not new
+  to this RFC, but worth stating since a `call`-shape plugin's whole
+  purpose is reaching arbitrary such endpoints.
+- **Env/config knobs are operator-controlled**, not tenant-controlled —
+  but this RFC adds several new ones, and "operator-controlled" isn't
+  the same as "validated"; a typo'd operator value shouldn't degrade
+  into something worse than the default.
+- **One pre-existing gap worth naming so silence isn't mistaken for
+  oversight**: the `sqlite` bare-path arm (§2 — `db_connect("/any/path")`,
+  no `://` to sniff) is arbitrary filesystem read/write via SQLite,
+  today, for any `.nir` program that can reach `db_connect` at all — the
+  sharpest tenant→operator capability in the entire built-in set. It
+  predates this RFC, and this RFC neither widens nor narrows it; it's
+  named here only so a reader doesn't mistake this document's silence
+  on it for having missed it.
+
+## Design
+
+### 1. Three resource shapes, not one builtin set per vendor
+
+`db` (request/response), `mq` (streaming pub/sub), and `http`/`https`
+(one-shot, no handle) are already, structurally, the three shapes ADR
+0004 proved generalize across vendors (MySQL as a second `db`-shaped
+backend, ActiveMQ/STOMP as a second `mq`-shaped backend). This RFC
+keeps that as a closed set for now, on the same terms `Domain`'s own
+doc comment already states for itself: *"Add one here... exactly when a
+real resource needs it — not speculatively ahead of that."* A fourth
+shape is a future RFC/ADR decision with a real backend behind it, not
+something this document tries to pre-enumerate.
+
+Every future service is one of these three shapes. A `.nir` program
+never sees a vendor name in a builtin name — only in the connection
+string it passes to `env(...)` (§6).
+
+**Naming the `.nir`-facing entrypoint for each shape, pinned here since
+an earlier draft left `call`'s unnamed** — a real gap, not a nit, found
+by trying to write an actual example against this design and
+discovering there was nothing to call. `conn` uses the existing
+`db_connect(url)`; `stream` uses the existing `mq_connect_via(url)`
+(ADR 0004's own precedent: a new, `_via`-suffixed entrypoint alongside
+`mq_connect`'s original fixed `(host, port)` shape, rather than
+overloading it). `call` gets the identical treatment, one new builtin,
+named `call_via` rather than after one specific scheme — an earlier
+draft called this `https_request_via`, which bakes an http-shaped bias
+into what's actually the generic `call`-shape dispatch entrypoint (it
+falls through to *any* registered `call`-shape plugin, not just
+HTTP-flavored ones — an `s3://`, `authedhttp://`, or any other scheme a
+plugin registers); `call_via` matches the `conn`/`stream`/`call` shape
+vocabulary this section already uses, and the `_via` suffix precedent
+`mq_connect_via` already sets for "a fixed-shape builtin plus a
+scheme-dispatched `_via` sibling":
+`call_via(url: str, path: str, body: str) -> Result(HttpResponse, str)`
+— scheme-sniffed exactly like the other two (§2), falling through to a
+registered `call`-shape plugin when the scheme isn't plain `http`/
+`https`. Core `http_get`/`http_post`/`https_get`/`https_post` are
+untouched and keep their existing fixed `(host, port, path[, body])`
+shape — `call_via` is additive, the same relationship `mq_connect_via`
+already has to `mq_connect`. Reusing `Result(HttpResponse, str)` as
+`call_via`'s return type is a deliberate lowest-common-denominator
+reuse of an existing shape (`ast.rs`'s `prelude_structs()` already
+injects `HttpResponse { status: i64, body: str }` the same way
+`http_get`/`http_post` return it today), not a claim that
+`call_via("smtp://...")` is HTTP underneath — a non-HTTP provider (an
+SMTP gateway, say) returning `{status, body}` through `call_via` is
+just reusing the closest-shaped existing struct, so a `.nir` reader
+should not read the return type as implying an HTTP response is always
+what comes back.
+
+### 2. Provider dispatch: runtime, not compile-time — the correction that matters most
+
+An earlier draft of this section had `codegen.rs` scheme-sniffing a
+`.nir` call site's `str` argument **at compile time** and emitting a
+direct `call`/`declare` against whichever `NativePluginBuiltin` matched
+— the same shape ADR 0004's interpreter-side `match` had. That's wrong
+for exactly the reason §6 exists: `db_connect(env("DATABASE_URL"))`
+means the scheme isn't known until the program *runs* and reads that
+variable. `codegen.rs` sees a call to `db_connect` with an `env(...)`
+expression as its argument — it cannot sniff `"mysql://..."` out of
+that string, because that string doesn't exist until runtime. A review
+pass caught this (framed as "`handle(Kind)` can't distinguish
+providers," since the identical gap resurfaces one call later, at
+`db_query` time — see below), and correctly enough — the fix goes
+deeper than a patch: **all** scheme dispatch moves to runtime, inside
+the kernel, not into `codegen.rs`'s call-site codegen at all.
+
+**What stays exactly as it is today.** `db_connect`/`db_query`/
+`db_execute`/`stop` (and `mq`'s/`http`'s equivalents) each compile to
+one fixed extern call, unchanged from current `codegen.rs` —
+`nir_db_connect(url_ptr, url_len, ...)`, `nir_db_query(handle, sql_ptr,
+sql_len, ...)`, and so on. No new `match` in codegen, no per-scheme
+`declare`. This is the real home of the "zero new dispatch machinery"
+claim the earlier draft made in the wrong place — it's true of
+`codegen.rs`, just not for the reason that draft gave.
+
+**What's new: a runtime provider table, populated once at process
+start (§4).** Every `nir_db_connect`/`nir_db_query`/... Rust
+implementation, given a runtime string or handle id, does this, all
+inside the kernel:
+
+1. `nir_db_connect(url, ...)`: check built-in schemes first (SQLite
+  path/`:memory:`, `postgres://`/`postgresql://`), exactly as today.
+  If none match, normalize the scheme (below) and look it up in a
+  process-wide `static PLUGIN_PROVIDERS: OnceLock<HashMap<&'static
+  str, ProviderFns>>`, populated once at startup (§4; never from
+  anything runtime-only). Found → **check out from
+  `PoolRegistry<PluginManagedConnection>` (§5), keyed by the
+  credential-stripped identity below — the same `get_or_create`-then-
+  `pool.get()` shape core `db`'s own `postgres_pool_registry()...`
+  (`db.rs`) already uses**; `connect_fn` runs only when that checkout
+  grows the pool, never called directly by `nir_db_connect` itself.
+  `kernel::acquire(domain)` brackets the checkout, not the pool's
+  growth (§5's ceiling section states this precisely — an earlier
+  draft said "on pool growth" here, which was wrong, and is corrected
+  in both places). The checkout is wrapped in the kernel-owned
+  `HandleTable<PluginConn>` (below); that table's id is returned as
+  the `handle(Kind)` value. Not found → the real, disclosed "no
+  provider registered for scheme X" error ADR 0004's own
+  "Consequences" section already named as this convention's one honest
+  cost — the error echoes only the **normalized scheme** (the part
+  before `://`, never the full URL), so it can never leak a credential
+  even though it does echo tenant-controlled input — now hit at
+  runtime, on a real string, exactly the way the
+  interpreter-side version of this mechanism always worked (the
+  earlier draft's actual mistake: ADR 0004's own dispatch was never
+  compile-time — the interpreter evaluated the argument to a
+  `Value::Str` and pattern-matched its *content* during execution,
+  which is runtime dispatch already; this RFC's compiled-path version
+  needed to match that, not invent a static `match` in `codegen.rs`).
+2. `nir_db_query(handle, sql, ...)`/`nir_db_execute`: look up `handle`
+  — core `db_table()` first, then `HandleTable<PluginConn>` on a miss,
+  the same priority built-in schemes already get in step 1; a miss in
+  *both* is the same invalid-handle error every kernel boundary
+  already returns for a bad id, not a new error kind. If found in
+  `HandleTable<PluginConn>`, read *that entry's own recorded*
+  `ProviderFns` and call its `op_fn` — never anything resolved from
+  the call site. This is what makes the cross-provider mixup the
+  review named structurally impossible, rather than merely checked: no
+  code path calls a provider's `_op` based on anything but what that
+  specific handle was given at `_connect` time. A "validate
+  `PluginConn.provider == the op's provider`" check, as originally
+  proposed as a patch on top of a compile-time-resolved call, isn't
+  needed as a separate step, because there is no compile-time-resolved
+  call to validate against — the handle's own table entry *is* the
+  only source of which function pointer ever gets called for it.
+  `stop` **returns the checkout to the pool** (removes the entry from
+  `HandleTable<PluginConn>`, then drops the `PooledConnection` guard it
+  held) rather than calling `close_fn` directly — `close_fn` only ever
+  runs where r2d2 already runs it: `has_broken`-triggered eviction on
+  put-back, r2d2's own internal idle/lifetime reaping, or this RFC's
+  reaper sweep (§5). This mirrors exactly how core `db`'s pooled
+  connections already behave, not a new lifecycle invented for
+  plugins.
+
+**Handle ownership is kernel-owned, not plugin-owned** (unchanged
+conclusion from the previous draft, now more clearly load-bearing): the
+kernel keeps one `HandleTable<PluginConn>` per shape (the same role
+`db_table()` plays for core `db`), `PluginConn` pairing the plugin's
+raw `i64` with the `ProviderFns` it was connected through. `.nir` code
+only ever holds the kernel's table id; a plugin's four functions (below)
+only ever receive the raw `i64` the kernel unwraps for them — on every
+call into the plugin, not just `_connect`'s return.
+
+**A stale handle id resolving to a different provider's connection —
+checked against the real `HandleTable<T>`, not assumed safe.** A review
+pass raised exactly the right concern: the "dispatch is structurally
+safe" argument above only holds if a closed handle's id can never be
+reassigned to a later, unrelated connection — otherwise a tenant
+holding a stale id from a closed S3 handle could have that same id land
+on a freshly opened MySQL handle's table slot, and the kernel would
+dispatch the *right* function pointers for the *wrong* logical handle.
+Checked against the actual, already-shipped `HandleTable<T>`
+(`kernel/mod.rs`, not new machinery this RFC needs to invent): `insert`
+mints an id via `next_id.fetch_add(1, Ordering::Relaxed)`, and `remove`
+only deletes the map entry — `next_id` is never decremented, reset, or
+returned to a freelist. Ids are monotonically unique for the life of
+the process; a removed id is never handed out again, by construction,
+not by convention or by a generational tag this RFC needs to add. This
+makes the concern moot for both core and plugin handles as they already
+exist, not something to newly design a fix for. One honest residual
+note, for completeness rather than because it's a real risk: the id
+space is a 63-bit positive `i64` range, and `fetch_add` never wraps in
+practice — same "generous, not tuned" posture as `MAX_DOMAINS`
+elsewhere in this document.
+
+**Pool keys, and `PluginConn`, must carry a credential-stripped
+identity — not the raw URL.** Two separate concerns land on the same
+fix. First: `PoolRegistry` keyed by provider name alone (as an earlier
+draft implied) means `db_connect("postgres://admin:pw@host/db1")` and a
+later `db_connect("postgres://readonly:pw2@host/db2")` — same provider,
+same pool — would silently reuse a physical connection opened under one
+identity to serve queries intended for a different user or database: a
+confused-deputy privilege escalation, worse for a plugin provider where
+a URL is more likely to carry distinct credentials (an S3 key pair, an
+OIDC client secret) than for core `db`. Second: a raw URL, password
+included, living in a pool key or a `PluginConn` for the process's
+whole lifetime is a real, if low-probability, exposure surface (core
+dumps, `/proc` memory, an accidental future `dump_report` leak). One
+rule fixes both: the pool key — and anything `PluginConn`/`HandleTable`
+retains past the `_connect` call — is **`(provider, credential-stripped
+identity)`**, not `(provider,)` and not the raw URL.
+"Credential-stripped identity" means the parsed `scheme://user@host:port/path`
+with the password component removed but the *username* kept (a
+different user is a different privilege scope, so it must still key a
+different pool). **Rescoped, since a review pass correctly caught
+that the previous wording can't survive contact with pooling itself**:
+the claim was "the raw URL is used once, at `_connect`, and never
+retained afterward" — but r2d2 redials by calling
+`ManageConnection::connect()` with no arguments, repeatedly, over the
+pool's whole life (after an `is_valid` failure evicts a connection, on
+ordinary pool growth, on a reaper-triggered top-up) — so the adapter
+*must* hold the full URL, password included, for the pool's entire
+lifetime to be able to redial at all. This doesn't sink the underlying
+argument, it just scopes it correctly: the boundaries that actually
+matter are that the raw URL never appears in a pool **key**, never in
+`PluginConn`/`HandleTable`, and never in anything `dump_report` or an
+error message prints (§6, §2's error-message rule) — not that it's
+discarded outright. It necessarily lives inside the pool manager
+itself (`PluginManagedConnection`, or core `PostgresManager` today,
+which is equally unable to redial without retaining its own URL) for
+as long as the pool exists — the same posture every shipped core
+manager already has, not a new exposure this RFC introduces. The
+core-dump/`/proc`-memory concern from the previous draft is still
+real at *that* narrower scope (a live process's memory always holds
+what it needs to redial) — worth stating honestly as a residual,
+disclosed cost, not something this rule eliminates. One more
+component needed pinning, not left implicit: the **query string is
+excluded from the identity too**, not just the password — a query
+string is exactly where SAS-token-style URLs (`?token=...`,
+`?api_key=...`) carry credentials in real-world convention, and the
+whole point of this rule is to never retain one past the connect call.
+The disclosed cost, stated rather than hidden: two URLs differing only
+in query parameters share a pool, including a parameter that's actually
+connection-affecting (`?sslmode=require`) rather than secret — a
+provider for which that distinction matters must fold the affecting
+parameter into the host/path portion of its own identity computation
+itself (a provider-specific normalization choice), rather than relying
+on this kernel-generic default to separate them. This is a correction
+to how `PoolRegistry::get_or_create`'s `key: &str` argument must be
+constructed for every provider this RFC adds, core and plugin alike —
+not a new data structure.
+
+**A real operational trap this identity rule creates, worth one line
+rather than discovering it during an incident**: rotating a password
+without changing user/host/path is, correctly, *not* a new identity —
+same pool, same physical connections. `db_connect("postgres://admin:pw1@h/db")`
+then, after a rotation, `db_connect("postgres://admin:pw2@h/db")` share
+a pool; the second caller silently gets connections still authenticated
+as `pw1` until the pool evicts them (idle/lifetime timeout, an
+`is_valid` failure) or the process restarts. This is the correct
+consequence of "same user is the same privilege scope," not a bug in
+it — but operators rotating a credential behind an unchanged
+user/host/path should treat that rotation as requiring a rolling
+restart, and a provider that needs rotation to take effect immediately
+must fold a versioned credential tag into its own identity computation
+instead of relying on this default rule.
+
+**Scheme → identifier normalization, spelled out exactly** (schemes
+aren't identifiers — they carry `+` suffixes, case variance, ports):
+take the substring before `://`, lowercase it, map `+`/`.`/`-` to `_`.
+`mysql+tls://...` → `mysql_tls`; `POSTGRESQL://...` → `postgresql`.
+Built-in scheme identifiers, pinned exactly rather than left implicit
+(this is the set a plugin may *not* register): `sqlite` (a bare path or
+`:memory:` — no `://` to strip; a fallback rule, not a normalized
+scheme), `postgres`, `postgresql`, `redis`, `http`, `https`. Two
+collision rules, both caught at build time, both loud rather than
+silent: a plugin scheme that normalizes to one of those six loses
+outright; two plugins whose schemes normalize to the *same* identifier
+as each other are equally ambiguous and both rejected —
+`build_with_native_plugins` fails the build in either case, naming the
+colliding identifier, never picking a winner silently.
+
+**A shape's plugin contract is four functions or none, checked at
+build time.** `NativePluginBuiltin::validate` (RFC 0008 Phase 1's real
+gate, already running before a build links) gains one more rule:
+registering `<shape>_provider_<scheme>_connect` without matching `_op`/
+`_close`/`_is_valid` (§5) for the same prefix fails the build
+immediately, naming the missing function — not a runtime surprise.
+
+**The `call` shape's contract was incoherent in the previous draft, and
+it's the shape most exposed to abuse — fixed, not just patched.** The
+previous draft gave `call` three functions (`_request`/`_is_valid`/
+`_close`, no `_connect`) while also claiming the kernel keeps an
+"internal pooled connection keyed by host" for it — but
+`PluginManagedConnection` (§5) needs a `connect_fn` to create anything
+poolable, and a three-function contract doesn't supply one. Left as
+written, that meant one of two bad outcomes: either the kernel can't
+actually pool `call`-shape plugins at all (the pooling sentence was
+dead spec), or `_request`'s own text — "the plugin either dials
+per-request or manages its own keep-alive internally" — is literally
+true, meaning a `call`-shape plugin's connection footprint is invisible
+to the kernel: no `Domain` accounting, no ceiling, no reaper, no
+rehydration. That's exactly backwards: `call` is the shape whose whole
+purpose is reaching arbitrary tenant-specified external URLs (§ Threat
+model), so it's the worst possible place for admission to go dark — a
+tenant pointing an `http`-shaped plugin at a URL of its choosing could
+hold unbounded connections with nothing to stop it.
+
+`call`-shape plugins matter for a second, independent reason worth
+naming, found while working through a concrete example (a payment
+gateway): core `http_post`/`https_post` have **no way to set a request
+header at all** — `typeck.rs`'s own signature is `(host, port, path,
+body)`, nothing else, and `nir_http_post`'s `declare`d LLVM signature
+matches. The underlying kernel (`http.rs::request_bytes`) *can* attach
+`Authorization: Bearer <token>`, but only the notify subsystem's own
+internal call path ever passes that argument — it's unreachable from
+any public `.nir` builtin. So today, `.nir` code cannot make an
+authenticated REST call at all, to anything, full stop — not a gap
+`env(...)` closes by itself. A `call`-shape plugin's `_request`
+function is native code with no such restriction: it can build whatever
+headers it needs internally, with a credential sourced via `env(...)`
+at connect time. This is the concrete reason a `call`-shape plugin, not
+core `https_post`, is how something like a payment gateway integration
+would actually have to be built under this design — noted here as a
+real, disclosed limitation of core `http`, not something this RFC
+claims to fix.
+
+The fix: `call` gets the same four-function contract as `conn`/`stream`
+after all, just not a `.nir`-visible one.
+`<call>_provider_<scheme>_connect(host: str) -> i64` dials (or
+otherwise prepares) one keep-alive session to a *host*, not a full
+per-request URL — called only by the kernel's own
+`PluginManagedConnection` adapter to populate
+`PoolRegistry<PluginManagedConnection>`, exactly mirroring what
+`HttpManager::connect` already does for core `http` (a real TCP dial,
+keyed by host, that `.nir` code never sees or triggers directly).
+`<call>_provider_<scheme>_request(raw_conn: i64, path, ...) -> str`
+replaces `_op`, operating on that pooled connection. `_is_valid`/
+`_close` are unchanged in shape from `conn`/`stream`. This restores
+real admission: exactly like core `http` today (`Domain::Http`'s own
+doc comment: "admission is held for the duration of one pooled
+checkout"), `kernel::acquire(domain)` brackets *each `_request` call's*
+own internal checkout — acquired when `_request` checks a connection
+out of `PoolRegistry<PluginManagedConnection>`, released when that call
+returns it — not held across multiple calls the way `conn`/`stream`'s
+session-scoped bracketing is (step 1 above; an earlier draft said "on
+pool growth" in both places, conflating session-scoped and
+per-request-scoped admission — corrected in both now).`connect_fn`
+still only runs when a checkout actually grows the pool. A `call`-shape
+plugin's concurrent *requests* are therefore ceiling-bound exactly like
+core `http`, and every pool it grows is reaper-swept exactly like
+`db`/`mq` — the gap the review named is closed by giving `call` the
+same admission path core `http` already has, not by declaring it out of
+scope.
+
+**A plugin function must never unwind across its own `extern "C"`
+boundary — this is a hard contract, not a kernel-side safety net.** All
+four ABI functions (`call`-shape included, now that its `_connect` is
+kernel-internal rather than absent) are plain `extern "C"`,
+not `extern "C-unwind"`. Per this crate's own already-established
+understanding of that distinction (`thread_pool.rs`'s doc comment:
+unwinding across a plain `extern "C"` boundary is a *defined abort at
+that boundary* since Rust 1.71 — not UB, but also not something a
+caller-side `catch_unwind` can intercept, because the abort happens
+inside the plugin's own frame before control ever returns to the
+kernel). That means a panic escaping a plugin's own Rust implementation
+of `is_valid_fn`/`connect_fn`/etc. takes down the **entire process**,
+not just the call — there is no kernel-side mitigation possible against
+this ABI, the same way `NativePluginBuiltin::validate`'s scalar-only
+restriction (RFC 0008 Phase 1) exists because some ABI questions are
+hard, not because they're solved. So this is a stated plugin-author
+contract, alongside `is_valid_fn`'s fail-fast requirement: a plugin
+written in Rust must wrap its own function bodies in `catch_unwind`
+internally and translate any panic into this ABI's existing error
+conventions (the 0/1/negative sentinels every other kernel boundary
+already uses) before returning across the FFI edge. Unenforceable by
+the kernel, same as `is_valid_fn`'s fail-fast requirement — a
+documented hazard, not a silent one. (§5 covers the separate, related
+question of what happens if a panic reaches the *reaper's own* code,
+not a plugin's.)
+
+**A plugin's four functions must be safe under concurrent invocation on
+the same raw `i64`.** `&handle(Kind)` is a real, already-allowed borrow
+form (`plugin.rs`'s own doc comment: "a *read* of a stateful resource
+must **borrow**, not consume"), and a borrowed handle can be captured
+by more than one concurrently spawned `.nir` thread — meaning the
+kernel can call a provider's `_op`/`_is_valid`/`_close` concurrently
+against the same raw `i64` in a well-typed program. This isn't new to
+plugins — the identical question already applies to any core `db`/`mq`
+handle held across `spawn` — and this RFC deliberately doesn't add
+kernel-side per-handle locking to answer it: a lock on the hot path
+would reintroduce exactly the blocking-under-contention primitive
+"Rejected alternatives" rules out for JCA, just relocated. So this is
+also a stated contract, not a kernel guarantee: a provider's four
+functions must be internally thread-safe (or the provider must document
+that a handle from it isn't safe to share across spawned threads) —
+consistent with `ownership.rs`'s general "the checker is the real gate"
+posture (its own doc comment) rather than runtime locking.
+
+**Where a plugin provider's admission ceiling and env var come from.**
+`register_domain(name, env_var, default_max)` (§3) needs both, and the
+compiler can't invent a plugin author's preferred values. Convention
+plus override: absent anything more specific, a plugin provider gets
+`NIRDOSHA_KERNEL_MAX_<SHAPE>_<NORMALIZED_SCHEME>` (uppercased) and the
+same `default_max` (10,000) every built-in domain already uses. A
+plugin author who wants something different attaches it as two more
+fields alongside the existing `name`/`params`/`ret`/`static_lib` on
+that provider's registration metadata — read once, at the single
+startup registration point (§4), never guessed by the compiler and
+never overridable from a second, independent code path (§4 explains
+why there's only one such path now).
+
+Cargo-driven auto-discovery (RFC 0008 Phase 3) is a real dependency for
+this to feel uniform in day-to-day use — without it, wiring a new
+plugin still means hand-editing the `build_with_native_plugins` call
+site. This RFC doesn't attempt that work; see "Open questions."
+
+### 3. Opening `Domain`: same non-blocking CAS, no longer a hardcoded match
+
+`Domain` becomes a registry instead of a closed enum, **without
+introducing a lock anywhere `acquire`/`release` touch** — an earlier
+draft of this section sketched `counters_for`'s hardcoded `match`
+becoming a `static REGISTRY: OnceLock<Mutex<Vec<(&'static str,
+DomainCounters)>>>` indexed by `DomainId`. That's wrong: a `Mutex` on
+the acquire path is exactly the blocking primitive "Rejected
+alternatives" rules out for JCA, reintroduced quietly by the registry
+mechanism itself rather than by anything provider-specific. The fix is
+splitting the rare write path (registration) from the hot read path
+(acquire/release):
+
+```rust
+const MAX_DOMAINS: usize = 4096; // generous, not tuned — same posture
+                                  // Domain::default_max already has
+
+static DOMAIN_SLOTS: [DomainCounters; MAX_DOMAINS] =
+    [const { DomainCounters::new() }; MAX_DOMAINS];
+static NEXT_DOMAIN: AtomicU32 = AtomicU32::new(0);
+// Registration-time only — never touched by acquire/release/stats.
+static NAME_INDEX: OnceLock<Mutex<HashMap<&'static str, DomainId>>> = OnceLock::new();
+
+pub struct DomainId(u32); // opaque index into DOMAIN_SLOTS
+
+/// Idempotent: a second call with the same `name` returns the same
+/// `DomainId` — kept as a defensive property even though §4's single
+/// eager registration pass is, in practice, the only caller. Takes
+/// `NAME_INDEX`'s lock via `lock().unwrap_or_else(|e| e.into_inner())`,
+/// never a bare `.unwrap()`: a panic while holding this lock (an
+/// allocation failure inside the `HashMap`, say) would otherwise
+/// poison it permanently, turning one transient fault into "no new
+/// provider can ever register again" for the rest of the process — the
+/// map it guards is just a name→id lookup, safe to keep using after a
+/// panic. `NEXT_DOMAIN.fetch_add` happens *inside* this lock, after
+/// checking whether `name` is already present — never before — so two
+/// duplicate `register_domain("db", ...)` calls burn exactly one slot
+/// between them, not one each.
+pub fn register_domain(name: &'static str, env_var: &'static str, default_max: i64) -> DomainId;
+
+pub fn acquire(domain: DomainId) -> bool {
+    let counters = &DOMAIN_SLOTS[domain.0 as usize]; // plain array index, no lock
+    // ... identical CAS loop to today's acquire, unchanged
+}
+pub fn release(domain: DomainId);                        // same array index, no lock
+pub fn stats(domain: DomainId) -> (i64, u64, u64, u64);   // same, no lock
+pub fn record_stale_rehydrated(domain: DomainId);         // same, no lock
+```
+
+**Decided: opaque `u32`, as sketched above — not an interned string
+key.** An earlier draft left `DomainId`'s representation open against
+an interned-string alternative; the string alternative buys nothing the
+registry doesn't already provide via `NAME_INDEX` (name → id is already
+a real, available lookup for anything that needs the name back), and a
+`u32` is what makes `DOMAIN_SLOTS`'s plain array indexing possible at
+all. This also settles `kernel::recorder`'s existing discriminant-based
+domain encoding, which an earlier draft treated as separate, deferred
+follow-up work: it isn't separate — it's a mechanical part of *this*
+change, done in the same pass as the rest of §3, not after it, since
+both of `dump_report`'s real consumers (§ Compatibility) are already
+being updated alongside this RFC regardless. If a binary (non-text)
+encoding of domain identity ever exists somewhere, it gets a version
+bump and a string table the same way any other format change would;
+today's flight-recorder text output already carries names, not raw
+discriminants, so nothing downstream of *that* format needs to change
+at all.
+
+`acquire`/`release`/`stats`/`record_stale_rehydrated` index straight
+into the static array — the exact same lock-free CAS-on-a-static shape
+`TCP`/`FILE`/... already have today, just addressed by a `u32` instead
+of hardcoded per-name. The seven existing domains are registered eagerly,
+at fixed indices 0–6 in `main`'s preamble (§4 — not "at first use";
+that phrasing here was never updated when §4 settled on eager
+registration, and this is the correction), as `DomainId` constants
+behind the same names (`domain::DB`, `domain::HTTP`, ...) so every
+existing call site
+(`kernel::acquire(Domain::Db)`) becomes `kernel::acquire(domain::DB)`
+with identical behavior, identical env var names
+(`NIRDOSHA_KERNEL_MAX_DB` unchanged), identical default ceiling. This is
+additive to the CAS mechanism, not a rewrite of it — the non-blocking
+guarantee is a property of `acquire`'s loop body, which stays untouched;
+only the one-time registration path gains a lock, and nothing on the
+`acquire`/`release` path ever waits on it. `MAX_DOMAINS` is a real,
+disclosed limit (same posture as `Domain::default_max`'s own
+"deliberately generous, not tuned") — registering past it is a loud
+**startup-time** error. (Deliberately back to this wording: a previous
+correction pass changed it to "registration-time" on the assumption
+that registration was lazy and could happen at any point in a running
+process; §4's own correction below removes that lazy path entirely —
+every provider now registers during `main`'s preamble, so exceeding
+`MAX_DOMAINS` is always caught before any `.nir` code runs, never
+sprung on a connect months into a long-running process.)
+
+`register_domain`'s `name` argument is the registry key, so every
+caller must agree on its exact spelling or the same provider silently
+burns two slots under two names. Canonical form, pinned here rather
+than left implicit: for a built-in domain, the existing bare name
+(`"db"`, `"mq"`, `"http"`, ...); for a plugin provider,
+`<shape>_provider_<normalized_scheme>` — the identical string §2's
+collision rule already normalizes and matches against built-in names.
+§4's single eager registration pass is the only caller of
+`register_domain` for either kind, using the exact same normalization
+function §2's runtime dispatch also uses — one function, not two
+independent implementations that could drift apart on spelling.
+
+This is also the literal answer to "the kernel should know what's
+what": `register_domain` **is** the catalog. A new
+`kernel::registered_domains() -> Vec<(&'static str, DomainId)>` (reading
+`NAME_INDEX`, itself only ever consulted off the hot path) gives
+`dump_report`/the flight recorder/§5's reaper a live enumeration of
+every service the running program actually depends on, core or
+plugin-supplied, instead of the current fixed seven-line
+`dump_report` loop.
+
+### 4. Registration is eager, at startup, over a set that's always fully known at build time
+
+An earlier draft of this section went through two designs: first, a
+compiler pass walking `.nir` `<shape>_connect` call sites as the *sole*
+registration mechanism (broke on `db_connect(env("DATABASE_URL"))` —
+a call site's scheme can be runtime-only, so a pass over call sites
+can't see it); then, in response, "lazy by default, manifest as
+pre-warm" — registration deferred to each provider's actual first
+connect. That second design is workable but turns out to be solving a
+problem that §2's own correction just made disappear: **which
+providers a binary could ever use is fully determined by what was
+linked into it**, not by what any particular `.nir` call site's string
+literal says. The seven built-in domains are always present. Every
+plugin provider is named in the `&[NativePluginBuiltin]` list passed to
+`build_with_native_plugins` — a build-time, Rust-side list the person
+building the binary supplies, regardless of whether any `.nir` source
+reaches it via a literal or an `env(...)`-sourced URL. What's genuinely
+runtime-only is *which already-registered* provider a given
+`db_connect(env(...))` call resolves to when it executes (§2's
+dispatch) — not *whether that provider is known to the kernel at all*
+(registration). Once that distinction is drawn, there's no reason for
+registration to be lazy at all.
+
+So registration is simply **eager, at process startup, over the full
+enumerable set**: `codegen.rs` emits one `register_domain(...)` call
+per built-in domain, in a fixed order (`domain::TCP` through
+`domain::SERVE_HTTP`, indices 0–6 — deterministic, not "whichever
+`acquire` happens to fire first," closing an ordering gap an earlier
+draft's Compatibility section assumed without actually stating),
+followed by one call per distinct provider in
+`build_with_native_plugins`'s list, in the order given, into `main`'s
+preamble, before any user code runs. Every provider's `env_var`/
+`default_max` (§2) comes from exactly **one** place — this single
+registration call, reading either the built-in `Domain` constants or
+the plugin's own registration metadata — so there's no second code path
+that could register the same provider under different admission
+settings depending on how a `.nir` program happens to spell its URL.
+
+This closes RFC 0007's "manifest pass... declared bounds feed the
+kernel's ceilings instead of the current hardcoded default" more
+narrowly than a literal AST-walking compiler pass would: the "manifest"
+here *is* `build_with_native_plugins`'s own plugin list plus the fixed
+built-in set — no new frontend pass over `.nir` call sites is needed at
+all. RFC 0007's fuller vision (NFR bound-checking, composition checks
+across actual call sites) stays future work, not claimed here.
+
+`register_domain`'s idempotence (§3) is kept as a defensive property,
+not a load-bearing one, now that there's a single eager registration
+point — harmless, and worth keeping in case a future revision adds a
+second call site.
+
+### 5. Proactive rehydration: a bounded sweep that never touches the hot path
+
+Every registered domain that's pool-backed also registers a
+`PoolRegistry<M>` (§ `pool.rs`, unchanged) keyed by provider. A new
+`kernel::reaper` module realizes its periodic wake using
+`kernel::thread_pool::ThreadPool` **as it actually exists**, verified
+against the real API (`submit(self: &Arc<Self>, job: Job) ->
+Result<(), SpawnError>`, `thread_pool.rs:161`) rather than assumed to
+have a timer/parked-worker feature it doesn't. `ThreadPool` only
+dispatches jobs; it has no built-in notion of a periodic wake. The
+reaper doesn't need one: it's realized as a **single job, submitted
+once, whose body is its own infinite loop** —
+`loop { sweep_all_pools(); thread::sleep(interval) }` — not a second
+threading primitive alongside `ThreadPool`, just one ordinary job that
+happens to never return. From `ThreadPool`'s own perspective this
+permanently occupies one worker for the life of the process (it never
+reaches `wait_for_job`'s idle state, so it's never a candidate for
+`IDLE_TIMEOUT` retirement) — a disclosed, deliberate cost of exactly
+one OS thread, not a new capability requirement on `thread_pool.rs`
+itself. The interval is `NIRDOSHA_KERNEL_REAPER_INTERVAL_SECS`, default
+30. A rehydration found this way calls the same
+`record_stale_rehydrated(domain)` counter that reactive, checkout-time
+rehydration already uses — proactive and reactive rehydration are the
+same event, discovered at a different time, not two telemetry surfaces.
+
+**Per-iteration panic containment, and a counter so a dead reaper isn't
+invisible.** `thread_pool.rs`'s own `worker_loop` already wraps a
+*whole job's* execution in `catch_unwind` — but the reaper's job body
+is `loop { sweep_all_pools(); sleep(...) }`, so a panic anywhere inside
+one `sweep_all_pools()` call (a kernel-side bug — a poisoned lock
+`.unwrap()`, an indexing error — not a plugin panic, which is the
+different, unrecoverable case §2's plugin contract already covers)
+would be caught at the *outermost* `catch_unwind`, ending the whole
+loop, not just that one sweep. The job "completes" from `ThreadPool`'s
+perspective — no crash, nothing visibly wrong — and rehydration
+silently stops forever while every other health signal stays green,
+exactly the failure mode a review pass named. Fix: `catch_unwind` goes
+*inside* the loop, around each `sweep_all_pools()` call individually,
+so one bad sweep is contained and the loop continues to the next
+`sleep`/wake; a caught panic increments a new
+`reaper_panics: AtomicU64` counter, surfaced through `dump_report`/
+`stats` (§3) — so a broken reaper is a visible number going up, not a
+silent absence.
+
+**Shutdown is out of scope for this RFC's own correctness claim, but
+the loop must not make it worse.** `ThreadPool` (as read) has no
+explicit shutdown/join API — a real compiled Nirdosha binary today has
+no graceful-shutdown story that joins background workers at all, so an
+abrupt process exit already kills every thread, reaper included,
+unconditionally; this RFC doesn't need to solve graceful shutdown to be
+correct. What it does need to not do is become a *new* obstacle if a
+future RFC (RFC 0006's structured-concurrency territory) adds one: the
+reaper's loop checks a shutdown flag (an `AtomicBool` or equivalent)
+each time it wakes, so a future join-based shutdown has something to
+signal. Stated plainly rather than hidden: a bare
+`thread::sleep(interval)` is uninterruptible for the whole interval, so
+even a signaled shutdown can take up to
+`NIRDOSHA_KERNEL_REAPER_INTERVAL_SECS` (default 30s) to actually notice
+and exit — acceptable for now; a `Condvar`-based sleep-with-interrupt
+(parked on a condvar the shutdown flag also signals, instead of a bare
+`sleep`) would cut that to near-zero if a future shutdown mechanism
+ever needs it tighter than 30s.
+
+**`NIRDOSHA_KERNEL_REAPER_INTERVAL_SECS` needs its own validation, not
+just a default.** This is a genuinely new operator-facing knob (§ Threat
+model's fourth bullet: operator-controlled but not automatically
+validated) — set to `0`, it produces `sleep(Duration::ZERO)`,
+effectively a busy loop pinning one core at 100% forever. Parsing
+follows the exact convention `PoolConfig::from_env` already establishes
+(§ `pool.rs`: a malformed value degrades to the default field-by-field,
+never fails the whole program) — extended with a floor: parse failure
+→ default (30s); parse success but below 1 second → clamp to 1 second;
+`0` and negative values are never accepted silently. A soft ceiling
+too, not just a floor: a value above 3600s (1 hour) is accepted but
+logs a startup warning rather than silently degrading proactive
+rehydration to near-never — an operator setting an enormous interval
+(`NIRDOSHA_KERNEL_REAPER_INTERVAL_SECS=99999999`) is far more likely to
+have made a typo than to have intended to disable proactive sweeping,
+and reactive checkout-time rehydration still covers correctness either
+way, so this is a warn, not a clamp.
+
+Robustness properties, stated explicitly rather than left implicit:
+
+- **Non-blocking checkout, not `pool.get()` — and, by this RFC's own
+  defaults, not a connection factory either.** A review pass raised a real concern
+  here: does `pool.try_get()` silently *grow* the pool (open a new
+  connection) when nothing's idle but the pool is under `max_size`,
+  which would turn the reaper into a background connection-opener —
+  visible server-side, and reintroducing exactly the blocking-connect
+  hazard `try_get` was chosen to avoid? Checked against this repo's
+  actual vendored dependency, not general r2d2 knowledge: `Cargo.lock`
+  pins `r2d2 0.8.10`, and its `try_get_inner`
+  (`r2d2-0.8.10/src/lib.rs:456-486`) only ever pops from the
+  already-idle list; on empty, it returns `Err` immediately without
+  calling `add_connection` (the function that *does* open a new
+  connection — called only from `get_timeout`'s blocking loop, never
+  from `try_get`'s path). `try_get`'s own doc comment confirms this
+  directly: "This method will not block waiting to establish a new
+  connection." So the concern doesn't hold against the version this
+  repo actually depends on — each wake, for every registered pool, the
+  reaper does one opportunistic `pool.try_get()` (`None` if nothing
+  idle, no side effect) + `ManageConnection::is_valid` + return. Plain
+  `pool.get()` blocks up to `connect_timeout` waiting for a free
+  connection — on a fully checked-out pool, that would stall the one
+  reaper worker for every other registered pool behind it; `try_get`
+  avoids that for the reason just cited, not by accident. One real
+  caveat worth stating: a *successful* pop does call
+  `establish_idle_connections` afterward, which — only if a provider's
+  `PoolConfig.min_idle` is set above its current default of `Some(0)`
+  (§ `pool.rs`) — can open more connections as a background top-up.
+  Inert under this RFC's own defaults; a provider that overrides
+  `min_idle` upward should expect the reaper's successful sweeps to
+  contribute to that top-up, not just validate.
+- **One opportunistic checkout per pool per wake, stated as the bound,
+  not hidden.** A pool of size N takes up to N wakes to sweep in full —
+  this is a deliberate ceiling on reaper work per wake, not an
+  oversight; tightening it (checking more than one connection per pool
+  per wake) is a tuning question for implementation, not a correctness
+  one.
+- **A per-`is_valid` timeout is a plugin contract, not a kernel
+  guarantee — it can't be enforced.** An earlier draft of this bullet
+  claimed "each `is_valid` call gets its own short timeout." That isn't
+  implementable against this ABI: `is_valid_fn` is a synchronous
+  `extern "C"` call, and Rust cannot interrupt a blocked C call running
+  on another thread from the outside. The only two real options are
+  blocking the one reaper worker on it (no timeout — exactly the hazard
+  this bullet was trying to avoid) or spawning a thread per validation
+  (destroys the "exactly one worker" design stated above). So this is a
+  **plugin contract requirement, not a kernel mechanism**: `is_valid_fn`
+  must be fail-fast (a cheap local probe — "is this socket still
+  readable" — not a fresh reconnect carrying its own TCP timeout). A
+  plugin that violates this stalls the sweep for every other registered
+  provider on that wake — a real, disclosed hazard, the same category
+  of cost ADR 0004's own "Consequences" section already accepts for a
+  load-bearing naming convention with nothing on the kernel's side
+  statically checking the other side's behavior. The per-wake pool cap
+  above bounds *how often* a misbehaving plugin's stall recurs, not its
+  duration once it happens.
+
+**Coverage latency, stated as a formula, not left for an operator to
+derive.** Worst-case time before the reaper proactively rehydrates a
+given stale idle connection is roughly `interval × pool_size ×
+ceil(#pools / per_wake_cap)` — with this RFC's defaults (30s interval,
+a size-10 pool, few registered pools) that's on the order of five
+minutes; with the pool-key growth this section discusses below and the
+per-wake cap, it degrades roughly linearly — a stale connection in a
+rarely-hit pool could sit unswept for hours. Acceptable for the stated
+goal (reactive, checkout-time rehydration has no such latency and still
+catches every case proactive sweeping might miss), but the formula
+belongs here so an operator tuning
+`NIRDOSHA_KERNEL_REAPER_INTERVAL_SECS` downward knows what they're
+actually buying. One fairness note worth stating alongside it: the
+per-wake cap makes the reaper work-bounded but not coverage-*fair* as
+written — whichever pools registered last are swept last, every cycle,
+forever. Starting each wake's sweep at a rotating offset into the pool
+list (round-robin, not always index 0) fixes that for free — one
+counter's worth of new state, worth specifying now rather than
+discovering as a real staleness blind spot later.
+
+**Hard constraint**: none of the above ever touches `kernel::acquire`'s
+synchronous CAS path. The reaper runs entirely on its own worker,
+against connections that are, by `PoolRegistry`/r2d2 construction,
+currently idle (returned, not checked out) — a caller's `acquire` is
+never blocked waiting on the reaper, and the reaper never blocks a
+caller. This is RFC 0007 §5's "no plane synchronously depends on a
+plane downstream" rule, applied to this specific mechanism, and it's
+what keeps [[nirdosha_admission_kernel_nonblocking]] true for every
+future provider, not just the ones that predate this RFC.
+
+**This RFC's fail-fast philosophy stops at `kernel::acquire` — checkout
+is a separate, bounded wait, already true today, not something this RFC
+introduces.** `pool.get()` (used in shipped `db.rs`/`http.rs`'s
+connect/query paths — confirmed by reading them, not assumed) blocks up
+to `connect_timeout` when a pool is exhausted: a real wait, one layer
+below `kernel::acquire`'s own instantaneous CAS, that a review pass
+correctly flagged as sitting awkwardly next to "Rejected alternatives"'
+rejection of JCA's blocking checkout. What keeps these from being the
+same failure: JCA/HikariCP's actual incident pattern is *unbounded or
+effectively-unbounded* waits compounding under load into
+thread-starvation deadlock; a `connect_timeout`-bounded wait fails
+loudly after a fixed, small bound — closer to an ordinary network
+client's connect timeout than to a resource-exhaustion deadlock. This
+RFC doesn't change that behavior for `db`/`http`, and gives plugin
+providers the identical bounded-wait checkout for consistency, rather
+than introducing a new inconsistency between built-in and plugin
+providers. Whether *checkout* itself (not just `acquire`) should also
+move to `try_get`-plus-immediate-error — eliminating this wait entirely,
+at the cost of pushing "pool exhausted, retry" handling onto `.nir`
+code — is a real, unresolved design fork; see "Open questions." This
+RFC's position, stated rather than left to be inferred: keep bounded
+blocking checkout for now, since a disclosed 5-second bound is a
+categorically different risk than JCA's actual incident history, and
+changing shipped `db`/`http` checkout semantics is a bigger, separate
+diff than "add a uniform provider model."
+
+**Caveat particular to a `max_size = 1` pool.** Even though the reaper
+never blocks *itself* waiting for a connection (`try_get`), while it
+holds the one connection it did get — for the duration of that one
+`is_valid` call — a concurrent real caller's `pool.get()` has zero idle
+connections to find and genuinely waits, up to `connect_timeout`, the
+same as if an ordinary request were mid-flight instead. This isn't new
+blocking the reaper introduces into `kernel::acquire`'s own path (the
+"Hard constraint" above is unaffected) — it's a size-1 pool sharing its
+one physical connection between a real caller and the sweeper the
+ordinary way it always shares that one connection between any two
+callers. Worth choosing `min_idle`/`max_size` ≥ 2 for a provider where
+this matters, not a defect in the reaper's design specifically.
+
+**What the ceiling actually bounds — pool growth must not leak past
+it.** Left unstated otherwise, `Domain`'s admission ceiling and a
+pool's own `PoolConfig::max_size` (§ `pool.rs`) are two independent
+numbers: r2d2 grows a pool up to `max_size` internally, on demand,
+inside `pool.get()`'s blocking path — code that never calls
+`kernel::acquire` at all. If `max_size` exceeds the domain's ceiling,
+the ceiling is decorative: physical connections can outgrow it without
+ever being denied. This RFC's rule, stated explicitly rather than left
+to an implementer's guess: **a provider's `PoolConfig::max_size` must
+be set ≤ its domain's `default_max`/env-var ceiling** — enforceable
+because §4's single eager registration point knows both numbers for
+every provider at once, and can refuse to build a pool whose configured
+`max_size` exceeds its own ceiling. The admission ceiling counts
+concurrently-*held* checkouts (`conn`/`stream`: connect-to-stop; `call`:
+one pooled checkout's duration, per `Domain::Http`'s existing doc
+comment), and `kernel::acquire`/`release` bracket exactly that hold —
+the pool's own `max_size` becomes an inner implementation detail a
+caller never actually hits first, rather than an independent, silently
+looser bound. One honest pre-existing gap this surfaces, not introduced
+by this RFC: today's shipped `db`/`http` code already pairs
+`Domain::default_max` (10,000) with `PoolConfig::default().max_size`
+(10) — consistent today only because `max_size` happens to be the
+tighter number, not because anything states or enforces that
+relationship as a rule. This RFC is what turns "happens to be
+consistent" into a stated, checked invariant.
+
+**The ceiling bounds concurrency per pool, not distinct pools per
+provider — a real, separate gap, sharpest for `call`.** §2's
+acquire-per-checkout bracketing closes *concurrency*: every checkout of
+every pool under one domain shares that domain's single CAS counter, so
+total concurrently-held checkouts across however many distinct pools a
+provider has is already bounded by the domain ceiling, regardless of
+pool-key count. What it does *not* bound is the **number of distinct
+pool keys itself** — `PoolRegistry::get_or_create` only ever inserts
+into its `HashMap<String, Pool<M>>`, never evicts. A `call`-shape
+plugin pools by host (§2); a tenant calling it against 10,000 distinct,
+attacker-chosen hosts creates 10,000 `HashMap` entries — each
+individually small (`min_idle: Some(0)`), but unbounded in aggregate:
+registry memory and bookkeeping grow with tenant whim, a slow-growth
+DoS distinct from a connection-exhaustion one. **This is pre-existing,
+not introduced by this RFC**: core `http`'s own `http_pool_registry()`
+(`http.rs:330`) is keyed by `pool_key(host, port)` today, with the
+identical no-eviction `get_or_create` — `http_get` against enough
+distinct tenant-chosen hosts already has this exact problem, in shipped
+code, checked directly rather than assumed. This RFC is what's
+generalizing the keyed-pool pattern to more providers, though, so it's
+the right place to state the rule going forward: **cap the number of
+distinct pool keys per provider** — one global
+`NIRDOSHA_KERNEL_POOL_MAX_KEYS` (not a per-scheme/per-prefix knob:
+pinned to exactly this one name here, since two implementers left to
+invent it independently would spell it two different ways), a
+generous, disclosed default — e.g. 256, the same "generous, not tuned"
+posture as `MAX_DOMAINS`. Once at the cap, a *new* key falls back to
+an unpooled, direct dial-per-request — but **`kernel::acquire(domain)`/
+`release(domain)` still bracket that fallback request exactly as if it
+were a checkout**, stated explicitly because the previous draft's "no
+admission-ceiling growth beyond the one connection in flight" reads
+ambiguously in exactly the dangerous direction: if the fallback path
+skipped `acquire` entirely (a plausible misreading — it isn't a real
+"checkout"), the cap would itself become a ceiling *bypass*, since a
+tenant past 256 keys could hold connections with no admission at all,
+reopening the exact exhaustion the ceiling exists to bound. So, pinned
+per shape: no `HashMap` entry, no reaper coverage, no pooling either
+way — but for `call`, the fallback is dial-per-request, released
+immediately after; for `conn`/`stream` past the cap, it's a direct,
+unpooled connection that's still wrapped in the handle table and still
+session-bracketed (`acquire` at connect, `release` at `stop`), exactly
+like a pooled one, just without a pool backing it. An LRU-eviction
+alternative (close the least-recently-used existing pool to make room)
+was considered and set aside: it needs bookkeeping `PoolRegistry`
+doesn't have today, and evicting a pool with in-flight checkouts
+against it needs its own correctness argument — degrading to unpooled
+dialing past the cap is simpler and strictly safer to reason about.
+This RFC applies the cap to every new keyed pool it adds (`call`-shape
+plugins, and any `conn`/`stream` plugin whose identity is
+host-cardinality-sensitive); retrofitting it onto core `http`'s
+existing `http_pool_registry()` is a real, disclosed follow-up this RFC
+doesn't itself attempt.
+
+**Plugin providers need a real `ManageConnection` impl, and can't
+supply one directly.** `PoolRegistry<M: r2d2::ManageConnection>` is
+generic over a *Rust trait* — a `NativePluginBuiltin` plugin, being a
+precompiled `extern "C"` staticlib, cannot implement a Rust trait
+across that boundary any more than it can return a `Vector`/`Matrix`
+(RFC 0008 Phase 1's own scalar-only ABI limit, for the identical
+reason: "a Rust trait object has no meaning to LLVM IR generated by a
+different compilation," `plugin.rs`'s own doc comment). This is why
+§2's shape contract includes a fourth required function,
+`<shape>_provider_<scheme>_is_valid(handle: i64) -> i64` (0/1, the same
+boolean-as-`i64` convention every other kernel boundary already uses),
+alongside `_connect`/`_op`/`_close`. The kernel supplies one generic
+adapter — `struct PluginManagedConnection { connect_fn, is_valid_fn,
+close_fn: extern "C" fn(...) }` — that implements `ManageConnection`
+once by calling through whichever function pointers were resolved for
+a given provider at registration time. Every plugin provider of a given
+shape reuses this same adapter type, so `PoolRegistry<PluginManagedConnection>`
+is the one pool type covering all of them; the reaper above and
+reactive checkout-time rehydration both call `is_valid_fn` through it
+exactly the way `db.rs`'s `SqliteManager::is_valid` calls into
+`rusqlite` today. `ManageConnection::has_broken` — a required method
+distinct from `is_valid` in r2d2's own trait definition, meant as a
+*fast*, non-round-tripping check, not a network probe — always returns
+`false` for `PluginManagedConnection`: a deliberate simplification, not
+an oversight. A genuinely broken connection `has_broken` misses on
+put-back is still caught by `is_valid` at its next checkout or the
+reaper's next sweep — **which depends on `test_on_check_out` actually
+being on for these pools**, stated explicitly rather than left as an
+unstated assumption: `PoolConfig::apply` (§ `pool.rs`) never calls
+r2d2's own `.test_on_check_out(...)` builder method, so every pool
+built through it — plugin pools under this RFC included, not just
+core `db`/`http` — inherits r2d2's own builder default, which is
+`true` (`r2d2-0.8.10/src/lib.rs`'s `Config::default`). Plugin pools go
+through the identical `PoolConfig::apply`/`get_or_create` path core
+pools already use, so this holds for them without needing anything
+new — but it's a real, checked fact about this repo's actual
+dependency, not a "presumably" — and it avoids a fifth required extern
+function in an ABI already trying to stay minimal.
+
+The unwrap direction, stated explicitly since it's the kind of detail
+an implementer could guess either way: `is_valid_fn`/`close_fn`, like
+`_op`, take the plugin's **raw `i64`**, never the kernel's
+`handle(Kind)` id. `.nir` code holds the kernel id → `PluginManagedConnection`
+looks it up in the kernel-owned `HandleTable<PluginConn>` (§2) →
+extracts the `PluginConn`'s raw `i64` → calls the plugin's extern
+function with that. The plugin's four functions never see a kernel id
+at all, on any of the four calls, not just `_connect`'s return — the
+kernel unwraps on every call into the plugin, symmetrically with how it
+wraps once on the way out of `_connect`.
+
+A `NativePluginBuiltin`-registered S3 provider that
+supplies all four functions gets the identical proactive sweep `db`/
+`http` get — for free, no plugin-side scheduling code required — but
+only because the kernel does the trait-adaptation work, not because the
+plugin implements `ManageConnection` itself.
+
+### 6. Uniform config resolution: `env(name)`
+
+One new builtin: `env(name: str) -> Result(str, str)`, `Err` if unset.
+A new `ENV_BUILTINS` list in `codegen.rs`, one `nir_env_get` extern
+wrapping `std::env::var` (a new `kernel/env.rs` or a few lines in
+`mod.rs` — no handle type, no pooling, no `Domain`, since reading the
+process environment isn't a scarce external resource the way `tcp`/
+`file`/`db` are). Every provider — core-shipped or plugin — takes its
+URL/credential as an ordinary `str` argument; `env(...)` is how `.nir`
+source populates it without a literal: `db_connect(env("DATABASE_URL"))`,
+a plugin's `s3_provider_s3_connect(env("S3_URL"))`. No provider-specific
+env-var sniffing anywhere in the compiler — where a secret comes from
+stays visible in `.nir` source, the same explicitness precedent
+`NIRDOSHA_TEST_POSTGRES_URL`'s existing fallback-with-override pattern
+already sets one layer down.
+
+**Decided: the real process environment only, never a `.env`-style
+file.** An earlier draft left this open; it doesn't need to stay open.
+`.env` convenience is a *launcher* concern (`direnv`, systemd's
+`EnvironmentFile=`, `docker run --env-file`) — not a language-runtime
+one. A runtime that silently reads a `.env` file breaks sealed
+deployments and reproducibility in exactly the way that made this
+worth asking about in the first place: a stray file changing behavior
+with nothing in the invocation announcing it. If `.env` convenience
+ever becomes a real need, it belongs at the CLI/compiler-driver level
+behind an explicit flag, never implicit inside `env(...)` itself. This
+is a firm "no," not a placeholder for later.
+
+**Decided: richer config (keypairs, cert+key pairs, whole credentials
+files) is out of scope for `env(...)`, and mostly doesn't need a new
+mechanism at all.** A `NativePluginBuiltin` plugin is native code — it
+can already read a file itself.
+`s3_provider_s3_connect(env("AWS_SHARED_CREDENTIALS_FILE"))` passes a
+*path*; the plugin opens it. No `file`-reading builtin is needed for
+the plugin ecosystem specifically: multi-part config is multiple
+`env(...)` calls combined by the caller; file-shaped config is a path
+via `env(...)` that the provider itself reads. The one case this
+doesn't cover is a **core builtin** needing file-shaped config —
+concretely, an HS256→RS256/ES256 JWT migration needing a keypair rather
+than a shared string — but that's core-compiler work either way (the
+JWT signing builtins live in `IDENTITY_BUILTINS`, not anything this RFC
+touches), so it's out of scope on those grounds regardless of this
+decision. A general-purpose `file_read` builtin, if one is ever
+justified beyond that narrow case, is its own RFC — reading arbitrary
+files raises its own admission/permission questions (a
+`Domain::File`-shaped ceiling already exists for `tcp`/`file` handles;
+whether a *string-returning* file read reuses it or needs something
+narrower isn't a question this document should answer in passing).
+
+**Once `env(...)` returns a value, it's an ordinary `str` — leakage is
+a real risk, not just unauthorized reads.** "Effect on the permission
+model" covers who may call `env(...)` at all; it doesn't cover what
+happens to the value afterward. A connection string returned by
+`env("DATABASE_URL")` often carries a password inline
+(`postgres://user:pass@host/db`) — once it's a plain `str`, every
+string operation applies, including concatenation into a log line or an
+error message a `serve` route echoes back to a client. This RFC doesn't
+propose a redaction mechanism (a real one would need `Ty::Str` to carry
+a taint bit, a bigger change than this document's scope), but example
+code and core kernels built against this RFC must not echo a connect
+error's URL verbatim, and any future example `.nir` program must not
+log an `env(...)` result directly — cheap discipline, cited here so
+it's a stated rule rather than something rediscovered as an incident
+later.
+
+**Illustrative examples only, not a spec.** `env(name)` takes an
+arbitrary `str` — this RFC defines the mechanism, not a fixed catalog
+of variable names, and nothing below is proposed for adoption as-is.
+The names a `.nir` program actually passes to `env(...)` are chosen by
+whoever writes the `<shape>_connect(env("..."))` call (core example
+code, or a plugin's own README), same as any other string literal. The
+list exists only to show the *range* of config a uniform `env(...)`
+needs to cover across the ecosystem this RFC targets — ordinary
+industry-convention names, not something Nirdosha defines or reserves:
+
+- SMTP/email: `SMTP_HOST`/`SMTP_PORT`/`SMTP_USER`/`SMTP_PASSWORD`, or a provider API key (`SENDGRID_API_KEY`, `POSTMARK_TOKEN`)
+- Object storage: `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_REGION`, `S3_BUCKET`/`S3_ENDPOINT` (MinIO/R2-style), or the GCS/Azure equivalents
+- Message queues: `RABBITMQ_URL`/`AMQP_URL`, `KAFKA_BROKERS`, `NATS_URL`
+- HTTP/external APIs: `API_BASE_URL`, a per-provider key by convention (`STRIPE_API_KEY`, `TWILIO_AUTH_TOKEN`)
+- Observability: `NIRDOSHA_OBSERVABILITY_URL` (already exists — `nfr.rs`), `SENTRY_DSN`, `OTEL_EXPORTER_OTLP_ENDPOINT`
+- Auth/secrets: `JWT_SECRET`, `SESSION_SECRET` — note a real HS256→RS256/ES256 migration needs a keypair, not a shared string; the "richer config" decision above covers why that's out of scope here
+- Federated OIDC/OAuth2, if Nirdosha ever delegates identity instead of self-issuing (it doesn't today): `OIDC_ISSUER_URL`/`OIDC_CLIENT_ID`/`OIDC_CLIENT_SECRET`, or a named IdP's own convention (`AUTH0_DOMAIN`, `COGNITO_USER_POOL_ID`)
+- SAML (unlikely to matter for the current demo): `SAML_IDP_METADATA_URL`, `SAML_SP_ENTITY_ID`
+
+None of these are wired to anything by this RFC — the only concrete,
+in-scope consumer today is `db_connect(env("DATABASE_URL"))`/the
+hardcoded JWT secret in `examples/features/
+57_nirdosha_ops_console_server_v2.nir`, both cited in the Motivation.
+The rest is scope illustration, kept here so a future reader sizing
+`env(...)`'s design doesn't under-estimate the variety of values it
+needs to pass through cleanly (plain strings, URLs, and — per the
+`JWT_SECRET` note above — at least one case, keypairs, it doesn't cover
+at all).
+
+## Effect on the permission model
+
+No change to `requires(role/claim: ...)`, the identity-layer `check_role`/
+`acquire` family (a different, unrelated "acquire" from `kernel::acquire`),
+or `serve.rs`'s route-exposure *rules* — this RFC doesn't touch how
+those are declared or checked. Two things below mean "no authorization
+impact" isn't quite the right summary of the whole picture, though:
+provider reachability, and what `dump_report` now reveals.
+
+**Provider reachability is a new capability surface this RFC creates,
+and it deserves stating rather than assuming away.** Before this RFC,
+`.nir` code could only ever reach the handful of built-in backends.
+After it, `db_connect("s3://...")` — no `env(...)` involved at all —
+makes *every* plugin linked into the binary reachable from *every*
+`.nir` program in it, with no declared, per-program scoping. This is
+consistent with the reachability model every existing builtin already
+has, though, not a regression from one: there is no `.nir`-level
+allow-list for `db_connect`/`http_get` today either — any function
+anywhere in a compiled program can already call them, and the actual
+trust decision happens once, at build time, in what the operator
+chooses to link (which `NativePluginBuiltin`s get passed to
+`build_with_native_plugins`, exactly like today's decision to link a
+`db`/`http`-capable binary at all). This RFC extends an already-zero-ACL
+model to more providers; it doesn't introduce a new *kind* of unscoped
+access. Whether a finer-grained, `requires(...)`-style per-program
+provider allow-list is worth adding later — real defense-in-depth for a
+multi-tenant `serve` deployment where different `.nir` programs in the
+same binary shouldn't all reach the same plugin — is a genuine open
+question, not resolved here.
+
+**`dump_report`'s HTTP route makes "no authorization impact" not
+literally true.** "Compatibility" already notes `compiled-serve` serves
+`dump_report()`'s raw text over HTTP; this RFC makes that output more
+informative than it was, since a plugin's normalized scheme name now
+appears in it — a live catalog of which backends, vendors, and
+integration points a deployment actually uses, exactly the
+reconnaissance an attacker would want before, say, aiming an `env(...)`
+exfiltration attempt at the right variable name. This route arguably
+belongs on the list of things `serve.rs`'s exposure rules ought to
+govern — it currently isn't gated by them at all. This RFC doesn't
+resolve that, but operator documentation for anything built against it
+should say plainly that this route isn't safe to expose unauthenticated
+in a deployment where the provider catalog itself is sensitive.
+
+`env(name)` lets `.nir` source read *any* process environment variable
+— a real new capability, since a careless or compromised `.nir` program
+with no legitimate reason to touch AWS could still read
+`AWS_SECRET_ACCESS_KEY` if it happens to be set in the process
+environment. **Decided: `Effect::Env`, added to `ast::Effect`'s closed
+set, unscoped.** An earlier draft left the shape of this open between
+three options; a compile-time allow-list is ruled out on the same
+grounds §2's own runtime-dispatch correction already established for
+provider reachability — the entire point of §6 is that variable names
+are deliberately *not* known at compile time in an env-driven
+deployment, so a compile-time list of "permitted names" would be
+checking against something the compiler structurally cannot see, the
+identical failure mode the original compile-time manifest pass had.
+`Effect::Env` gives the real, available thing instead: an audit/
+declaration point ("this program reads the environment") on the same
+"notation with nothing to check, added when a real domain needs it"
+terms `Domain`'s own doc comment already states for itself — consistent
+with that precedent rather than inventing a new kind of gate. A finer
+allow-list stays possible later, layered on top as a lint or a separate
+capability check (§ "Open questions" on a per-program provider
+allow-list sketches the same shape for provider reachability) — but
+that's additive, not a prerequisite for shipping `Effect::Env` itself.
+
+`NativePluginBuiltin`-registered providers inherit `Ty::Handle`'s
+existing affine-ownership guarantees (RFC 0005 §1) unchanged — opening
+`Domain` touches only the kernel-side counter lookup, not
+`ownership.rs`'s checking.
+
+## Compatibility
+
+- `Domain` enum → registry is source-compatible for every existing call
+  site: the seven built-in domains keep their existing names as
+  pre-registered `DomainId` constants. Nothing external ever
+  serialized `Domain as u8` — but `dump_report`'s **text output** is a
+  real, textually unstable surface, not a cosmetic one: moving from a
+  fixed seven-line loop to iterating `registered_domains()` changes
+  line order/count once any plugin-backed domain registers (existing
+  domains stay first if `registered_domains()` preserves registration
+  order, but that's a property to guarantee, not assume). Two real
+  consumers already parse this exact text and need updating alongside
+  this change: `crates/compiler/tests/nirdosha_ops_console.rs` (filters
+  stdout lines by the fixed `"nirdosha kernel flight recorder:"` header
+  and per-domain indentation) and `crates/compiled-serve/src/lib.rs`
+  (serves `dump_report()`'s raw text directly as an HTTP response body
+  — any real client of that route inherits the same instability).
+- No existing `.nir` program's behavior changes: `db_connect`'s
+  scheme-sniff (now inside `nir_db_connect`'s own Rust implementation,
+  §2 — not `codegen.rs`) gains a plugin-lookup fallback after its
+  existing built-in checks; those built-in SQLite/Postgres code paths
+  are untouched, and `codegen.rs`'s call-site codegen for `db_connect`
+  doesn't change at all. **`mq_connect_via` does not get this fallback
+  in this pass** (status box, above) — it stays exactly as it typechecks
+  and ownership-checks today, with no live kernel implementation, so
+  there is nothing to disclose a behavior change *against* for it yet.
+  `call_via` is a wholly new, additive builtin (next bullet), so it has
+  no prior behavior to preserve.
+- `env(...)` is a new, additive builtin name — can't collide with a
+  user identifier, since every name in `ast::BUILTIN_NAMES` is already
+  reserved.
+- `call_via(...)` is likewise new and additive (§1's rename note: it
+  was never shipped under its earlier draft name `https_request_via`,
+  so there is nothing to migrate callers away from). One behavior worth
+  stating plainly rather than leaving implicit: a **plugin-routed**
+  `call_via` call always reports `status: 200` on success — `_request`'s
+  pinned ABI (§2, "the `call` shape's contract") is a single `str`
+  return with no separate status-code channel, so there is no numeric
+  status for the kernel to relay. `call_via` against `http://`/
+  `https://` is unaffected — those go through the exact same
+  `nir_http_get`/`nir_http_post`-style parsing as core `http`, real
+  status code included.
+
+- **JCA-style blocking pool checkout** (wait-with-timeout when a pool
+  is exhausted): rejected outright. This is the textbook cause of a
+  well-known class of Java production incidents — thread-starvation
+  deadlock under connection-pool exhaustion, the entire reason
+  HikariCP ships dedicated leak-detection diagnostics. It directly
+  contradicts [[nirdosha_admission_kernel_nonblocking]].
+  `kernel::acquire` stays fail-fast CAS for every domain this RFC adds,
+  with no exception for plugin-registered ones.
+- **Per-provider bespoke env-var sniffing** (teach `db_connect` to
+  check `DATABASE_URL` automatically, a future `s3_connect` to check
+  `S3_URL`, etc.): rejected. Implicit, not auditable from `.nir` source
+  alone, and doesn't generalize to a provider the core compiler has
+  never heard of — a plugin's integration would need its own bespoke
+  sniffing, duplicated per provider. The explicit `env(...)` builtin
+  (§6) is strictly more general and keeps the config source visible in
+  source.
+- **A brand-new "service" abstraction distinct from `NativePluginBuiltin`**
+  (a dedicated registration API/trait, closer to what the proposal ADR
+  0004 itself responded to originally asked for): rejected for the same
+  reason ADR 0004 gave the first time — the representation (an opaque
+  affine handle plus a scalar/`str` ABI) and the routing convention
+  (scheme-sniff by naming convention) both already exist. A second,
+  parallel mechanism would fragment the plugin surface RFC 0008 already
+  built rather than complete it.
+- **Resurrecting ADR 0004's dispatch exactly as written**: impossible —
+  it targeted `self.plugins: HashMap<String, PluginFn>`, which no
+  longer exists; the interpreter it depended on is gone. This RFC
+  targets `NativePluginBuiltin`, the only live compiled-path plugin
+  ABI, instead.
+
+## Open questions
+
+Four earlier open questions here are now decided — folded into the
+Design/"Effect on the permission model" sections above rather than
+left as open items (§6 covers richer config and `.env`-file loading;
+"Effect on the permission model" covers the `Effect::Env` gate shape;
+§3 covers `DomainId`'s representation). What's left is genuinely
+undecided, with the criteria for resolving each stated rather than
+left implicit:
+
+- **Per-domain reaper interval**: global to start
+  (`NIRDOSHA_KERNEL_REAPER_INTERVAL_SECS`, one value for every
+  provider), not per-domain. The extension point already exists at
+  zero extra design cost, though: §2's plugin-metadata
+  convention-plus-override pattern (`env_var`/`default_max`)
+  generalizes directly to an interval field the same way, whenever a
+  real provider needs a different cadence than every other one.
+  Revisit trigger: a real provider demonstrating that need, not
+  speculatively ahead of it.
+- **RFC 0008 Phase 3** (Cargo-driven plugin auto-discovery): genuinely
+  separate work, correctly out of this RFC's scope. One warning worth
+  carrying forward into whoever picks it up: auto-discovery widens the
+  build-time-trusted set from "a list the operator hand-read and
+  passed to `build_with_native_plugins`" to "whatever dependency
+  resolution happens to pull in" — meaning §2's collision-detection
+  rules become *more* load-bearing once auto-discovery lands, not
+  less, since nobody is hand-reading the plugin list to catch a
+  collision by eye anymore. Version-pinning discipline and §2's
+  build-time collision validation are both prerequisites for Phase 3,
+  not optional hardening on top of it.
+- **A fourth resource shape** beyond `conn`/`stream`/`call`: still a
+  judgment call for whenever it's actually needed, not designed
+  speculatively here — but the bar is pinned now rather than left
+  vague: a *working* plugin built against the existing three shapes
+  that demonstrates the mismatch is a real ergonomics problem, not a
+  hypothetical one, **and** its own ADR (not just an RFC) once
+  accepted, since a new shape changes `Ty` the way `conn`/`stream`/
+  `call` already do — matching `docs/adr/README.md`'s own line between
+  a judgment call and a designed-up-front change. Pinning this
+  explicitly now is what stops a future revision from sneaking a
+  fourth shape in casually, under an RFC that treats it as a minor
+  addition.
+- **Checkout fail-fast (`try_get`) vs. today's bounded `pool.get()`**:
+  the one question that genuinely needs field data rather than more
+  argument — §5 already scoped it honestly rather than deciding it by
+  philosophy, and that framing holds. Sharpened decision criteria:
+  this should be resolved by **telemetry** — actual pool-exhaustion
+  frequency at realistic ceiling/`max_size` ratios in a real
+  deployment — not by which failure mode sounds worse in the
+  abstract. And if it does flip, it should flip **per-provider, as
+  opt-in metadata** (the same convention-plus-override shape as
+  `env_var`/`default_max`/the reaper interval above), never as a
+  global semantic change — shipped `db`/`http` checkout behavior
+  should never be silently altered out from under an existing
+  deployment.
+- **A per-program provider allow-list**: kept open, and honestly, kept
+  open partly because *the unit of scoping doesn't exist yet* —
+  Nirdosha compiles one binary; "per-program" would mean per-route or
+  per-module attribution the runtime doesn't currently track anywhere.
+  §2's runtime-dispatch correction (a review pass's own finding, this
+  document's biggest design change) also rules out the naive version
+  of this: a compile-time scheme allow-list would break exactly the
+  way the original compile-time manifest pass broke, for the identical
+  reason — a scheme resolved from `env(...)` isn't known at compile
+  time to check against a list. The coherent boundary today is the one
+  this RFC already uses: the build-time linking decision. One thing
+  worth stating so a future RFC doesn't start from zero, though: a
+  *runtime* capability check is compatible with this design without
+  any rework — `PLUGIN_PROVIDERS`' lookup and `HandleTable`'s
+  per-entry dispatch (§2) don't preclude a capability/allow-list check
+  being added inside `nir_db_connect` itself, gated on whatever
+  scoping unit a future revision defines; nothing here forecloses
+  that, it's just not designed here.

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -22,6 +22,7 @@ this list.
 | [0008](./0008-native-plugin-abi-widening.md) | Native plugin ABI widening and Cargo-driven discovery — a compile-time-only path to a real plugin ecosystem |
 | [0009](./0009-ui-catalog-extensibility.md) | Grammar-of-graphics charts and compile-time UI-plugin components — escaping the closed 4-chart/7-control catalog without opening a runtime hole |
 | [0010](./0010-landing-and-serve-exposure.md) | Per-role/claim `landing` screens, and the compiled-`serve` route-exposure model (deny-by-default on mutating exposure) |
+| [0011](./0011-uniform-service-provider-model.md) | A uniform service-provider model — open admission domains, revived plugin dispatch, and proactive rehydration for any future backend |
 
 A decision made in the course of implementing something, not designed
 up front, goes in [`docs/adr/`](../docs/adr/README.md) instead — a


### PR DESCRIPTION
## Summary

Implements all 8 phases of `rfcs/0011-uniform-service-provider-model.md`, a
fully-designed RFC that had nothing implemented yet. The RFC lets a future
backend (object storage, a payment API, an OIDC IdP, ...) be added to
Nirdosha as a native plugin **without a compiler change**, by finishing
three things this repo had already half-built: ADR 0004's scheme-dispatch
shape, RFC 0008 Phase 1's plugin ABI (real but never exercised beyond
typechecking/scalars), and RFC 0007's unwired `HandleTable`/`PoolRegistry`/
`ThreadPool` primitives.

This PR bundles all 8 phases into one commit rather than the ~8 separate
PRs the RFC's own text recommends, at the requester's explicit direction.
A second, separate commit on this branch (`fix(build,codegen): thread
+crt-static through RUSTFLAGS...` / `feat(demo): richer Ops Console v2
per-role dashboards`) contains **pre-existing, unrelated work** that was
sitting uncommitted in the working tree before this RFC-0011 effort began
(a Windows CRT linker fix continuing `dce391b`/`4336be0`, and three new
per-role Ops Console v2 dashboard endpoints) — split out deliberately so it
isn't misattributed to the RFC-0011 work in this description. Please review
that commit separately if it's in scope for you; everything below is about
the RFC-0011 commit only.

## Phase-by-phase

- **Phase 1 — `env(name)` builtin.** `env(name: str) -> Result(str, str)` +
  a new `Effect::Env` (unscoped, per the RFC's own already-"Decided"
  §6). Full stack: `ast.rs`/`typeck.rs`/`codegen.rs`/`effects.rs`/
  `ownership.rs`, plus `nir_env_get` in `runtime-kernels`.

- **Phase 2a — open `Domain` registry (plumbing).** Replaced the closed
  7-variant `Domain` enum with an open registry: `DomainId = u32`,
  `DOMAIN_SLOTS`/`NAME_INDEX`, single-source `register_builtin_domains()`
  driven by one `BUILTIN_DOMAINS` array (the *only* place the built-in
  domain order is written down), `codegen.rs` emits exactly one bootstrap
  call in `main`'s preamble. `recorder::Event.domain` widened `u8`→`u16`
  (the write side, not just the read side — sized for >255 domains once
  plugins register). Verified **byte-identical** `dump_report` output
  against a real Postgres instance, with the 7 built-in domain ids
  confirmed stable at 0–6 through the encode/decode round trip.

- **Phase 2b — `db.rs` admission gating (investigated, not changed).**
  The plan's premise was that `db.rs`'s connect path was ungated. Turned
  out to be wrong: `db_connect`/`db_stop`'s `kernel::acquire`/`release`
  bracketing already existed one layer up, in `lib.rs`'s FFI wrapper
  (predating this RFC entirely, from `796e255`). Adding gating inside
  `kernel::db::connect()` too would have **double-gated** every
  `db_connect` call, corrupting the held-count — so nothing was added
  there; a doc comment plus a ceiling-enforcement regression test were
  added instead, and no RFC Compatibility-section edit was needed since
  there's no new disclosed behavior change.

- **Phase 3 — plugin provider contract.** `NativePluginBuiltin` gained
  `env_var`/`default_max` metadata fields. New `validate_plugin_roster()`
  enforces the "four functions or none" rule (`<shape>_provider_<scheme>_
  connect` requires matching `_is_valid`/`_close` plus either `_op`
  (conn/stream-shape) or `_request` (call-shape)), scheme normalization
  (lowercase, strip `://`, `+`/`.`/`-`→`_`), and collision detection
  against both built-in scheme identifiers and other plugins.

- **Phase 4 — eager plugin registration.** `codegen.rs` emits one
  `nir_kernel_register_domain(...)` call per distinct validated provider,
  immediately after Phase 2a's built-in bootstrap call, still inside
  `main`'s preamble before any user code runs.

- **Phase 5 — pool adapter + ceiling enforcement.** New
  `PoolRegistry<PluginManagedConnection>` (generic `r2d2::ManageConnection`
  impl over provider function pointers) in `kernel/pool.rs`.
  `get_or_create_within_ceiling` refuses to build a pool whose
  `max_size` would exceed its domain's admission ceiling, as a named,
  startup-time error. `NIRDOSHA_KERNEL_POOL_MAX_KEYS`-bounded unpooled
  fallback for providers with many distinct connection targets, still
  `acquire`/`release`-bracketed exactly like a real checkout (a
  deliberately checked property, not an assumed one — the RFC's own
  "dangerous direction to get wrong" warning).

- **Phase 6 — runtime scheme dispatch.** New
  `crates/runtime-kernels/src/kernel/plugin_provider.rs`: the
  `PLUGIN_PROVIDERS` table, `connect_conn_shape` (conn/stream-shape
  fallback), `call_via` (call-shape fallback), credential-stripped
  `pool_key_identity`, and a verbatim-duplicated `normalize_scheme` (no
  shared crate exists between `compiler` and `runtime-kernels`, so this
  ~6-line function is intentionally kept in sync by hand in both places,
  backed by identical test vectors in both). `db_connect`'s plugin
  fallback wired into `lib.rs`'s `nir_db_connect`/`nir_db_stop`/
  `nir_db_query`/`nir_db_execute`. New `.nir`-visible builtin
  `call_via(url, path, body) -> Result(HttpResponse, str)`, renamed from
  the RFC's earlier `https_request_via` draft name (which baked an
  http-shaped bias into what's actually a generic `call`-shape dispatch
  entrypoint) — the rename is landed in the RFC doc itself, not just this
  PR description. `http://`/`https://` URLs sniff straight to the
  existing core HTTP path; anything else falls through to the plugin
  table. Per-request (not session-scoped) admission bracketing for
  `call_via`, verified by a test that only passes if a ceiling-of-1
  provider's admission is released between two sequential calls.

- **Phase 7 — reaper.** New `kernel/reaper.rs`: one self-looping job
  submitted to a dedicated `ThreadPool`, sweeping every pool-backed
  registry (sqlite, postgres, http, https, plugin — a generic
  `Sweepable` mechanism, not hardcoded to just the plugin pool). Each
  sweep is individually `catch_unwind`-wrapped so one bad sweep doesn't
  silently end the reaper thread; a `reaper_panics` counter surfaces
  through `dump_report`. `NIRDOSHA_KERNEL_REAPER_INTERVAL_SECS` parsing
  with a default/floor/soft-ceiling, matching this file's existing
  degrade-to-default convention.

- **Phase 8 — one real plugin, end to end.** New crate
  `crates/plugin-example-native-authed-http/`, a real `call`-shape plugin
  reading a bearer token via the environment at connect time and
  injecting it as an `Authorization` header on every request — the exact
  gap the RFC's own Motivation section names (no way to set custom
  headers from `.nir` today). Proven against both an automated test (a
  real local HTTP server on an ephemeral port, asserting the observed
  `Authorization` header) and a manual standalone run watched live.

## Bugs caught and fixed during implementation (not left in)

- **`HandleTable` id-space collision.** `db_table()` (core db connections)
  and the new plugin-connection `HandleTable` both would have started
  minting ids at 1 — a plugin-conn id could then collide with an
  unrelated, still-live core-db id, and the "check core table first, then
  plugin table on a miss" dispatch priority would silently resolve to the
  *wrong* connection. Fixed with `HandleTable::new_starting_at`, giving
  the plugin table a disjoint high range (`1 << 62`).
- **Pool-config default vs. a low domain ceiling.** `PoolConfig::from_env`'s
  own default `max_size` (10) has no idea what a given provider's real
  ceiling is — for any provider whose `default_max`/env-var ceiling is
  below 10, an un-clamped config would fail the ceiling check on *every*
  single checkout, making a legitimately low-ceiling provider permanently
  unusable rather than merely rate-limited. Fixed by clamping pool
  `max_size` down to the provider's own resolved ceiling in one shared
  helper (`plugin_pool_config`), used by both `db_connect`'s and
  `call_via`'s plugin paths. Caught by the Phase 6 per-request admission
  test before it shipped.
- **Mutex poisoning on `MAX_DOMAINS` overflow.** The overflow panic
  originally fired while still holding `NAME_INDEX`'s lock, permanently
  poisoning it and breaking every later domain registration in the same
  process. Fixed by dropping the guard before panicking.
- **Reaper test design vs. real r2d2 semantics.** An early version of the
  panic-containment test made the mock connection manager panic on its
  "first `is_valid` call," assuming that only fires on sweep — but
  r2d2 0.8.10's `try_get_inner` retry loop also calls `is_valid` on a
  freshly-`add_connection`'d connection during pool *setup*, not just on
  idle-popped ones, so the panic fired at the wrong time. Fixed with an
  explicit, externally-controlled "armed" flag instead of relying on call
  ordering.
- **Plugin connections never recorded rehydration.** `record_stale_
  rehydrated` is called from every other connection manager's `is_valid`
  on the `Err` path (`SqliteManager`, `PostgresManager`, `HttpManager`) but
  `PluginManagedConnection` had no `domain` field to do the same — found
  and fixed while wiring the Phase 7 reaper.

## RFC document edits (landed alongside the code, not deferred)

`rfcs/0011-uniform-service-provider-model.md`'s status box and
Compatibility section were kept in sync phase by phase, per the RFC's own
instruction that a plan/status-box checkmark shouldn't silently drift from
the document it claims to implement:
- Phase 2a's single-source registration design amended into both §3 and
  §4 (replacing the RFC's own earlier "codegen emits one call per
  built-in" / "registered as compile-time constants" text).
- Phase 6's `https_request_via` → `call_via` rename, plus a clarifying
  sentence that a non-HTTP provider's response through `call_via` is a
  deliberate lowest-common-denominator reuse of `HttpResponse`'s shape,
  not a claim that the underlying protocol is HTTP.
- `mq_connect_via`'s own plugin fallback recorded as **explicitly
  deferred** in the status-box checklist, with a pointer to `db_connect`'s
  fallback (`kernel::plugin_provider::connect_conn_shape`) as the template
  a follow-up should copy — `mq_connect_via` is typechecked/
  ownership-checked today but has no live kernel implementation at all
  (`codegen.rs`'s own `MQ_BUILTINS` doc comment already said this was
  deliberate, "a separate mechanism, owned elsewhere").
- Status box now shows all 8 phases as Done, with the closing summary
  updated accordingly.

## Review

The three background research passes that verified this plan's file:line
citations against current code (before implementation started) all came
back accurate, with only minor line-number drift. I additionally
hand-reviewed the highest-risk surfaces myself after the codebase's
automated `/code-review` hit a session rate limit mid-run: `kernel/pool.rs`
(the plugin pool adapter and key-cap fallback), `kernel/plugin_provider.rs`
(the new dispatch table and its unsafe FFI boundary), `lib.rs`'s new FFI
entrypoints (including the function-pointer `transmute`s
`nir_kernel_register_plugin_provider` needs, since `_op`/`_request` differ
in arity), and `codegen.rs`'s preamble-emission loop. No further issues
found; the non-blocking CAS admission property
(`kernel::acquire`/`release`) is preserved unchanged in spirit throughout
— just re-indexed from an enum match to an array index.

## Test plan

- [x] `cargo build -p nirdosha` and `cargo build --manifest-path
      crates/runtime-kernels/Cargo.toml` — clean.
- [x] `cargo test -p nirdosha --test codegen --test native_plugin_codegen
      --test native_plugin_examples --test effects --test ownership` — all
      pass (153+ tests, including new Phase 1/3/4/6/8 tests).
- [x] `cargo test --manifest-path crates/runtime-kernels/Cargo.toml` — 140
      passed; the only failure is a pre-existing, unrelated test-ordering
      flake (`recorder::tests::partial_and_full_page_flushes...`) present
      before this work started, confirmed passing in isolation.
- [x] `cargo test -p nirdosha --test nirdosha_ops_console -- --ignored`
      against a real Postgres dev container — byte-identical `dump_report`
      text assertions pass (proves Phase 2a's registry rewrite didn't
      change built-in domain output).
- [x] Phase 8's compiled example binary run manually, standalone, watched
      live: observed `Authorization: Bearer manual-run-secret-42` and the
      correct path land on an independently-started local HTTP server.
- [ ] `cargo test --workspace` was not run — a pre-existing, unrelated
      `nirdosha-grammar-check` crate fails to build regardless of this
      change (confirmed out of scope before starting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
